### PR TITLE
Improve render scale help text in F11 menu

### DIFF
--- a/src/spice2x/launcher/options.cpp
+++ b/src/spice2x/launcher/options.cpp
@@ -1721,7 +1721,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .title = "Window Forced Render Scaling",
         .name = "windowscale",
         .desc = "For windowed mode: forcibly set DX9 back buffer dimensions to match window size. "
-            "Works great on some games, but completely broken on others.",
+            "Reduces pixelated scaling artifacts. Works great on some games, but completely broken on others",
         .type = OptionType::Bool,
         .category = "Graphics (Windowed)",
     },

--- a/src/spice2x/overlay/windows/screen_resize.cpp
+++ b/src/spice2x/overlay/windows/screen_resize.cpp
@@ -139,8 +139,16 @@ namespace overlay::windows {
         if (ImGui::Checkbox("Always on Top", &cfg::SCREENRESIZE->window_always_on_top) ) {
             graphics_update_z_order(window);
         }
+        ImGui::BeginDisabled();
+        ImGui::Checkbox("Forced Render Scaling", &GRAPHICS_WINDOW_BACKBUFFER_SCALE);
+        ImGui::EndDisabled();
+        ImGui::SameLine();
+        ImGui::HelpMarker(
+            "For windowed mode: forcibly set DX9 back buffer dimensions to match window size. "
+            "Reduces pixelated scaling artifacts. Works great on some games, but completely broken on others.\n\n"
+            "This can't be changed in-game; instead, set -windowscale option in spicecfg and restart.");
+
         ImGui::Checkbox("Keep Aspect Ratio", &cfg::SCREENRESIZE->client_keep_aspect_ratio);
-        ImGui::TextWrapped("Hint: if game is blurry after resizing, try -windowscale option in spicecfg.");
         ImGui::Checkbox("Manual window move/resize", &cfg::SCREENRESIZE->enable_window_resize);
         ImGui::BeginDisabled(!cfg::SCREENRESIZE->enable_window_resize);
 


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
n/a

## Description of change
Previously, F11 menu just provided text-based hint on how to enable -windowscale option.

Instead, show a disabled checkbox that correctly reflects the current state, nudging the user to read the tooltip.

Elaborate the option tooltip for -windowscale as well for consistency & explain *why* you might want to enable this.

## Compiling
💯 

## Testing
Tested 32/64 bit.
