### PR TITLE
audio: log errors when RegOpenKey fails for ASIO registry hooks

### DIFF
--- a/src/spice2x/games/iidx/iidx.cpp
+++ b/src/spice2x/games/iidx/iidx.cpp
@@ -100,9 +100,25 @@ namespace games::iidx {
                 *phkResult = DEVICE_ASIO_REG_HANDLE;
 
                 log_info("iidx::asio", "replacing '{}' with '{}'", lpSubKey, ASIO_DRIVER.value());
-
-                return RegOpenKeyExA_orig(real_asio_reg_handle, ASIO_DRIVER.value().c_str(), ulOptions, samDesired,
+                const auto result = RegOpenKeyExA_orig(
+                        real_asio_reg_handle,
+                        ASIO_DRIVER.value().c_str(),
+                        ulOptions,
+                        samDesired,
                         &real_asio_device_reg_handle);
+
+                if (result != ERROR_SUCCESS) {
+                    log_warning(
+                        "iidx::asio",
+                        "failed to open registry subkey '{}', error=0x{:x}",
+                        ASIO_DRIVER.value().c_str(), result);
+                    log_warning(
+                        "iidx::asio",
+                        "due to improper ASIO setting, game will likely fail to launch; double check -iidxasio and the registry",
+                        ASIO_DRIVER.value().c_str(), result);
+                }
+
+                return result;
             }
         }
 

--- a/src/spice2x/games/sdvx/sdvx.cpp
+++ b/src/spice2x/games/sdvx/sdvx.cpp
@@ -79,9 +79,25 @@ namespace games::sdvx {
                 *phkResult = DEVICE_ASIO_REG_HANDLE;
 
                 log_info("sdvx::asio", "replacing '{}' with '{}'", lpSubKey, ASIO_DRIVER.value());
-
-                return RegOpenKeyExA_orig(real_asio_reg_handle, ASIO_DRIVER.value().c_str(), ulOptions, samDesired,
+                const auto result = RegOpenKeyExA_orig(
+                        real_asio_reg_handle,
+                        ASIO_DRIVER.value().c_str(),
+                        ulOptions,
+                        samDesired,
                         &real_asio_device_reg_handle);
+
+                if (result != ERROR_SUCCESS) {
+                    log_warning(
+                        "sdvx::asio",
+                        "failed to open registry subkey '{}', error=0x{:x}",
+                        ASIO_DRIVER.value().c_str(), result);
+                    log_warning(
+                        "sdvx::asio",
+                        "due to improper ASIO setting, game will likely fall back to WASAPI; double check -sdvxasio and the registry",
+                        ASIO_DRIVER.value().c_str(), result);
+                }
+
+                return result;
             }
         }
 


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
n/a

## Description of change
When RegOpenKey* hooks fail when substituting user's ASIO driver, log a warning message.

This can happen when the user types in the wrong value for `-iidxasio` or `-sdvxasio`, which is a common issue.

## Compiling
🥇 

## Testing
Tested LDJ/KFC
