### PR TITLE
museca: add Start and 10KEY lights

### DIFF
--- a/src/spice2x/acio/bmpu/bmpu.cpp
+++ b/src/spice2x/acio/bmpu/bmpu.cpp
@@ -33,6 +33,11 @@ static int __cdecl ac_io_bmpu_control_1p_start_led_off() {
     if (avs::game::is_model("KDM")) {
         auto &lights = games::dea::get_lights();
         Lights::writeLight(RI_MGR, lights.at(games::dea::Lights::P1Start), 0.f);
+
+    // MUSECA
+    } else if (avs::game::is_model("PIX")) {
+        auto &lights = games::museca::get_lights();
+        Lights::writeLight(RI_MGR, lights.at(games::museca::Lights::Start), 0.f);
     }
 
     return 1;
@@ -44,6 +49,11 @@ static int __cdecl ac_io_bmpu_control_1p_start_led_on() {
     if (avs::game::is_model("KDM")) {
         auto &lights = games::dea::get_lights();
         Lights::writeLight(RI_MGR, lights.at(games::dea::Lights::P1Start), 1.f);
+
+    // MUSECA
+    } else if (avs::game::is_model("PIX")) {
+        auto &lights = games::museca::get_lights();
+        Lights::writeLight(RI_MGR, lights.at(games::museca::Lights::Start), 1.f);
     }
 
     return 1;
@@ -55,6 +65,11 @@ static int __cdecl ac_io_bmpu_control_2p_start_led_off() {
     if (avs::game::is_model("KDM")) {
         auto &lights = games::dea::get_lights();
         Lights::writeLight(RI_MGR, lights.at(games::dea::Lights::P2Start), 0.f);
+    
+    // MUSECA
+    } else if (avs::game::is_model("PIX")) {
+        auto &lights = games::museca::get_lights();
+        Lights::writeLight(RI_MGR, lights.at(games::museca::Lights::Keypad), 0.f);
     }
 
     return 1;
@@ -66,6 +81,11 @@ static int __cdecl ac_io_bmpu_control_2p_start_led_on() {
     if (avs::game::is_model("KDM")) {
         auto &lights = games::dea::get_lights();
         Lights::writeLight(RI_MGR, lights.at(games::dea::Lights::P2Start), 1.f);
+
+    // MUSECA
+    } else if (avs::game::is_model("PIX")) {
+        auto &lights = games::museca::get_lights();
+        Lights::writeLight(RI_MGR, lights.at(games::museca::Lights::Keypad), 1.f);
     }
 
     return 1;

--- a/src/spice2x/games/museca/io.cpp
+++ b/src/spice2x/games/museca/io.cpp
@@ -71,6 +71,8 @@ std::vector<Light> &games::museca::get_lights() {
 
         GameAPI::Lights::sortLights(
                 &lights,
+                "Start",
+                "Keypad",
                 "Title R",
                 "Title G",
                 "Title B",

--- a/src/spice2x/games/museca/io.h
+++ b/src/spice2x/games/museca/io.h
@@ -46,6 +46,8 @@ namespace games::museca {
     // all lights in correct order
     namespace Lights {
         enum {
+            Start,
+            Keypad,
             TitleR,
             TitleG,
             TitleB,


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
Fixes #295 

## Description of change
Add missing `Start` and `10KEY` lights output, as see in the test menu.

## Compiling
👍 

## Testing
Seems fine in museca test mode.
