### PR TITLE
build: add git commit hash to produced artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,15 @@ jobs:
         working-directory: ./src/spice2x
     steps:
       - uses: actions/checkout@v4
+      - name: Calculate commit SHA
+        id: vars
+        run: |
+          calculatedSha=$(git rev-parse --short ${{ github.sha }})
+          echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_ENV
       - name: Compile
         run: ./build_docker.sh
       - uses: actions/upload-artifact@v4
         with:
-          name: spice2x
+          name: spice2x-ci-${{ env.COMMIT_SHORT_SHA }}
           path: src/spice2x/bin
           if-no-files-found: error


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
n/a

## Description of change
Previously, the artifact produced by the CI action was `spice2x.zip`.

With this change, it will be `spice2x-ci-1234567.zip` where 1234567 is the first 7 chars of the commit hash.

Note that for PRs, github produces a merge commit before queueing the action, so the commit hash won't match up with the HEAD of a fork. The goal is to just generate unique-ish filenames so this is not a huge deal.

## Compiling
## Testing

Action has been run in the fork.
