### PR TITLE
sdvx: disable sdvx landscape option

### DIFF
--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -1170,13 +1170,17 @@ int main_implementation(int argc, char *argv[]) {
         }
     }
 
-    if (options[launcher::Options::SDVXFullscreenLandscape].value_bool() && !GRAPHICS_WINDOWED) {
-#if SPICE64
-        GRAPHICS_FS_ORIENTATION_SWAP = true;
-#else
-        log_warning("launcher", "-sdvxlandscape is not supported in 32-bit SDVX, ignoring...");
-#endif
-    }
+//     // SDVXFullscreenLandscape disabled due to it messing with in-game camera angle
+//     // FullscreenOrientationFlip continues to live on, however.
+//
+//     if (options[launcher::Options::SDVXFullscreenLandscape].value_bool() && !GRAPHICS_WINDOWED) {
+// #if SPICE64
+//         GRAPHICS_FS_ORIENTATION_SWAP = true;
+// #else
+//         log_warning("launcher", "-sdvxlandscape is not supported in 32-bit SDVX, ignoring...");
+// #endif
+//     }
+
     if (options[launcher::Options::FullscreenOrientationFlip].value_bool() && !GRAPHICS_WINDOWED) {
         GRAPHICS_FS_ORIENTATION_SWAP = true;
     }

--- a/src/spice2x/launcher/options.cpp
+++ b/src/spice2x/launcher/options.cpp
@@ -228,7 +228,8 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc =
             "Allows you to play portrait games in in landscape (and vice versa) by transposing resolution and applying image scaling.\n\n"
             "Works great for some games, but can COMPLETELY BREAK other games - YMMV!\n\n"
-            "Strongly consider combining this with -forceres option to render at monitor native resolution",
+            "Strongly consider combining this with -forceres option to render at monitor native resolution\n\n"
+            "WARNING: for SDVX, this messes with camera angle for note lanes, causing it to be zoomed out!",
         .type = OptionType::Bool,
         .category = "Graphics (Full Screen)"
     },
@@ -2049,15 +2050,17 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
     },
     {
         // SDVXFullscreenLandscape
-        .title = "SDVX Landscape Mode (SDVX5+)",
+        .title = "(DISABLED) SDVX Landscape Mode (SDVX5+)",
         .name = "sdvxlandscape",
         .desc =
+            "Option HIDDEN and DISABLED due to it affecting in-game camera angle for displaying lanes.\n\n"
             "Allows you to play in landscape by transposing resolution and applying image scaling.\n\n"
             "Works only for SDVX5 and above! This is identical to -forceresswap.\n\n"
             "Will launch at 1080p by default; strongly consider combining this with -forceres option to render at monitor native resolution",
         .type = OptionType::Bool,
+        .hidden = true,
         .game_name = "Sound Voltex",
-        .category = "Game Options"
+        .category = "Game Options",
     },
     {
         // spice2x_EnableSMXStage


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
Fixes #302

## Description of change
To avoid confusion, temporarily remove `-sdvxlandscape` because of the issue described in the bug above.

`forceresswap` is still kept, so there is still a way to do exactly what `-sdvxlandscape` used to do, if someone really wants it.

## Testing
Checked that `-sdvxlandscape` is ignored, and that `-sdvxlandscape`  continues to be honored.