### PR TITLE
avs: make max path check stricter

### DIFF
--- a/src/spice2x/avs/game.cpp
+++ b/src/spice2x/avs/game.cpp
@@ -77,7 +77,7 @@ namespace avs {
             log_info("avs-game", "DLL path: {}", dll_path_s.c_str());
 
             // MAX_PATH is 260
-            if (140 < dll_path_s.length()) {
+            if (130 <= dll_path_s.length()) {
                 log_warning(
                     "avs-game",
                     "PATH TOO LONG WARNING\n\n\n"


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
n/a

## Description of change
The check to warn the user about potential MAX_PATH violation should be stricter. Saw a user with 150 characters run into a crash during boot for SDVX3.

## Testing
Tested paths under 130 / over 130, in both 32/64 bits.