### PR TITLE
patchmanager: always log patch identifier of main DLL

### DIFF
--- a/src/spice2x/overlay/windows/patch_manager.cpp
+++ b/src/spice2x/overlay/windows/patch_manager.cpp
@@ -1645,6 +1645,8 @@ namespace overlay::windows {
         std::string first_id = get_game_identifier(MODULE_PATH / firstDll);
         std::filesystem::path firstPath = fmt::format("patches/{}.json", first_id);
 
+        log_misc("patchmanager", "patch identifier of {}: {}", firstDll, first_id);
+
         auto extraDlls = getExtraDlls(firstDll);
         std::erase_if(extraDlls, [](const std::string& dll) {
             auto identifier = get_game_identifier(MODULE_PATH / dll);


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
n/a

## Description of change
Always log the DLL identifier string in patch manager, even if there are no patches.

## Testing
Tested 32 / 64 bits.