### PR TITLE
net: mark netadapter IP as sensitive option

### DIFF
--- a/src/spice2x/hooks/networkhook.cpp
+++ b/src/spice2x/hooks/networkhook.cpp
@@ -179,7 +179,7 @@ void networkhook_init() {
     strncpy(s_prefix, inet_ntoa(prefix), 16);
 
     // log preferences
-    log_info("network", "Network preferences: {}", s_network, s_subnet, s_prefix);
+    // log_info("network", "Network preferences: {}, {}, {}", s_network, s_subnet, s_prefix);
 
     // GetAdaptersInfo hook
     auto orig_addr = detour::iat_try(

--- a/src/spice2x/launcher/options.cpp
+++ b/src/spice2x/launcher/options.cpp
@@ -306,6 +306,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "Force the use of an adapter with the specified network. Must also provide -subnet",
         .type = OptionType::Text,
         .category = "Network Adapters",
+        .sensitive = true,
     },
     {
         .title = "Preferred NetAdapter Subnet",


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
n/a

## Description of change
Mark the option as "sensitive" which censors the option value (adapter's IP address)
Remove the log entry from spice

This isn't perfect because most of the games like to log the IP address and subnet anyway, but at least spice itself will stop doing it.

## Testing
Tested 64 bit LDJ with parameter set.
