### PR TITLE
loveplus: stub impl of cpusbxpkm.dll (printer)

### DIFF
--- a/src/spice2x/CMakeLists.txt
+++ b/src/spice2x/CMakeLists.txt
@@ -124,8 +124,8 @@ else()
         # https://github.com/msys2/MINGW-packages/pull/6880
         # some games crash if some DLLS load above 4GB VA, so manually set base address to standard 32-bit VA,
         # and might as well double make sure ASLR is disabled here
-        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections,--disable-dynamicbase,--image-base=0x400000")
-        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--gc-sections,--disable-dynamicbase,--image-base=0x400000")
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections,--disable-dynamicbase,--image-base=0x400000,--enable-stdcall-fixup")
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--gc-sections,--disable-dynamicbase,--image-base=0x400000,--enable-stdcall-fixup")
 
         # set visibility to hidden
         set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -fvisibility=hidden")
@@ -160,8 +160,8 @@ else()
         set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-fno-ident -ffunction-sections -fdata-sections")
 
         # linker fix to load below 4GB
-        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections,--disable-dynamicbase,--image-base=0x400000")
-        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--gc-sections,--disable-dynamicbase,--image-base=0x400000")
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections,--disable-dynamicbase,--image-base=0x400000,--enable-stdcall-fixup")
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--gc-sections,--disable-dynamicbase,--image-base=0x400000,--enable-stdcall-fixup")
 
         # set visibility to hidden
         set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -fvisibility=hidden")
@@ -184,8 +184,8 @@ else()
         set(CMAKE_CXX_FLAGS_DEBUG "-gdwarf")
 
         # linker fix to load below 4GB
-        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--disable-dynamicbase,--image-base=0x400000")
-        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--disable-dynamicbase,--image-base=0x400000")
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--disable-dynamicbase,--image-base=0x400000,--enable-stdcall-fixup")
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--disable-dynamicbase,--image-base=0x400000,--enable-stdcall-fixup")
 
         # enable debug symbols on level 3 and keep frame pointers
         set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g3 -fno-omit-frame-pointer")
@@ -738,6 +738,16 @@ if(NOT MSVC)
     set_target_properties(spicetools_stubs_nvEncodeAPI64 PROPERTIES COMPILE_FLAGS "-m64" LINK_FLAGS "-m64")
 endif()
 
+# cpusbxpkm.dll (32 bit)
+set(SOURCE_FILES stubs/cpusbxpkm.cpp)
+add_library(spicetools_stubs_cpusbxpkm SHARED ${SOURCE_FILES} stubs/cpusbxpkm.def)
+set_target_properties(spicetools_stubs_cpusbxpkm PROPERTIES PREFIX "")
+set_target_properties(spicetools_stubs_cpusbxpkm PROPERTIES OUTPUT_NAME "cpusbxpkm")
+
+if(NOT MSVC)
+    set_target_properties(spicetools_stubs_cpusbxpkm PROPERTIES COMPILE_FLAGS "-m32" LINK_FLAGS "-m32")
+endif()
+
 # output directories
 ####################
 
@@ -747,7 +757,7 @@ set_target_properties(spicetools_cfg
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/spicetools")
 
 # output 32bit
-set_target_properties(spicetools_spice spicetools_spice_laa spicetools_stubs_kbt spicetools_stubs_kld
+set_target_properties(spicetools_spice spicetools_spice_laa spicetools_stubs_kbt spicetools_stubs_kld spicetools_stubs_cpusbxpkm
         PROPERTIES
         ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/archive32"
         LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/spicetools/32"

--- a/src/spice2x/build_all.sh
+++ b/src/spice2x/build_all.sh
@@ -60,7 +60,7 @@ DIST_ENABLE=1
 DIST_FOLDER="./dist"
 DIST_NAME="spice2x-$(date +%y)-$(date +%m)-$(date +%d).zip"
 DIST_COMMENT=${DIST_NAME}$'\n'"$GIT_BRANCH - $GIT_HEAD"$'\nThank you for playing.'
-TARGETS_32="spicetools_stubs_kbt spicetools_stubs_kld spicetools_cfg spicetools_spice spicetools_spice_laa"
+TARGETS_32="spicetools_stubs_kbt spicetools_stubs_kld spicetools_cfg spicetools_spice spicetools_spice_laa spicetools_stubs_cpusbxpkm"
 TARGETS_64="spicetools_stubs_kbt64 spicetools_stubs_kld64 spicetools_stubs_nvEncodeAPI64 spicetools_stubs_nvcuvid spicetools_stubs_nvcuda spicetools_spice64"
 
 # determine build type
@@ -181,7 +181,7 @@ fi
 echo "Copy files to output directory..."
 rm -rf ${OUTDIR}
 mkdir -p ${OUTDIR}
-#mkdir -p ${OUTDIR}/stubs/32
+mkdir -p ${OUTDIR}/stubs/32
 mkdir -p ${OUTDIR}/stubs/64
 mkdir -p ${OUTDIR}/extras/largeaddressaware
 if false # ((DEBUG > 0))
@@ -200,6 +200,7 @@ then
     #cp ${BUILDDIR_64}/spicetools/64/nvEncodeAPI64.dll ${OUTDIR}/stubs/64 2>/dev/null
     #cp ${BUILDDIR_64}/spicetools/64/nvcuda.dll ${OUTDIR}/stubs/64 2>/dev/null
     #cp ${BUILDDIR_64}/spicetools/64/nvcuvid.dll ${OUTDIR}/stubs/64 2>/dev/null
+	#cp ${BUILDDIR_32}/spicetools/32/cpusbxpkm.dll ${OUTDIR}/stubs/32 2>/dev/null
 else
     # release files
     cp ${BUILDDIR_32}/spicetools/spicecfg.exe ${OUTDIR} 2>/dev/null
@@ -213,6 +214,7 @@ else
     cp ${BUILDDIR_64}/spicetools/64/nvEncodeAPI64.dll ${OUTDIR}/stubs/64 2>/dev/null
     cp ${BUILDDIR_64}/spicetools/64/nvcuda.dll ${OUTDIR}/stubs/64 2>/dev/null
     cp ${BUILDDIR_64}/spicetools/64/nvcuvid.dll ${OUTDIR}/stubs/64 2>/dev/null
+    cp ${BUILDDIR_32}/spicetools/32/cpusbxpkm.dll ${OUTDIR}/stubs/32 2>/dev/null
 fi
 
 # pack source files to output directory

--- a/src/spice2x/stubs/cpusbxpkm.cpp
+++ b/src/spice2x/stubs/cpusbxpkm.cpp
@@ -1,0 +1,88 @@
+#include <cstdint>
+
+#define EXPORT __declspec(dllexport)
+
+enum {
+    Error_NoError = 0,
+    Error_DeviceNotFound = 100,
+    Error_Busy,
+    Error_Printing_Busy,
+    Error_Printing_Ready,
+    Error_PortBusy,
+    Error_GetCPDIDinfo,
+    Error_PrinterBusy,
+    Error_FuncParamError = 201,
+    Error_MemAllocError,
+    Error_Timeout,
+};
+
+extern "C" int32_t EXPORT __stdcall CPU9CheckPaperRemain(void *p1, void *p2) {
+    return Error_FuncParamError;
+}
+
+extern "C" int32_t EXPORT __stdcall CPU9CheckPrinter(void *p1, void *p2) {
+    return Error_FuncParamError;
+}
+
+extern "C" int32_t EXPORT __stdcall CPU9CheckPrintEnd(uint32_t p1, void *p2, void *p3) {
+    return Error_FuncParamError;
+}
+
+extern "C" int32_t EXPORT __stdcall CPU9GetFWInfo(void *p1, void *p2) {
+    return Error_FuncParamError;
+}
+
+extern "C" int32_t EXPORT __stdcall CPU9GetMediaType(void *p1, void *p2) {
+    return Error_FuncParamError;
+}
+
+extern "C" int32_t EXPORT __stdcall CPU9GetTempInfo(void *p1, void *p2) {
+    return Error_FuncParamError;
+}
+
+extern "C" int32_t EXPORT __stdcall CPU9GetTotalPrintCount(void *p1, void *p2) {
+    return Error_FuncParamError;
+}
+
+extern "C" int32_t EXPORT __stdcall CPU9PreHeat(void *p1) {
+    return Error_FuncParamError;
+}
+
+extern "C" int32_t EXPORT __stdcall CPU9PrintJobCancel(void *p1) {
+    return Error_FuncParamError;
+}
+
+extern "C" int32_t EXPORT __stdcall CPU9PrintOut(void *p1, void *p2) {
+    return Error_FuncParamError;
+}
+
+extern "C" int32_t EXPORT __stdcall CPU9SetPrintParameter2(void *p1, void *p2) {
+    return Error_FuncParamError;
+}
+
+extern "C" int32_t EXPORT __stdcall CPUASendImage(void *p1, void *p2, void *p3, void *p4) {
+    return Error_FuncParamError;
+}
+
+extern "C" int32_t EXPORT __stdcall CPUASendImagePrint(
+    void *p1, void *p2, void *p3, bool p4, void *p5, int32_t p6, void *p7) {
+    return Error_FuncParamError;
+}
+
+extern "C" int32_t EXPORT __stdcall CPUASendImagePrint2(
+    void *p1, void *p2, void *p3, bool p4, bool p5, void *p6, int32_t p7, void *p8) {
+    return Error_FuncParamError;
+}
+
+extern "C" int32_t EXPORT __stdcall CPUASetPrintParameter(void *p1, void *p2, bool p3, void *p4, void *p5) {
+    return Error_FuncParamError;
+}
+
+extern "C" int32_t EXPORT __stdcall CPUXSearchPrinters(void *p1, void *p2, int32_t p3, void *p4) {
+    return Error_FuncParamError;
+}
+
+extern "C" void EXPORT __stdcall CPUXInit() {
+    return;
+}
+

--- a/src/spice2x/stubs/cpusbxpkm.def
+++ b/src/spice2x/stubs/cpusbxpkm.def
@@ -1,0 +1,18 @@
+EXPORTS
+    CPU9CheckPaperRemain
+    CPU9CheckPrinter
+    CPU9CheckPrintEnd
+    CPU9GetFWInfo
+    CPU9GetMediaType
+    CPU9GetTempInfo
+    CPU9GetTotalPrintCount
+    CPU9PreHeat
+    CPU9PrintJobCancel
+    CPU9PrintOut
+    CPU9SetPrintParameter2
+    CPUASendImage
+    CPUASendImagePrint
+    CPUASendImagePrint2
+    CPUASetPrintParameter
+    CPUXInit
+    CPUXSearchPrinters


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
n/a

## Description of change
Add a stub for `cpusbxpkm.dll`. The stub doesn't work, it's only enough to allow the game to load; but that is irrelevant since spice hooks the printer at runtime.

## Testing
Observed the game boot, and was able to print out the test image from test menu. Will do more testing on a real server.
