### PR TITLE
loveplus: improve window searching for touch hook

### DIFF
--- a/src/spice2x/games/loveplus/loveplus.cpp
+++ b/src/spice2x/games/loveplus/loveplus.cpp
@@ -30,16 +30,15 @@ namespace games::loveplus {
         if (!TOUCH_ATTACHED) {
 
             // Find the game window.
-            // We check the foreground window first, then fall back to searching for the window title
-            // All game versions seem to have their model first in the window title
-            HWND wnd = GetForegroundWindow();
-            if (!string_begins_with(GetActiveWindowTitle(), "LovePlus")) {
-                wnd = FindWindowBeginsWith(avs::game::MODEL);
-            }
+            HWND wnd = FindProcessWindowBeginsWith("LovePlusAC");
 
             // attach touch hook
             if (wnd) {
-                log_info("loveplus", "using window handle for touch: {}", fmt::ptr(wnd));
+                log_info(
+                    "loveplus",
+                    "using window handle for touch: {} ({})",
+                    fmt::ptr(wnd),
+                    get_window_title(wnd));
                 touch_create_wnd(wnd);
             } else {
                 log_info("loveplus", "falling back to the DirectX window handle for touch");

--- a/src/spice2x/util/utils.h
+++ b/src/spice2x/util/utils.h
@@ -227,6 +227,7 @@ static inline std::vector<HWND> find_windows_beginning_with(const std::string &t
     return windows;
 }
 
+// exists for compat only; prefer to use FindProcessWindowBeginsWith instead
 static inline HWND FindWindowBeginsWith(std::string title) {
 
     // get all windows
@@ -245,6 +246,28 @@ static inline HWND FindWindowBeginsWith(std::string title) {
     }
 
     // nothing found
+    return nullptr;
+}
+
+static inline HWND FindProcessWindowBeginsWith(const std::string &title) {
+    // try foreground window first
+    HWND fg_win = GetForegroundWindow();
+    if (string_begins_with(get_window_title(fg_win), title)) {
+        DWORD fg_pid;
+        GetWindowThreadProcessId(fg_win, &fg_pid);
+        if (fg_pid == GetCurrentProcessId()) {
+            return fg_win;
+        }
+    }
+
+    // try different windows
+    for (const auto window : find_windows_beginning_with(title)) {
+        DWORD fg_pid;
+        GetWindowThreadProcessId(window, &fg_pid);
+        if (fg_pid == GetCurrentProcessId()) {
+            return window;
+        }
+    }
     return nullptr;
 }
 


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
Fixes #320 

## Description of change
Replacing the existing logic that searches for game window to hook touch on.

Eventually, we should fix all the other games that hook touch by matching on window title with a call to `FindProcessWindowBeginsWith`.

## Testing
Tested with notepad open that was also titled `LovePlusAC`. Game hooked correctly when the game was in focus during boot, and also when notepad was in focus.