### PR TITLE
launcher: option to make command line args take precedence

### DIFF
--- a/src/spice2x/cfg/option.h
+++ b/src/spice2x/cfg/option.h
@@ -43,6 +43,7 @@ public:
     std::string value;
     std::vector<Option> alternatives;
     bool disabled = false;
+    bool conflicting = false;
 
     explicit Option(OptionDefinition definition, std::string value = "") :
         definition(std::move(definition)), value(std::move(value)) {

--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -1226,7 +1226,27 @@ int main_implementation(int argc, char *argv[]) {
     }
     log_info("launcher", "arguments:\n{}", arguments.str());
 
-    if (launcher::LOG_CMD_OVERRIDE_HELP) {
+    // print out conflicts
+    size_t conflicts = 0;
+    for (const auto &option : options) {
+        if (option.conflicting && option.get_definition().type != OptionType::Bool) {
+            conflicts += 1;
+            if (launcher::USE_CMD_OVERRIDE) {
+                log_warning(
+                    "launcher",
+                    "multiple values for -{}, command line args take precedence: {}",
+                    option.get_definition().name, 
+                    option.value);
+            } else {
+                log_warning(
+                    "launcher",
+                    "multiple values for -{}, spicecfg values take precedence: {}",
+                    option.get_definition().name,
+                    option.value);
+            }
+        }
+    }
+    if (conflicts) {
         if (launcher::USE_CMD_OVERRIDE) {
             log_info(
                 "launcher",

--- a/src/spice2x/launcher/options.cpp
+++ b/src/spice2x/launcher/options.cpp
@@ -44,7 +44,6 @@ static const std::vector<std::string> CATEGORY_ORDER_NONE = {
 };
 
 bool launcher::USE_CMD_OVERRIDE = false;
-bool launcher::LOG_CMD_OVERRIDE_HELP = false;
 
 /*
  * Option Definitions
@@ -2522,26 +2521,7 @@ std::vector<Option> launcher::merge_options(
                                 new_option.value_add(value);
                             }
                         }
-
-                        // note that we are early, before logging is initialized
-                        // so these messages get logged to the console only, not the log file
-                        if (option.get_definition().type != OptionType::Bool) {
-                            LOG_CMD_OVERRIDE_HELP = true;
-                            if (USE_CMD_OVERRIDE) {
-                                log_warning(
-                                    "options",
-                                    "multiple values detected in -{}, command line args take precedence: {}",
-                                    new_option.get_definition().name,
-                                    new_option.value);
-                            } else {
-                                log_warning(
-                                    "options",
-                                    "multiple values detected in -{}, spicecfg values take precedence: {}",
-                                    new_option.get_definition().name,
-                                    new_option.value);
-                            }
-                        }
-
+                        new_option.conflicting = true;
                     } else {
                         auto &new_option = merged.emplace_back(override.get_definition(), "");
                         new_option.disabled = true;

--- a/src/spice2x/launcher/options.h
+++ b/src/spice2x/launcher/options.h
@@ -259,7 +259,6 @@ namespace launcher {
     }
 
     extern bool USE_CMD_OVERRIDE;
-    extern bool LOG_CMD_OVERRIDE_HELP;
     
     const std::vector<std::string> &get_categories(Options::OptionsCategory category);
     const std::vector<OptionDefinition> &get_option_definitions();


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
Fixes #190 

## Description of change
When `-cmdoverride` is specified, any command line arguments are taken first before merging with what is in the config file.

## Testing
Still testing...
