### PR TITLE
launcher: detect custom nvidia DLLs

### DIFF
--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -1912,6 +1912,9 @@ int main_implementation(int argc, char *argv[]) {
     libutils::warn_if_dll_exists("d3d12.dll");
     libutils::warn_if_dll_exists("dxgi.dll");
     libutils::warn_if_dll_exists("opengl32.dll");
+    libutils::warn_if_dll_exists("nvcuda.dll");
+    libutils::warn_if_dll_exists("nvcuvid.dll");
+    libutils::warn_if_dll_exists("nvEncodeAPI64.dll");
 
     // complain loudly & early about dll load ordering issue
     libutils::check_duplicate_dlls();


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
n/a

## Description of change
Complain if nvcuda.dll, nvcuvid.dll, or nvEncodeAPI64.dll are found in modules or in root directory. This would complain for spice-provided stubs as well.

## Testing
