### PR TITLE
acio: detect crash during acio init due to RTSS/Afterburner and complain

### DIFF
--- a/src/spice2x/acio/acio.cpp
+++ b/src/spice2x/acio/acio.cpp
@@ -41,6 +41,7 @@
 namespace acio {
     HINSTANCE DLL_INSTANCE = nullptr;
     std::vector<acio::ACIOModule *> MODULES;
+    std::atomic<bool> IO_INIT_IN_PROGRESS = false;
 }
 
 /*
@@ -58,6 +59,7 @@ static inline acio::HookMode get_hookmode() {
 
 void acio::attach() {
     log_info("acio", "SpiceTools ACIO");
+    IO_INIT_IN_PROGRESS = true;
 
     // load settings and instance
     acio::DLL_INSTANCE = LoadLibraryA("libacio.dll");
@@ -111,6 +113,8 @@ void acio::attach() {
     for (auto &module : MODULES) {
         module->attach();
     }
+
+    IO_INIT_IN_PROGRESS = false;
 }
 
 void acio::attach_icca() {

--- a/src/spice2x/acio/acio.h
+++ b/src/spice2x/acio/acio.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <vector>
 
 #include <windows.h>
@@ -11,6 +12,7 @@ namespace acio {
     // globals
     extern HINSTANCE DLL_INSTANCE;
     extern std::vector<acio::ACIOModule *> MODULES;
+    extern std::atomic<bool> IO_INIT_IN_PROGRESS;
 
     void attach();
     void attach_icca();

--- a/src/spice2x/launcher/signal.cpp
+++ b/src/spice2x/launcher/signal.cpp
@@ -6,6 +6,7 @@
 #include <windows.h>
 #include <dbghelp.h>
 
+#include "acio/acio.h"
 #include "external/stackwalker/stackwalker.h"
 #include "hooks/libraryhook.h"
 #include "launcher/shutdown.h"
@@ -96,6 +97,19 @@ static LONG WINAPI TopLevelExceptionFilter(struct _EXCEPTION_POINTERS *Exception
 
         // print signal
         log_warning("signal", "exception raised: {}", exception_code(ExceptionRecord));
+
+        // check ACIO init failures
+        if (acio::IO_INIT_IN_PROGRESS) {
+            log_warning(
+                "signal",
+                "exception raised during ACIO init, this usually happens when a third party application interferes with hooks");
+            log_warning(
+                "signal",
+                "    please check for the following, disable them, and try launching the game again:");
+            log_warning(
+                "signal",
+                "    RivaTuner Statistics Server (RTSS), MSI Afterburner, kernel mode anti-cheat");
+        }
 
         // walk the exception chain
         struct _EXCEPTION_RECORD *record_cause = ExceptionRecord->ExceptionRecord;


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
n/a

## Description of change
When an exception is caught during ACIO hook init, print a special message to suggest the user to disable RTSS and MSI Afterburner, since they are known to cause issues.

## Testing
Tried with RTSS enabled with High detection and with it disabled. Also tried to crash the game a different way and check that the message is not printed and the callstack is shown propeerly.