### PR TITLE
patcher: add gitadora libshare-pj.dll to extra DLL list

### DIFF
--- a/src/spice2x/overlay/windows/patch_manager.cpp
+++ b/src/spice2x/overlay/windows/patch_manager.cpp
@@ -80,7 +80,7 @@ namespace overlay::windows {
         {"arkmmd.dll", {"gamemmd.dll"}},
         {"arkklp.dll", {"lpac.dll"}},
         {"arknck.dll", {"weac.dll"}},
-        {"gdxg.dll", {"game.dll"}}
+        {"gdxg.dll", {"game.dll", "libshare-pj.dll"}}
     };
 
     static size_t url_recent_idx = -1;


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
n/a

## Description of change
Allow importing patches for `libshare-pj.dll`

## Testing
Observed patch for the new DLL being attempted to be imported in the logs.