### PR TITLE
Check for IFS LayeredFS after loading hooks

### DIFF
--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -2077,15 +2077,6 @@ int main_implementation(int argc, char *argv[]) {
         networkhook_init();
     }
 
-    // layeredfs
-    if (fileutils::dir_exists("data_mods") &&
-        !fileutils::file_exists("ifs_hook.dll") &&
-        !fileutils::file_exists(MODULE_PATH / "ifs_hook.dll")) {
-        log_warning("launcher", "data_mods directory was found, but ifs_hook.dll is not present; your mods will not load");
-        log_warning("launcher", "to fix this, download ifs_layeredfs and add it as a DLL hook (-k)");
-        log_warning("launcher", "https://github.com/mon/ifs_layeredfs");
-    }
-
     update_msvcrt_args(argc, argv);
 
     // load hooks
@@ -2097,6 +2088,14 @@ int main_implementation(int argc, char *argv[]) {
         } else {
             bt5api_hook(module);
         }
+    }
+
+    // layeredfs
+    if (fileutils::dir_exists("data_mods") &&
+        GetModuleHandleA("ifs_hook.dll") == nullptr) {
+        log_warning("launcher", "data_mods directory was found, but ifs_hook.dll is not present; your mods will not load");
+        log_warning("launcher", "to fix this, download ifs_layeredfs and add it as a DLL hook (-k)");
+        log_warning("launcher", "https://github.com/mon/ifs_layeredfs");
     }
 
     // apply patches


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
N/A

## Description of change
Minor fix for a warning in the log. Moves the check for IFS LayeredFS _after_ loading hooks. Also checks for the module with `GetModuleHandle` instead, which should cover all paths as long as `ifs_hook.dll` hasn't been renamed. 😅 

## Testing

Before:
```
[2025/07/19 15:59:56] W:launcher: data_mods directory was found, but ifs_hook.dll is not present; your mods will not load
[2025/07/19 15:59:56] W:launcher: to fix this, download ifs_layeredfs and add it as a DLL hook (-k)
[2025/07/19 15:59:56] W:launcher: https://github.com/mon/ifs_layeredfs
[2025/07/19 15:59:56] I:launcher: msvcrt!__argc value before: 0
[2025/07/19 15:59:56] I:launcher: msvcrt!__argc value after: 57
[2025/07/19 15:59:56] I:launcher: loading hook DLL C:\Users\Emma\AppData\Local\Programs\SpiceTools\hooks\64\ifs_hook.dll
[2025/07/19 15:59:56] I:libraryhook: LibraryHook Attach
```

After changes - no warning observed:
```
[2025/07/19 15:59:08] I:launcher: msvcrt!__argc value before: 0
[2025/07/19 15:59:08] I:launcher: msvcrt!__argc value after: 57
[2025/07/19 15:59:08] I:launcher: loading hook DLL C:\Users\Emma\AppData\Local\Programs\SpiceTools\hooks\64\ifs_hook.dll
[2025/07/19 15:59:08] I:libraryhook: LibraryHook Attach
```
