### PR TITLE
ddr: automatically register codecs on launch

### DIFF
--- a/src/spice2x/games/ddr/ddr.h
+++ b/src/spice2x/games/ddr/ddr.h
@@ -7,6 +7,7 @@ namespace games::ddr {
 
     // settings
     extern bool SDMODE;
+    extern bool NO_CODEC_REGISTRATION;
 
     // Buffers to store RGB data for tape LEDs on gold cabinets
     const size_t TAPELED_DEVICE_COUNT = 11;
@@ -18,5 +19,8 @@ namespace games::ddr {
         virtual void pre_attach() override;
         virtual void attach() override;
         virtual void detach() override;
+
+    private:
+        void register_codecs();
     };
 }

--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -629,6 +629,9 @@ int main_implementation(int argc, char *argv[]) {
     if (options[launcher::Options::DDR43Mode].value_bool()) {
         games::ddr::SDMODE = true;
     }
+    if (options[launcher::Options::DDRSkipCodecRegisteration].value_bool()) {
+        games::ddr::NO_CODEC_REGISTRATION = true;
+    }
     if (options[launcher::Options::LoadSteelChronicleModule].value_bool()) {
         attach_sc = true;
     }

--- a/src/spice2x/launcher/options.cpp
+++ b/src/spice2x/launcher/options.cpp
@@ -810,6 +810,15 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .category = "Game Options",
     },
     {
+        // DDRSkipCodecRegisteration
+        .title = "DDR Skip Codec Registration",
+        .name = "ddrnocodec",
+        .desc = "Prevent automatic registration of codecs in the com folder",
+        .type = OptionType::Bool,
+        .game_name = "Dance Dance Revolution",
+        .category = "Game Options (Advanced)",
+    },
+    {
         .title = "Force Load Pop'n Music Module",
         .name = "pnm",
         .desc = "Manually enable Pop'n Music module",

--- a/src/spice2x/launcher/options.h
+++ b/src/spice2x/launcher/options.h
@@ -86,6 +86,7 @@ namespace launcher {
             spice2x_SDVXSubRedraw,
             LoadDDRModule,
             DDR43Mode,
+            DDRSkipCodecRegisteration,
             LoadPopnMusicModule,
             PopnMusicForceHDMode,
             PopnMusicForceSDMode,


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
#345 

## Description of change
On launch of spice.exe / spice64.exe, call `regsvr32` on known codecs in the `com` directory.

Add an option to skip this (`-ddrnocodec`) as a chicken bit.

## Testing
Tested 32 and 64 bit DDR.