### PR TITLE
ddr: enclose file path in quotes & use wchar when registering codecs

### DIFF
--- a/src/spice2x/games/ddr/ddr.cpp
+++ b/src/spice2x/games/ddr/ddr.cpp
@@ -84,11 +84,12 @@ namespace games::ddr {
 
             log_info("ddr", "found DLL: {}", filename.string());
             if (filename == "k-clvsd.dll" || filename.string().find("xactengine") == 0) {
-                const std::string cmd = "regsvr32.exe /s " + file.path().string();
-                
+                const std::wstring wcmd = L"regsvr32.exe /s \"" + file.path().wstring() + L"\"";
+                const std::string cmd = "regsvr32.exe /s \"" + file.path().string() + "\"";
+
                 int result = 0;
-                std::thread t([cmd, &result]() {
-                    result = system(cmd.c_str());
+                std::thread t([wcmd, &result]() {
+                    result = _wsystem(wcmd.c_str());
                 });
                 t.join();
                 log_info("ddr", "`{}` returned {}", cmd, result);


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
#345 

## Description of change
Account for the path to codec DLL having spaces in it and use wide chars.

## Testing
Testing 32 and 64 bits.
