### PR TITLE
pc: add language hook

### DIFF
--- a/src/spice2x/hooks/lang.cpp
+++ b/src/spice2x/hooks/lang.cpp
@@ -126,16 +126,19 @@ static int WINAPI GetLocaleInfoEx_hook (
         LPWSTR lpLCData,
         int cchData)
 {
-    // if (lpLocaleName == LOCALE_NAME_INVARIANT) {
-    //     log_misc("hooks::lang", "GetLocaleInfoEx_hook hit (LOCALE_NAME_INVARIANT), {}, {}", LCType, cchData);
-    // } else if (lpLocaleName == LOCALE_NAME_SYSTEM_DEFAULT) {
-    //     log_misc("hooks::lang", "GetLocaleInfoEx_hook hit (LOCALE_NAME_SYSTEM_DEFAULT), {}", LCType, cchData);
-    // } else if (lpLocaleName == LOCALE_NAME_USER_DEFAULT) {
-    //     log_misc("hooks::lang", "GetLocaleInfoEx_hook hit (LOCALE_NAME_USER_DEFAULT), {}", LCType, cchData);
-    // } else {
-    //     log_misc("hooks::lang", "GetLocaleInfoEx_hook hit ({}), {}, {}", ws2s(lpLocaleName), LCType, cchData);
-    // }
-    
+
+#if 0
+    if (lpLocaleName == LOCALE_NAME_INVARIANT) {
+        log_misc("hooks::lang", "GetLocaleInfoEx_hook hit (LOCALE_NAME_INVARIANT), {}, {}", LCType, cchData);
+    } else if (lpLocaleName == LOCALE_NAME_SYSTEM_DEFAULT) {
+        log_misc("hooks::lang", "GetLocaleInfoEx_hook hit (LOCALE_NAME_SYSTEM_DEFAULT), {}, {}", LCType, cchData);
+    } else if (lpLocaleName == LOCALE_NAME_USER_DEFAULT) {
+        log_misc("hooks::lang", "GetLocaleInfoEx_hook hit (LOCALE_NAME_USER_DEFAULT), {}, {}", LCType, cchData);
+    } else {
+        log_misc("hooks::lang", "GetLocaleInfoEx_hook hit ({}), {}, {}", ws2s(lpLocaleName), LCType, cchData);
+    }
+#endif
+
     if (lpLocaleName == LOCALE_NAME_USER_DEFAULT &&
         LCType == LOCALE_SISO639LANGNAME &&
         lpLCData != NULL &&


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
Fixes #362 

## Description of change
Add a hook for `GetLocaleInfoEx` and return `ja-JP` to fix the "translation not found" issue in XIF.

## Testing
Tested with/without Disable ACP option.
