### PR TITLE
pc: fix certain controller bindings not working

### DIFF
--- a/src/spice2x/games/pc/pc.cpp
+++ b/src/spice2x/games/pc/pc.cpp
@@ -11,6 +11,7 @@
 #include "acioemu/handle.h"
 #include "misc/wintouchemu.h"
 #include "hooks/graphics/graphics.h"
+#include "rawinput/rawinput.h"
 
 namespace games::pc {
     std::string PC_INJECT_ARGS = "";
@@ -22,6 +23,18 @@ namespace games::pc {
     static decltype(RegisterRawInputDevices) *RegisterRawInputDevices_orig = nullptr;
 
     static BOOL WINAPI RegisterRawInputDevices_hook(PCRAWINPUTDEVICE pRawInputDevices, UINT uiNumDevices, UINT cbSize) {
+
+        // if the caller is spice itself, then pass through.
+        if (pRawInputDevices &&
+            (uiNumDevices > 0) &&
+            (pRawInputDevices[0].hwndTarget == RI_MGR->input_hwnd)) {
+            
+            return RegisterRawInputDevices_orig(pRawInputDevices, uiNumDevices, cbSize);
+        }
+        
+        // otherwise, it must be the game; prevent the game from registering for raw input
+        // and hijacking WM_INPUT messages.
+        SetLastError(0xDEADBEEF);
         return FALSE;
     }
 

--- a/src/spice2x/rawinput/rawinput.h
+++ b/src/spice2x/rawinput/rawinput.h
@@ -54,7 +54,6 @@ namespace rawinput {
 
         HotplugManager *hotplug;
         std::vector<Device> devices;
-        HWND input_hwnd = nullptr;
         WNDCLASSEX input_hwnd_class {};
         std::thread *input_thread = nullptr;
         std::thread *flush_thread = nullptr;
@@ -90,6 +89,8 @@ namespace rawinput {
         static DeviceInfo get_device_info(const std::string &device_name);
 
     public:
+
+        HWND input_hwnd = nullptr;
 
         RawInputManager();
         ~RawInputManager();


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
Fixes #364 

## Description of change
The game attempts to hook raw input, but raw input API can only be used by one window per process. Hook `RegisterRawInputDevices` and prevent the game from registration for raw input notifications.

## Testing
Tested that HID keyboard works with `Bind` option.