### PR TITLE
launcher: show a giant warning when the user specifies -exec option

### DIFF
--- a/src/spice2x/games/mfg/mfg.cpp
+++ b/src/spice2x/games/mfg/mfg.cpp
@@ -28,7 +28,7 @@ namespace games::mfg {
         SetEnvironmentVariableA("VFG_CABINET_TYPE", MFG_CABINET_TYPE.c_str());
 
         // add card reader
-        portName = MFG_CABINET_TYPE == "UKS" ? L"\\\\.\\COM1" : L"\\\\.\\COM3";
+        portName = (MFG_CABINET_TYPE == "UKS") ? std::wstring(L"\\\\.\\COM1") : std::wstring(L"\\\\.\\COM3");
         acioHandle = new acioemu::ACIOHandle(portName.c_str(), 1);
         devicehook_init_trampoline();
         devicehook_add(acioHandle);

--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -1272,6 +1272,19 @@ int main_implementation(int argc, char *argv[]) {
         }
     }
 
+    if (options[launcher::Options::GameExecutable].is_active() && !cfg::CONFIGURATOR_STANDALONE) {
+        log_warning(
+            "launcher",
+            "WARNING - user specified -exec option\n\n\n"
+            "!!!                                                             !!!\n"
+            "!!! Using -exec option disables all game-specific hooks!        !!!\n"
+            "!!! Unless you know exactly what you are doing, clear -exec     !!!\n"
+            "!!!   and try again. Using -exec by itself will result in weird !!!\n"
+            "!!!   errors and loss of functionality.                         !!!\n"
+            "!!!                                                             !!!\n"
+            );
+    }
+
     if (options[launcher::Options::FullscreenResolution].is_active()) {
         std::pair<uint32_t, uint32_t> result;
         if (parse_width_height(options[launcher::Options::FullscreenResolution].value_text(), result)) {


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
#345

## Description of change
If `-exec` is specified, log a giant warning.

Also, fix some compiler warnings in MFG.

## Testing
Confirmed message being logged in log.txt.