### PR TITLE
iidx,sdvx: detect SuperstepSound init failures and log a message upon crash

### DIFF
--- a/src/spice2x/games/iidx/iidx.cpp
+++ b/src/spice2x/games/iidx/iidx.cpp
@@ -27,6 +27,7 @@
 #include "util/memutils.h"
 #include "util/sigscan.h"
 #include "util/utils.h"
+#include "launcher/signal.h"
 
 #include "external/robin_hood.h"
 
@@ -232,6 +233,9 @@ namespace games::iidx {
         } else if (data.find(" W:touch: missing trigger:") != std::string::npos) {
             out.clear();
             return true;
+        } else if (data.find("SuperstepSound: Audio device is not available") != std::string::npos) {
+            launcher::signal::SUPERSTEP_SOUND_ERROR = TRUE;
+            return false;
         } else {
             return false;
         }

--- a/src/spice2x/games/sdvx/sdvx.cpp
+++ b/src/spice2x/games/sdvx/sdvx.cpp
@@ -24,6 +24,7 @@
 #include "io.h"
 #include "acioemu/handle.h"
 #include "cfg/configurator.h"
+#include "launcher/signal.h"
 
 static decltype(RegCloseKey) *RegCloseKey_orig = nullptr;
 static decltype(RegEnumKeyA) *RegEnumKeyA_orig = nullptr;
@@ -208,6 +209,10 @@ namespace games::sdvx {
         if (data.find("M:AppConfig: [env/") != std::string::npos) {
             out = "";
             return true;
+        }
+        if (data.find("SuperstepSound: Audio device is not available") != std::string::npos) {
+            launcher::signal::SUPERSTEP_SOUND_ERROR = TRUE;
+            return false;
         }
         return false;
     }

--- a/src/spice2x/launcher/signal.cpp
+++ b/src/spice2x/launcher/signal.cpp
@@ -29,6 +29,9 @@ namespace launcher::signal {
     // settings
     bool DISABLE = false;
     bool USE_VEH_WORKAROUND = false;
+
+    // states
+    bool SUPERSTEP_SOUND_ERROR = false;
 }
 
 #define V(variant) case variant: return #variant
@@ -109,6 +112,13 @@ static LONG WINAPI TopLevelExceptionFilter(struct _EXCEPTION_POINTERS *Exception
             log_warning(
                 "signal",
                 "    RivaTuner Statistics Server (RTSS), MSI Afterburner, kernel mode anti-cheat");
+        }
+
+        if (launcher::signal::SUPERSTEP_SOUND_ERROR) {
+            log_warning("signal", "audio initialization error was previously detected during boot!");
+            log_warning("signal", "    (W:SuperstepSound: Audio device is not available!!!)");
+            log_warning("signal", "    this crash is most likely related to audio init failure");
+            log_warning("signal", "    fix your audio device, double check your audio options/patches, and try again");
         }
 
         // walk the exception chain

--- a/src/spice2x/launcher/signal.h
+++ b/src/spice2x/launcher/signal.h
@@ -5,6 +5,7 @@ namespace launcher::signal {
     // settings
     extern bool DISABLE;
     extern bool USE_VEH_WORKAROUND;
+    extern bool SUPERSTEP_SOUND_ERROR;
 
     //void print_stacktrace();
     void attach();


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
#345 

## Description of change
If we see SuperstepSound failure during boot, remember it, and when the game eventually crashes, log a series of warning messages to surface why the game likely failed to launch.

## Testing
Tested both iidx and sdvx with an audio device set to not allow exclusive mode.
