### PR TITLE
ea3: remove verbose debug logs by default

### DIFF
--- a/src/spice2x/avs/ea3.cpp
+++ b/src/spice2x/avs/ea3.cpp
@@ -41,6 +41,7 @@ namespace avs {
         int HTTP11 = -1;
         int URL_SLASH = -1;
         int PCB_TYPE = -1;
+        bool EA3_DEBUG_VERBOSE = false;
 
         // handle
         std::string VERSION_STR = "unknown";
@@ -410,6 +411,11 @@ namespace avs {
                 log_fatal("avs-ea3", "node not found: /ea3/id/pcbid (try using -p to specify PCBID)");
             } else if (strlen(EA3_PCBID) == 0) {
                 log_fatal("avs-ea3", "no PCBID set (try using -p to specify PCBID)");
+            }
+
+            // remove <debug> since it can expose pcbid in logged requests
+            if (!EA3_DEBUG_VERBOSE) {
+                avs::core::property_search_remove_safe(ea3_config, nullptr, "/ea3/debug/verbose");
             }
 
             // remember IDs

--- a/src/spice2x/avs/ea3.h
+++ b/src/spice2x/avs/ea3.h
@@ -28,6 +28,7 @@ namespace avs {
         extern int HTTP11;
         extern int URL_SLASH;
         extern int PCB_TYPE;
+        extern bool EA3_DEBUG_VERBOSE;
 
         // handle
         extern std::string VERSION_STR;

--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -365,6 +365,9 @@ int main_implementation(int argc, char *argv[]) {
     if (options[launcher::Options::VerboseAVSLogging].value_bool()) {
         hooks::avs::config::LOG = true;
     }
+    if (options[launcher::Options::AllowEA3Verbose].value_bool()) {
+        avs::ea3::EA3_DEBUG_VERBOSE = true;
+    }
     if (options[launcher::Options::spice2x_AutoOrientation].is_active()) {
         GRAPHICS_ADJUST_ORIENTATION =
             (graphics_orientation)options[launcher::Options::spice2x_AutoOrientation].value_uint32();

--- a/src/spice2x/launcher/options.cpp
+++ b/src/spice2x/launcher/options.cpp
@@ -1673,6 +1673,16 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .category = "Debug Log",
     },
     {
+        // AllowEA3Verbose
+        .title = "Allow EA3 Verbose Debug Logging",
+        .name = "ea3verbose",
+        .desc = "This option is only useful for network developers; leave this OFF.\n\n"
+            "By default, ea3/debug/verbose node is removed by spice to prevent exposing PCBID in the logs. "
+            "When this is enabled, ea3/debug/verbose node in the XML will be kept and exposed to the game",
+        .type = OptionType::Bool,
+        .category = "Debug Log",
+    },
+    {
         .title = "Disable Colored Output",
         .name = "nocolor",
         .desc = "Disable terminal colors for log outputs to console",
@@ -2375,7 +2385,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Bool,
         .category = "Development",
         .disabled = true,
-    },
+    }
 };
 
 const std::vector<std::string> &launcher::get_categories(Options::OptionsCategory category) {

--- a/src/spice2x/launcher/options.h
+++ b/src/spice2x/launcher/options.h
@@ -188,6 +188,7 @@ namespace launcher {
             DebugCreateFile,
             VerboseGraphicsLogging,
             VerboseAVSLogging,
+            AllowEA3Verbose,
             DisableColoredOutput,
             DisableACPHook,
             DisableSignalHandling,


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
n/a

## Description of change
Recently distributed iidx data has this enabled in ea3-config.xml by default, exposing people's PCBID in the logs.

Find the node in the XML and remove it on boot, unless user overrides it with a new option.

## Testing
Tested using asphyxia.