### PR TITLE
pcm: support 2024091200 version

### DIFF
--- a/src/spice2x/games/pcm/pcm.cpp
+++ b/src/spice2x/games/pcm/pcm.cpp
@@ -148,5 +148,13 @@ namespace games::pcm {
                 system, "?GetEscrowBillKind@GsBillVali@@SAHXZ"));
         detour::inline_hook(BillVali_SetAcceptBill, libutils::try_proc(
                 system, "?SetAcceptBill@GsBillVali@@SA_NH@Z"));
+
+        // NOTE: for 2024091200 or newer
+        detour::inline_hook(BillVali_ReceiveBill, libutils::try_proc(
+                system, "?ReceiveBill@GsBillVali@@SA_NXZ"));
+        detour::inline_hook(BillVali_GetEscrowBillKind, libutils::try_proc(
+                system, "?GetEscrowBillKind@GsBillVali@@SA?AW4E_BILLKIND@@XZ"));
+        detour::inline_hook(BillVali_SetAcceptBill, libutils::try_proc(
+                system, "?SetAcceptBill@GsBillVali@@SA_NW4E_BILLKIND@@@Z"));
     }
 }


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
none

## Description of change
Supports PCM version 2024091200.

## Testing
1. After starting the PCM, touch card and auth.
2. Press the bill insert button.
3. Check account balance has increased.

## Known issue
For example, if you are asked to insert 10,000 yen, inserting 1,000 yen will not be rejected and will be recognized correctly.
This has not been fixed as i have focused on getting it to work at a minimum.
