### PR TITLE
troubleshooter: properly fix deadlock

### DIFF
--- a/src/spice2x/launcher/signal.cpp
+++ b/src/spice2x/launcher/signal.cpp
@@ -101,7 +101,7 @@ static LONG WINAPI TopLevelExceptionFilter(struct _EXCEPTION_POINTERS *Exception
         switch (ExceptionRecord->ExceptionCode) {
             case EXCEPTION_ILLEGAL_INSTRUCTION:
                 deferredlogs::defer_error_messages({
-                    "Illegal instruction exception:",
+                    "illegal instruction exception:",
                     "    either your CPU is too old (e.g., does not support SSE4.2 or AVX2 ",
                     "    but perhaps the game requires it); or, a bad patch was applied."
                     });
@@ -124,7 +124,7 @@ static LONG WINAPI TopLevelExceptionFilter(struct _EXCEPTION_POINTERS *Exception
 
         // dump deferred logs BEFORE stack trace since some errors cause stack trace logic to hang
         // (e.g., ACIO init hang due to RTSS)
-        deferredlogs::dump_to_logger();
+        deferredlogs::dump_to_logger(true);
 
         // walk the exception chain
         struct _EXCEPTION_RECORD *record_cause = ExceptionRecord->ExceptionRecord;

--- a/src/spice2x/util/deferlog.h
+++ b/src/spice2x/util/deferlog.h
@@ -10,5 +10,5 @@ namespace deferredlogs {
     extern const std::initializer_list<std::string> SUPERSTEP_SOUND_ERROR_MESSAGE;
 
     void defer_error_messages(std::initializer_list<std::string> messages);
-    void dump_to_logger();
+    void dump_to_logger(bool is_crash=false);
 }


### PR DESCRIPTION
## Description of change
Finally figured out where the deadlock was coming from - it's because the `dump_to_logger` was writing `SuperstepSound: Audio device is not available` to the logger which calls back into the log hook, and then emits another deferred message, trying to acquire the lock again on the same stack.

## Testing
Tested the superstep sound failure case again.
