### PR TITLE
iidx: set CONNECT_CAMERA env var even when iidx module is not enabled

### DIFF
--- a/src/spice2x/games/iidx/iidx.cpp
+++ b/src/spice2x/games/iidx/iidx.cpp
@@ -420,10 +420,6 @@ namespace games::iidx {
 
         // environment variables must be set before the DLL is loaded as the VC++ runtime copies all
         // environment variables at startup
-        if (DISABLE_CAMS) {
-            SetEnvironmentVariable("CONNECT_CAMERA", "0");
-        }
-
         if (SCREEN_MODE.has_value()) {
             SetEnvironmentVariable("SCREEN_MODE", SCREEN_MODE.value().c_str());
         }

--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -482,6 +482,9 @@ int main_implementation(int argc, char *argv[]) {
         // Disable legacy behaviour to avoid conflict
         games::iidx::DISABLE_CAMS = true;
     }
+    if (games::iidx::DISABLE_CAMS) {
+        SetEnvironmentVariable("CONNECT_CAMERA", "0");
+    }
     if (options[launcher::Options::IIDXCamHookOverride].is_active()) {
         games::iidx::TDJ_CAMERA_OVERRIDE = options[launcher::Options::IIDXCamHookOverride].value_text();
     }


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
Fixes #403 

## Description of change
Set CONNECT_CAMERA env var even when iidx module is not enabled, so that camhook can work without -iidx being set with real IO

## Testing
tested with emulated i/o and real i/o by user (see linked issue)