### PR TITLE
troubleshooter: add cases for audio hook and dx9on12

### DIFF
--- a/src/spice2x/games/iidx/iidx.cpp
+++ b/src/spice2x/games/iidx/iidx.cpp
@@ -405,14 +405,6 @@ namespace games::iidx {
 
         // init cfgmgr32 hooks
         cfgmgr32hook_init(avs::game::DLL_INSTANCE);
-
-        // report common errors on iidx31 and above
-        if (avs::game::is_ext(2023091500, MAXINT) && GRAPHICS_9_ON_12_STATE == DX9ON12_FORCE_ON) {
-            deferredlogs::defer_error_messages({
-                "common incompatibility with DX 9on12 + IIDX 31 and above",
-                "    IIDX31+ is known to be incompatible with DX 9on12, leading to blank screen or crashes"
-            });
-        }
     }
 
     void IIDXGame::pre_attach() {

--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -946,6 +946,11 @@ int main_implementation(int argc, char *argv[]) {
     }
     if (options[launcher::Options::DisableAudioHooks].value_bool()) {
         hooks::audio::ENABLED = false;
+        deferredlogs::defer_error_messages({
+            "audio hooks are forcibly disabled by user (-audiohookdisable)",
+            "    having hooks disabled means some required audio fixes are not being applied",
+            "    if you have audio-related crashes, you should try again after clearing this option"
+            });
     }
     if (options[launcher::Options::spice2x_DisableVolumeHook].value_bool()) {
         hooks::audio::VOLUME_HOOK_ENABLED = false;


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
#345

## Description of change
Add auto-troubleshooter messages for when audio hooks are disabled, and when 9on12 is turned on by user.

## Testing
Manual verification