### PR TITLE
signal: force minimize widnows before showing crash handler dialog

### DIFF
--- a/src/spice2x/util/deferlog.cpp
+++ b/src/spice2x/util/deferlog.cpp
@@ -2,6 +2,7 @@
 #include <atomic>
 
 #include "build/defs.h"
+#include "hooks/graphics/graphics.h"
 #include "deferlog.h"
 #include "util/logging.h"
 
@@ -76,6 +77,13 @@ namespace deferredlogs {
     void show_popup_for_crash() {
         static std::once_flag shown;
         std::call_once(shown, []() {
+
+            // minimize all windows
+            // only needed because in multi-monitor full screen games, MessageBox fails to show above the game
+            for (auto &hwnd : GRAPHICS_WINDOWS) {
+                ShowWindow(hwnd, SW_FORCEMINIMIZE); 
+            }
+
             const std::string title = "spice2x (" + to_string(VERSION_STRING_CFG) + ") - crash handler";
             std::string text;
             text += "Game has crashed.\n\n";


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
#410 

## Description of change
Forcibly minimize all windows before showing the crash dialog. Without this, the dialog shows "behind" the game when launching multi-monitor fullscreen games (TDJ, VM)

## Testing
Tested TDJ and VM in fullscreen.
