### PR TITLE
mfc: detect 2025 version

### DIFF
--- a/src/spice2x/games/mfc/mfc.cpp
+++ b/src/spice2x/games/mfc/mfc.cpp
@@ -308,6 +308,13 @@ namespace games::mfc {
         auto allinone_module = libutils::try_module("allinone.dll");
         auto system_module = libutils::try_module("system.dll");
 
+        // Mahjong Fight Club - 2025?
+        // they removed allinone.dll and moved i/o into system.dll
+        if (allinone_module == nullptr) {
+            log_misc("mfc", "using system.dll instead of allinone.dll for i/o hooks");
+            allinone_module = system_module;
+        }
+
         // network fix
         detour::iat_try("?nic_dhcp_maybe_exist@@YAEXZ", nic_dhcp_maybe_exist, system_module);
 

--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -1676,6 +1676,14 @@ int main_implementation(int argc, char *argv[]) {
                 attach_io = true;
                 attach_mfc = true;
                 break;
+
+            // Mahjong Fight Club - 2025?
+            // they removed allinone.dll and moved i/o into system.dll
+            } else if (check_dll("system.dll") && fileutils::file_exists("data/mfc.ini")) {
+                avs::game::DLL_NAME = "system.dll";
+                attach_io = true;
+                attach_mfc = true;
+                break;
             }
 
             // FutureTomTom


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
n/a

## Description of change
They moved some DLLs around so MFC wasn't being auto-detected, and I/O hooks were not being performed. Fix that.

## Testing
The game boots into test menu, some i/o works, touch doesn't, not playable yet.
