### PR TITLE
launcher: hide pcbid when -cmdoverride specified

### DIFF
--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -1262,18 +1262,19 @@ int main_implementation(int argc, char *argv[]) {
     for (const auto &option : options) {
         if (option.conflicting && option.get_definition().type != OptionType::Bool) {
             conflicts += 1;
+            const auto& value = option.get_definition().sensitive ? "*****" : option.value;
             if (launcher::USE_CMD_OVERRIDE) {
                 log_warning(
                     "launcher",
                     "multiple values for -{}, command line args take precedence: {}",
                     option.get_definition().name, 
-                    option.value);
+                    value);
             } else {
                 log_warning(
                     "launcher",
                     "multiple values for -{}, spicecfg values take precedence: {}",
                     option.get_definition().name,
-                    option.value);
+                    value);
             }
         }
     }


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
Fixes #419 

## Description of change
-cmdoverride caused pcbid to be logged in plain text

## Testing
