### PR TITLE
rawinput: use UTF-8 for device descriptor

### DIFF
--- a/src/spice2x/util/utils.h
+++ b/src/spice2x/util/utils.h
@@ -340,3 +340,13 @@ static inline bool parse_width_height(const std::string wh, std::pair<uint32_t, 
         return false;
     }
 }
+
+static inline std::string wchar_to_u8(const wchar_t* wstr) {
+    int size = WideCharToMultiByte(CP_UTF8, 0, wstr, -1, nullptr, 0, nullptr, nullptr);
+    if (size <= 1) {
+        return "";
+    }
+    std::string out(size - 1, 0);
+    WideCharToMultiByte(CP_UTF8, 0, wstr, -1, out.data(), size - 1, nullptr, nullptr);
+    return out;
+}


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
n/a

## Description of change
For HID device descriptor, use the "W" version of Windows API, and make sure UTF-8 is being used throughout since that's the only format IMGUI supports.

Before this change, non-Latin characters would have shown up as `HID ??? ?????` for a mouse, for example.

Due to the way ImGui loads fonts, only the following languages are supported:

* Simplified Chinese
* Cyrillic
* Japanese
* Korean
* Thai
* Vietnamese

## Testing
Tested various combination of Windows UI language and non-Unicode language. 