### PR TITLE
patches: disable patches tab for unity games

### DIFF
--- a/src/spice2x/overlay/windows/patch_manager.cpp
+++ b/src/spice2x/overlay/windows/patch_manager.cpp
@@ -288,6 +288,12 @@ namespace overlay::windows {
             this->reload_local_patches();
         }
 
+        if (avs::game::DLL_NAME == "kamunity.dll") {
+            ImGui::TextColored(ImVec4(1.f, 0.f, 0.f, 1.f), "Patches are not supported for Unity-based games.");
+            ImGui::TextColored(ImVec4(1.f, 0.f, 0.f, 1.f), "Instead, look for downloads of pre-patched DLLs.");
+            return;
+        }
+
         // game code info
         std::string identifiers;
         identifiers += avs::game::get_identifier() + "\n\n";


### PR DESCRIPTION
## Description of change
To redirect confused users why no one is developing a remote patch server for PolCho

## Testing
checked spicecfg in working vs non-working games