### PR TITLE
mfc: fix 2025 version touch

### DIFF
--- a/src/spice2x/games/mfc/mfc.h
+++ b/src/spice2x/games/mfc/mfc.h
@@ -4,6 +4,8 @@
 
 namespace games::mfc {
 
+    extern bool HG_MODE;
+
     struct joystick_state {
         bool up = false;
         bool down = false;

--- a/src/spice2x/hooks/graphics/backends/d3d9/d3d9_backend.cpp
+++ b/src/spice2x/hooks/graphics/backends/d3d9/d3d9_backend.cpp
@@ -15,6 +15,7 @@
 #include "cfg/screen_resize.h"
 #include "games/iidx/iidx.h"
 #include "games/sdvx/sdvx.h"
+#include "games/mfc/mfc.h"
 #include "games/io.h"
 #include "hooks/graphics/graphics.h"
 #include "launcher/launcher.h"
@@ -1358,6 +1359,11 @@ void graphics_d3d9_on_present(
     const bool is_tdj = avs::game::is_model("LDJ") && games::iidx::TDJ_MODE;
     if (is_vm || is_tdj) {
         graphics_d3d9_ldj_on_present(wrapped_device);
+    }
+
+    const bool is_mfc = avs::game::is_model("KK9") && games::mfc::HG_MODE;
+    if (is_mfc) {
+        wintouchemu::update();
     }
 
     // check screenshot key

--- a/src/spice2x/misc/wintouchemu.cpp
+++ b/src/spice2x/misc/wintouchemu.cpp
@@ -34,6 +34,7 @@ namespace wintouchemu {
     bool FORCE = false;
     bool INJECT_MOUSE_AS_WM_TOUCH = false;
     bool LOG_FPS = false;
+    bool ADD_TOUCH_FLAG_PRIMARY = false;
 
     static inline bool is_emu_enabled() {
         return FORCE || !is_touch_available("wintouchemu::is_emu_enabled") || GRAPHICS_SHOW_CURSOR;
@@ -187,16 +188,28 @@ namespace wintouchemu {
                 switch (touch_event->type) {
                     case TOUCH_DOWN:
                         if (valid) {
+                            if (ADD_TOUCH_FLAG_PRIMARY) {
+                                touch_input->dwFlags |= TOUCHEVENTF_PRIMARY;
+                            }
+
                             touch_input->dwFlags |= TOUCHEVENTF_DOWN;
                         }
                         break;
                     case TOUCH_MOVE:
                         if (valid) {
+                            if (ADD_TOUCH_FLAG_PRIMARY) {
+                                touch_input->dwFlags |= TOUCHEVENTF_PRIMARY;
+                            }
+
                             touch_input->dwFlags |= TOUCHEVENTF_MOVE;
                         }
                         break;
                     case TOUCH_UP:
                         // don't check valid so that this touch ID can be released
+                        if (ADD_TOUCH_FLAG_PRIMARY) {
+                            touch_input->dwFlags |= TOUCHEVENTF_PRIMARY;
+                        }
+
                         touch_input->dwFlags |= TOUCHEVENTF_UP;
                         break;
                 }
@@ -238,16 +251,28 @@ namespace wintouchemu {
                     switch (mouse_state.touch_event) {
                         case TOUCHEVENTF_DOWN:
                             if (valid) {
+                                if (ADD_TOUCH_FLAG_PRIMARY) {
+                                    touch_input->dwFlags |= TOUCHEVENTF_PRIMARY;
+                                }
+
                                 touch_input->dwFlags |= TOUCHEVENTF_DOWN;
                             }
                             break;
                         case TOUCHEVENTF_MOVE:
                             if (valid) {
+                                if (ADD_TOUCH_FLAG_PRIMARY) {
+                                    touch_input->dwFlags |= TOUCHEVENTF_PRIMARY;
+                                }
+
                                 touch_input->dwFlags |= TOUCHEVENTF_MOVE;
                             }
                             break;
                         case TOUCHEVENTF_UP:
                             // don't check valid so that this touch ID can be released
+                            if (ADD_TOUCH_FLAG_PRIMARY) {
+                                touch_input->dwFlags |= TOUCHEVENTF_PRIMARY;
+                            }
+
                             touch_input->dwFlags |= TOUCHEVENTF_UP;
                             break;
                     }

--- a/src/spice2x/misc/wintouchemu.h
+++ b/src/spice2x/misc/wintouchemu.h
@@ -8,6 +8,7 @@ namespace wintouchemu {
     extern bool FORCE;
     extern bool INJECT_MOUSE_AS_WM_TOUCH;
     extern bool LOG_FPS;
+    extern bool ADD_TOUCH_FLAG_PRIMARY;
 
     void hook(const char *window_title, HMODULE module = nullptr, int delay_in_s=0);
     void hook_title_ends(


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
n/a

## Description of change
HG cabinet uses wintouch and it requires TOUCHEVENTF_PRIMARY flag in order to accept touch inputs.
Added wintouchemu on game hook and TOUCHEVENTF_PRIMARY flag on wintouchemu.
 
## Testing
The game boots into test menu, touch now works. (tested in I/O TEST -> TOUCH PANEL CHECK with '-s' flag)
TDJ subscreen overlay and nostalgia seems works fine regardless added TOUCHEVENTF_PRIMARY flag but more testing required.
