### PR TITLE
cfg: fix combo boxes

### DIFF
--- a/src/spice2x/overlay/windows/config.cpp
+++ b/src/spice2x/overlay/windows/config.cpp
@@ -2844,7 +2844,7 @@ namespace overlay::windows {
                                     label += fmt::format(" ({})", element.second);
                                 }
                                 
-                                bool selected = current_item == element.first;
+                                bool selected = current_item == label;
                                 if (ImGui::Selectable(label.c_str(), selected)) {
                                     this->options_dirty = true;
                                     option.value = element.first;


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
n/a

## Description of change
Combo boxes for options were not highlighting the currently selected item. Also, when there were no description provided for an option, it was still showing the empty `()` in the selected value.

## Testing
