### PR TITLE
mdx: fix io mode bio2 boot crash

### DIFF
--- a/src/spice2x/avs/ea3.cpp
+++ b/src/spice2x/avs/ea3.cpp
@@ -452,9 +452,15 @@ namespace avs {
                 security_code << "*";
             }
             security_code << EA3_MODEL;
-            security_code << EA3_DEST;
-            security_code << EA3_SPEC;
-            security_code << EA3_REV;
+            if (strcmp(EA3_MODEL, "MDX") == 0 && strcmp(EA3_SPEC, "I") == 0) {
+                security_code << "E";
+                security_code << "B";
+                security_code << "B";
+            } else {
+                security_code << EA3_DEST;
+                security_code << EA3_SPEC;
+                security_code << EA3_REV;
+            }
             std::string security_code_str = security_code.str();
             log_info("avs-ea3", "security code: {}", security_code_str);
 


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
n/a

## Description of change
Currently when 'bio2' specified on 'io' parameter of app-config the game crashed due to security code check.
These codes changes security code to corresponding one and adds fake BIO2 entry to satisfy BIO2 check.

## Testing
Tested with MDX-003 and J:I:B ident.
The game boots and A3 now displays gold cab theme and displays MATCHING GROUP, MATCHING SIDE on NETWORK OPTIONS test mode menu.