### PR TITLE
mdx: change init_code instead of security_code for gold cab

### DIFF
--- a/src/spice2x/avs/ea3.cpp
+++ b/src/spice2x/avs/ea3.cpp
@@ -487,8 +487,7 @@ namespace avs {
             if (strcmp(EA3_MODEL, "MDX") == 0 && strcmp(EA3_SPEC, "I") == 0) {
                 init_code << "G";
                 init_code << "B";
-            }
-            else {
+            } else {
                 init_code << EA3_SPEC;
                 init_code << EA3_REV;
             }


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
n/a

## Description of change
This changes previous security code change to init code change (#435)

## Testing
