### PR TITLE
MDX: Fixed Status Control Buffer Emulators (P4IO Timing Fix)

### DIFF
--- a/src/spice2x/acio/mdxf/mdxf.cpp
+++ b/src/spice2x/acio/mdxf/mdxf.cpp
@@ -11,7 +11,8 @@
 const size_t STATUS_BUFFER_SIZE = 32;
 
 // static stuff
-static uint8_t COUNTER = 0;
+static uint8_t COUNTER_P1 = 0;
+static uint8_t COUNTER_P2 = 0;
 
 // buffers
 #pragma pack(push, 1)
@@ -45,13 +46,14 @@ static bool __cdecl ac_io_mdxf_get_control_status_buffer(int node, void *buffer,
     // Dance Dance Revolution
     if (avs::game::is_model("MDX")) {
 
-        // get buffer index
-        auto i = (COUNTER + a3) % std::size(BUFFERS.STATUS_BUFFER_P1);
-
         // copy buffer
         if (node == 17 || node == 25) {
+			// get buffer index
+			auto i = (COUNTER_P1 + a3) % std::size(BUFFERS.STATUS_BUFFER_P1);
             memcpy(buffer, BUFFERS.STATUS_BUFFER_P1[i], STATUS_BUFFER_SIZE);
         } else if (node == 18 || node == 26) {
+			// get buffer index
+			auto i = (COUNTER_P2 + a3) % std::size(BUFFERS.STATUS_BUFFER_P2);
             memcpy(buffer, BUFFERS.STATUS_BUFFER_P2[i], STATUS_BUFFER_SIZE);
         } else {
 
@@ -106,9 +108,6 @@ static bool __cdecl ac_io_mdxf_set_output_level(unsigned int a1, unsigned int a2
 
 static bool __cdecl ac_io_mdxf_update_control_status_buffer(int node) {
 
-    // increase counter
-    COUNTER = (COUNTER + 1) % std::size(BUFFERS.STATUS_BUFFER_P1);
-
     // check freeze
     if (STATUS_BUFFER_FREEZE) {
         return true;
@@ -119,11 +118,15 @@ static bool __cdecl ac_io_mdxf_update_control_status_buffer(int node) {
     switch (node) {
         case 17:
         case 25:
-            buffer = BUFFERS.STATUS_BUFFER_P1[COUNTER];
+			// increase counter
+			COUNTER_P1 = (COUNTER_P1 + 1) % std::size(BUFFERS.STATUS_BUFFER_P1);
+            buffer = BUFFERS.STATUS_BUFFER_P1[COUNTER_P1];
             break;
         case 18:
         case 26:
-            buffer = BUFFERS.STATUS_BUFFER_P2[COUNTER];
+			// increase counter
+			COUNTER_P2 = (COUNTER_P2 + 1) % std::size(BUFFERS.STATUS_BUFFER_P2);
+            buffer = BUFFERS.STATUS_BUFFER_P2[COUNTER_P2];
             break;
         default:
 


### PR DESCRIPTION
## Description of change
In its current state, the emulated `libacio2.dll` functions `ac_io_mdxf_get_control_status_buffer` and `ac_io_mdxf_update_control_status_buffer` only operate using a single head pointer (`COUNTER`) for the ring buffers of `[panel_state,timestamp]` (simplified for brevity here) polls for both players, when they should be maintaining a separate head pointer for each ring buffer. On every frame, `arkmdxp4.dll` makes calls to `ac_io_mdxf_update_control_status_buffer`, which [in this emulated version] advances the head pointer, creates a new entry for the latest panel state info along with the current time, and stores it at the head of the ring buffer. This function is called for each player: After the call for 1P, the head pointer is advanced by 1, so by the time it's called for 2P, the head pointer had already been advanced by 1, meaning the new entry for 2P's panel state ring buffer is written two entries ahead of where the last entry for 2P was written. This is an example of how the entries were written for each ring buffer:

```
Frame 1:
1P[0] = t0
2P[1] = t0

Frame 2: 
1P[2] = t1
2P[3] = t1

Frame 3:
1P[4] = t2
2P[5] = t2

Frame 4:
1P[6] = t3
2P[0] = t3

...

Frame 7:
1P[5] = t6
2P[6] = t6

Frame 8:
1P[0] = t7
2P[1] = t7
```

This is an issue because `arkmdxp4.dll` calls `ac_io_mdxf_get_control_status_buffer` on every frame to load the last 7 polls for each player, which depends on the ring buffer entries being in reverse chronological order to properly determine when an arrow is pressed and when it was released, but this is what it sees from the ring buffers after 8 frames:

```
1P: t7 -> t3 -> t6 -> t2 -> t5 -> t1 -> t4
2P: t7 -> t3 -> t6 -> t2 -> t5 -> t1 -> t4
```

In this case, `arkmdxp4.dll` assigns step times based on polls that are out of order, resulting in unpredictable timestamp assignment to each step, with the issue compounding at lower framerates since the timestamp deltas between each poll will be greater (see side note). After implementing two separate head pointers for each ring buffer, those same two arrays become:

```
1P: t7 -> t6 -> t5 -> t4 -> t3 -> t2 -> t1
2P: t7 -> t6 -> t5 -> t4 -> t3 -> t2 -> t1
```

This is how `arkmdxp4.dll` expects this data to be structured, so timing should become more consistent after this change.

Side note: in this particular p4io implementation, the only place the polls are updated is once per frame on the calls to `ac_io_mdxf_update_control_status_buffer`, meaning the polling rate of the controller used is locked to the framerate of the game. There should be another thread not tied to the main one that listens to input from the OS and updates these ring buffers on a much faster cadence.

## Testing
I played a few songs to make sure nothing was broken. I also attached a debugger and verified the ring buffer entries are now being returned in reverse chronological order as intended.
