### PR TITLE
iidx: fix play record feature broken by new NVIDIA driver update

### DIFF
--- a/src/spice2x/hooks/graphics/nvenc_hook.cpp
+++ b/src/spice2x/hooks/graphics/nvenc_hook.cpp
@@ -55,7 +55,7 @@ namespace nvenc_hook {
         log_misc("nvenc_hook", "  encodeConfig.frameIntervalP: {}", encode->encodeConfig->frameIntervalP);
         log_misc("nvenc_hook", "  encodeConfig.monoChromeEncoding: {}", encode->encodeConfig->monoChromeEncoding);
 
-        auto rc = &encode->encodeConfig->rcParams;
+        const auto rc = &encode->encodeConfig->rcParams;
         const auto h264 = &encode->encodeConfig->encodeCodecConfig.h264Config;
         log_misc("nvenc_hook", "  encodeConfig.encodeCodecConfig.h264Config.sliceMode: {}", h264->sliceMode);
         log_misc("nvenc_hook", "  encodeConfig.encodeCodecConfig.h264Config.sliceModeData: {}", h264->sliceModeData);


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
fixes #442

## Description of change
New NVIDIA driver update (591.44) dropped support for older NVENC API. Specifically,

* TDJ uses `NV_ENC_PRESET_HQ_GUID` but this is no longer supported; must be swapped with new encoder presets
* `NvEncGetEncodePresetConfig` does not take new encoder presets, the -Ex version must be used

All of this happens because bm2dx.dll takes code from an older NVENC sample.

To address this,

* Install additional hooks for NVENC API
* Hijack calls to `NvEncGetEncodePresetConfig` and instead swap with `NvEncGetEncodePresetConfigEx` (only if the initial call fails, which is how we detect old vs new driver), replacing `NV_ENC_PRESET_HQ_GUID` with `NV_ENC_PRESET_P4_GUID` and `NV_ENC_TUNING_INFO_HIGH_QUALITY` (functionally equivalent according to NVIDIA docs - https://docs.nvidia.com/video-technologies/video-codec-sdk/11.1/nvenc-preset-migration-guide/index.html)
* When calling `nvEncInitializeEncoder`, hijack and swap in the preset GUID again.

## Testing
Tested on 591.44 driver on a RTX 4070.

The resulting videos were compared as well, and they are practically identical from encoder perspective.
