### PR TITLE
iidx: option to disable recording function

### DIFF
--- a/src/spice2x/hooks/graphics/nvenc_hook.cpp
+++ b/src/spice2x/hooks/graphics/nvenc_hook.cpp
@@ -27,6 +27,8 @@ static BOOL new_preset_guids = false;
 
 namespace nvenc_hook {
 
+    bool FORCE_DISABLE;
+
     std::optional<std::string> VIDEO_CQP_STRING_OVERRIDE;
     std::optional<NV_ENC_QP> VIDEO_CQP_OVERRIDE;
 
@@ -189,6 +191,11 @@ namespace nvenc_hook {
     }
 
     NVENCSTATUS NVENCAPI NvEncodeAPICreateInstance_hook(NV_ENCODE_API_FUNCTION_LIST *pFunctionList) {        
+
+        if (FORCE_DISABLE) {
+            return NV_ENC_ERR_NO_ENCODE_DEVICE;
+        }
+
         // log_misc("nvenc_hook", "NvEncodeAPICreateInstance hook hit");
         auto status = NvEncodeAPICreateInstance_orig(pFunctionList);
 

--- a/src/spice2x/hooks/graphics/nvenc_hook.h
+++ b/src/spice2x/hooks/graphics/nvenc_hook.h
@@ -1,7 +1,12 @@
 #pragma once
 
+#ifdef SPICE64
+
 namespace nvenc_hook {
 
+    extern bool FORCE_DISABLE;
     extern std::optional<std::string> VIDEO_CQP_STRING_OVERRIDE;
     void initialize();
 }
+
+#endif

--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -539,6 +539,9 @@ int main_implementation(int argc, char *argv[]) {
     if (options[launcher::Options::IIDXRecQuality].is_active()) {
         nvenc_hook::VIDEO_CQP_STRING_OVERRIDE = options[launcher::Options::IIDXRecQuality].value_text();
     }
+    if (options[launcher::Options::IIDXRecDisable].value_bool()) {
+        nvenc_hook::FORCE_DISABLE = true;
+    }
 #endif
     if (options[launcher::Options::LoadJubeatModule].value_bool()) {
         attach_jb = true;

--- a/src/spice2x/launcher/options.cpp
+++ b/src/spice2x/launcher/options.cpp
@@ -2235,12 +2235,21 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
     },
     {
         // IIDXRecQuality
-        .title = "IIDX NVENC Quality",
+        .title = "IIDX Recording Quality",
         .name = "iidxreccqp",
         .desc = "WARNING: double check if your network allows this & your hardware supports it.\n\n"
             "For TDJ Play Record feature, specify ConstQP quality settings for NVENC. Lower is higher quality but bigger file.\n\n"
             "Two options: specify a single number (20) to set CQ Level, or specify comma-separated numbers (23,25,20) to set P, B, I levels",
         .type = OptionType::Text,
+        .game_name = "Beatmania IIDX",
+        .category = "Game Options (Advanced)",
+    },
+    {
+        // IIDXRecDisable
+        .title = "IIDX Recording Force Disable",
+        .name = "iidxnorec",
+        .desc = "When enabled, this prevents the play record feature from being used",
+        .type = OptionType::Bool,
         .game_name = "Beatmania IIDX",
         .category = "Game Options (Advanced)",
     },

--- a/src/spice2x/launcher/options.h
+++ b/src/spice2x/launcher/options.h
@@ -238,6 +238,7 @@ namespace launcher {
             spice2x_EnableSMXStage,
             spice2x_EnableSMXDedicab,
             IIDXRecQuality,
+            IIDXRecDisable,
             MidiAlgoVer,
             MidiNoteSustain,
             InputRequiresFocus,


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
#442 

## Description of change
Adds a new option that intentionally fails the recording functionality. Basically a chicken bit to opt out of recording in case a future driver update or whatever breaks things and causes crashes.

## Testing
Tested on iidx32.
