### PR TITLE
troubleshooter: detect lack of ipv4

### DIFF
--- a/src/spice2x/hooks/networkhook.cpp
+++ b/src/spice2x/hooks/networkhook.cpp
@@ -125,8 +125,13 @@ static ULONG WINAPI GetAdaptersInfo_hook(PIP_ADAPTER_INFO pAdapterInfo, PULONG p
         free(pIpForwardTable);
         pIpForwardTable = (MIB_IPFORWARDTABLE *) malloc(dwSize);
     }
-    if (GetIpForwardTable(pIpForwardTable, &dwSize, 1) != NO_ERROR || pIpForwardTable->dwNumEntries == 0)
+    if (GetIpForwardTable(pIpForwardTable, &dwSize, 1) != NO_ERROR || pIpForwardTable->dwNumEntries == 0) {
+        defer_network_adapter_error();
+        if (GetAdaptersInfo_log) {
+            log_warning("network", "GetIpForwardTable failed");
+        }
         return ret;
+    }
 
     // determine best interface
     DWORD best = pIpForwardTable->table[0].dwForwardIfIndex;


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
#345 

## Description of change
Most games will show a network error if there is no network adapter with a valid IPv4 address

Detect this case in netfix code and show a warning message in log + deferred error message.

## Testing
Tested with no network adapters, with IPv6 only adapter, and a disconnected NIC.
