### PR TITLE
iidx,sdvx: error message for subscreen unavailable does not draw a proper ImGui window

### DIFF
--- a/src/spice2x/overlay/windows/generic_sub.cpp
+++ b/src/spice2x/overlay/windows/generic_sub.cpp
@@ -90,14 +90,20 @@ namespace overlay::windows {
         this->flags |= ImGuiWindowFlags_NoBackground;
         
         if (this->disabled_message.has_value()) {
+            this->draws_window = true;
             this->flags &= ~ImGuiWindowFlags_NoBackground;
             ImGui::TextColored(YELLOW, "%s", this->disabled_message.value().c_str());
+            ImGui::TextUnformatted("");
+            if (ImGui::Button("Close")) {
+                this->set_active(false);
+            }
             return;
         }
 
         this->draw_texture();
 
         if (!this->texture) {
+            this->draws_window = true;
             this->flags &= ~ImGuiWindowFlags_NoBackground;
             ImGui::TextColored(YELLOW, "Failed to acquire surface texture for subscreen.");
             if (avs::game::is_model("LDJ")) {
@@ -110,6 +116,10 @@ namespace overlay::windows {
                     YELLOW,
                     "Ensure that you did not accidentally enable a patch \n"
                     "that turns off subscreen rendering.");
+            }
+            ImGui::TextUnformatted("");
+            if (ImGui::Button("Close")) {
+                this->set_active(false);
             }
         }
 

--- a/src/spice2x/overlay/windows/iidx_sub.cpp
+++ b/src/spice2x/overlay/windows/iidx_sub.cpp
@@ -15,7 +15,6 @@ namespace overlay::windows {
             this->disabled_message =
                 "Close this overlay and use the second window.\n"
                 "If you don't see the window, double check your DLL type and apply TDJ I/O patches as needed.";
-            this->draws_window = false;
         }
 
         float size = 0.5f;


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
n/a

## Description of change
In cases where the subscreen overlay window does not have anything to show (either via misconfiguration or an error), ensure that the window border is shown with the close button. Additionally, add a small button to close the dialog to help the user.

## Testing
manual validation
