### PR TITLE
overlay: clarify subscreen types

### DIFF
--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -523,6 +523,9 @@ int main_implementation(int argc, char *argv[]) {
         overlay::windows::IIDX_SEGMENT_LOCATION =
             options[launcher::Options::spice2x_IIDXLEDPos].value_text();
     }
+    if (options[launcher::Options::IIDXLEDBorderless].value_bool()) {
+        overlay::windows::IIDX_SEGMENT_BORDERLESS = true;
+    }
     if (options[launcher::Options::spice2x_IIDXNoESpec].value_bool()) {
         games::iidx::DISABLE_ESPEC_IO = true;
     }

--- a/src/spice2x/launcher/options.cpp
+++ b/src/spice2x/launcher/options.cpp
@@ -680,6 +680,16 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         },
     },
     {
+        // IIDXLEDBorderless
+        .title = "IIDX LED Ticker Borderless",
+        .name = "iidxledborderless",
+        .aliases= "iidxledborderless",
+        .desc = "Make LED ticker overlay window borderless (remove window decoration)",
+        .type = OptionType::Bool,
+        .game_name = "Beatmania IIDX",
+        .category = "Overlay",
+    },
+    {
         .title = "Force Load Sound Voltex Module",
         .name = "sdvx",
         .desc = "Manually enable Sound Voltex Module",

--- a/src/spice2x/launcher/options.h
+++ b/src/spice2x/launcher/options.h
@@ -71,6 +71,7 @@ namespace launcher {
             spice2x_IIDXLEDFontSize,
             spice2x_IIDXLEDColor,
             spice2x_IIDXLEDPos,
+            IIDXLEDBorderless,
             LoadSoundVoltexModule,
             SDVXForce720p,
             SDVXPrinterEmulation,

--- a/src/spice2x/overlay/windows/exitprompt.cpp
+++ b/src/spice2x/overlay/windows/exitprompt.cpp
@@ -1,6 +1,8 @@
 #include "exitprompt.h"
+#include "avs/game.h"
 #include "misc/eamuse.h"
 #include "util/logging.h"
+#include "games/iidx/iidx.h"
 
 namespace overlay::windows {
 
@@ -55,7 +57,21 @@ namespace overlay::windows {
         }
         ImGui::Spacing();
         build_button(this->overlay->window_config, "Show Config", size, NextItem::NEW_LINE, false);
-        build_button(this->overlay->window_sub, "Show Subscreen", size, NextItem::NEW_LINE, false);
+
+        std::string sub = "Show Subscreen";
+        if (avs::game::is_model("LDJ")) {
+            if (games::iidx::TDJ_MODE) {
+                sub = "Show TDJ Subscreen";
+            } else {
+                sub = "Show LDJ LED Ticker";
+            }
+        } else if (avs::game::is_model("KFC")) {
+            sub = "Show Valkyrie Subscreen";
+        } else if (avs::game::is_model("REC")) {
+            sub = "Show DRS Dance Floor";
+        }
+
+        build_button(this->overlay->window_sub, sub, size, NextItem::NEW_LINE, false);
 
         ImGui::TextDisabled("Graphics");
         build_button(this->overlay->window_camera, "Camera control", size, NextItem::NEW_LINE);

--- a/src/spice2x/overlay/windows/iidx_seg.h
+++ b/src/spice2x/overlay/windows/iidx_seg.h
@@ -8,12 +8,14 @@ namespace overlay::windows {
     extern uint32_t IIDX_SEGMENT_FONT_SIZE;
     extern std::optional<uint32_t> IIDX_SEGMENT_FONT_COLOR;
     extern std::string IIDX_SEGMENT_LOCATION;
+    extern bool IIDX_SEGMENT_BORDERLESS;
 
     class IIDXSegmentDisplay : public Window {
     public:
         IIDXSegmentDisplay(SpiceOverlay *overlay);
         void calculate_initial_window() override;
         void build_content() override;
+        float get_title_bar_height();
     private:
         ImVec4 color;
         void draw_ticker(char *ticker_string);

--- a/src/spice2x/overlay/windows/iidx_sub.cpp
+++ b/src/spice2x/overlay/windows/iidx_sub.cpp
@@ -9,7 +9,7 @@
 namespace overlay::windows {
 
     IIDXSubScreen::IIDXSubScreen(SpiceOverlay *overlay) : GenericSubScreen(overlay) {
-        this->title = "IIDX Sub Screen";
+        this->title = "IIDX TDJ Subscreen";
 
         if (GRAPHICS_IIDX_WSUB) {
             this->disabled_message =

--- a/src/spice2x/overlay/windows/sdvx_sub.cpp
+++ b/src/spice2x/overlay/windows/sdvx_sub.cpp
@@ -8,7 +8,7 @@
 namespace overlay::windows {
 
     SDVXSubScreen::SDVXSubScreen(SpiceOverlay *overlay) : GenericSubScreen(overlay) {
-        this->title = "SDVX Sub Screen";
+        this->title = "SDVX Subscreen";
 
         bool isValkyrieCabinetMode = avs::game::SPEC[0] == 'G' || avs::game::SPEC[0] == 'H';
         if (!isValkyrieCabinetMode) {


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
#345 

## Description of change
In the main menu (Esc key), instead of just saying `Show subscreen`, detect game and say `Show TDJ Subscreen` `Show LDJ LED Ticker` etc.

For the LED ticker window, show the title bar by default, and add an option to hide it back.

This is to help with cases where people get stuck with being in LDJ mode when they meant to turn on TDJ.

## Testing
Tested all configurations (IIDX LDJ/TDJ, SDVX UFC, DRS)
