### PR TITLE
avs: Increased heap size for later gitadora games

### DIFF
--- a/src/spice2x/avs/core.cpp
+++ b/src/spice2x/avs/core.cpp
@@ -1108,6 +1108,8 @@ namespace avs {
 
             // SOUND VOLTEX
             {"soundvoltex.dll", 0x10000000},
+            // GITADORA
+            {"gdxg.dll", 0x2000000},
 #endif
             // jubeat
             {"jubeat.dll", 0x2000000},


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
None

## Description of change
Increase the heap size for GITADORA games.

Later releases of GITADORA attempt to allocate a block of memory (size of 0x7ECF78) for notes_info.xml but fail due to heap size being too small, leading to HDD ERROR 5-1502-0008.

## Testing
Tested with current and previous GITADORA releases.
