### PR TITLE
troubleshooter: deferred message for fatal errors

### DIFF
--- a/src/spice2x/avs/core.cpp
+++ b/src/spice2x/avs/core.cpp
@@ -1234,6 +1234,7 @@ namespace avs {
                                 break;
                             case 'F':
                                 new_style = logger::Style::RED;
+                                deferredlogs::report_fatal_message();
                                 break;
                             default:
                                 position = 0;
@@ -1302,6 +1303,7 @@ namespace avs {
                     break;
                 case 'F':
                     style = logger::Style::RED;
+                    deferredlogs::report_fatal_message();
                     break;
                 case 'W':
                     style = logger::Style::YELLOW;

--- a/src/spice2x/util/deferlog.cpp
+++ b/src/spice2x/util/deferlog.cpp
@@ -32,6 +32,16 @@ namespace deferredlogs {
         deferred_errors.emplace_back(messages);
     }
 
+    void report_fatal_message() {
+        static std::once_flag printed;
+        std::call_once(printed, []() {
+            deferredlogs::defer_error_messages({
+                "game reported FATAL error(s)",
+                "    look for messages containing F: in the log",
+                });
+        });
+    }
+
     void dump_to_logger(bool is_crash) {
         static std::once_flag printed;
         std::call_once(printed, [is_crash]() {

--- a/src/spice2x/util/deferlog.h
+++ b/src/spice2x/util/deferlog.h
@@ -10,6 +10,7 @@ namespace deferredlogs {
     extern const std::initializer_list<std::string> SUPERSTEP_SOUND_ERROR_MESSAGE;
 
     void set_softid(const std::string& softid);
+    void report_fatal_message();
     void defer_error_messages(std::initializer_list<std::string> messages);
     void dump_to_logger(bool is_crash=false);
 }


### PR DESCRIPTION
## Description of change
When the game logs a fatal error message, queue up a deferred message for the troubleshooter.
