### PR TITLE
gitadora: (arena model) lights

### DIFF
--- a/src/spice2x/games/gitadora/bi2x_hook.cpp
+++ b/src/spice2x/games/gitadora/bi2x_hook.cpp
@@ -1,5 +1,6 @@
 #include "bi2x_hook.h"
 
+#include <optional>
 #include <cstdint>
 #include "util/detour.h"
 #include "util/logging.h"
@@ -326,6 +327,34 @@ namespace games::gitadora {
 
         if (i_pNodeCtl != aioIob2Bi2xAc1) {
             return aioIob2Bi2xAC1_SetOutputData_orig(i_pNodeCtl, i_CnPin, i_Data);
+        }
+
+        std::optional<Lights::gitadora_lights_t> light;
+        switch (i_CnPin) {
+            case 14:
+                light = Lights::ArenaWooferR;
+                break;
+            case 15:
+                light = Lights::ArenaWooferG;
+                break;
+            case 16:
+                light = Lights::ArenaWooferB;
+                break;
+            case 17:
+                light = Lights::ArenaCardR;
+                break;
+            case 18:
+                light = Lights::ArenaCardG;
+                break;
+            case 19:
+                light = Lights::ArenaCardB;
+                break;
+            default:
+                break;
+        }
+        if (light.has_value()) {
+            auto &lights = games::gitadora::get_lights();
+            GameAPI::Lights::writeLight(RI_MGR, lights.at(light.value()), i_Data / 255.f);
         }
     }
 

--- a/src/spice2x/games/gitadora/io.cpp
+++ b/src/spice2x/games/gitadora/io.cpp
@@ -215,7 +215,15 @@ std::vector<Light> &games::gitadora::get_lights() {
 
                 "Title Average R (Arena)",
                 "Title Average G (Arena)",
-                "Title Average B (Arena)"
+                "Title Average B (Arena)",
+
+                "Woofer R (Arena)",
+                "Woofer G (Arena)",
+                "Woofer B (Arena)",
+
+                "Card Reader R (Arena)",
+                "Card Reader G (Arena)",
+                "Card Reader B (Arena)"
         );
     }
 

--- a/src/spice2x/games/gitadora/io.h
+++ b/src/spice2x/games/gitadora/io.h
@@ -193,10 +193,16 @@ namespace games::gitadora {
             GuitarRightSpeakerLowerG,
             GuitarRightSpeakerLowerB,
 
-            // guitar/drum title RGB LED strip, Arena Model only
+            // arena model (common for both guitar and drum)
             ArenaTitleAvgR,
             ArenaTitleAvgG,
             ArenaTitleAvgB,
+            ArenaWooferR,
+            ArenaWooferG,
+            ArenaWooferB,
+            ArenaCardR,
+            ArenaCardG,
+            ArenaCardB,
         } gitadora_lights_t;
     }
 


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
#477 

## Description of change
Add lights for J region cab. I can't figure out how the extra lights on U region cab are wired up.

## Testing
Tested guitar and drums, J and U regions.
