### PR TITLE
iidx, sdvx: bi2x hook fix

### DIFF
--- a/src/spice2x/games/iidx/bi2x_hook.cpp
+++ b/src/spice2x/games/iidx/bi2x_hook.cpp
@@ -470,7 +470,11 @@ namespace games::iidx {
             aioNmgrIob2->iob2 = new AIO_NMGR_IOB2{};
             aioNmgrIob2->iob2->pAIO_NMGR_IOB_BeginManage = AIO_NMGR_IOB_BeginManageStub;
         }
-        log_info("bi2x_hook", "aioNMgrIob2_Create");
+
+        log_info("bi2x_hook", "aioNMgrIob2_Create returned {}, padded size=0x{:x}, IOB2 @ {}, size=0x{:x}",
+            fmt::ptr(&aioNmgrIob2->iob2), sizeof(*aioNmgrIob2), 
+            fmt::ptr(aioNmgrIob2->iob2), sizeof(*aioNmgrIob2->iob2));
+
         return &aioNmgrIob2->iob2;
     }
 

--- a/src/spice2x/games/sdvx/bi2x_hook.cpp
+++ b/src/spice2x/games/sdvx/bi2x_hook.cpp
@@ -359,7 +359,10 @@ namespace games::sdvx {
             aioNmgrIob2->iob2 = new AIO_NMGR_IOB2{};
             aioNmgrIob2->iob2->pAIO_NMGR_IOB_BeginManage = AIO_NMGR_IOB_BeginManageStub;
         }
-        log_info("bi2x_hook", "aioNMgrIob2_Create");
+        log_info("bi2x_hook", "aioNMgrIob2_Create returned {}, padded size=0x{:x}, IOB2 @ {}, size=0x{:x}",
+            fmt::ptr(&aioNmgrIob2->iob2), sizeof(*aioNmgrIob2), 
+            fmt::ptr(aioNmgrIob2->iob2), sizeof(*aioNmgrIob2->iob2));
+
         BI2X_INITIALIZED = true;
 
         // enable hack to make PIN pad work for KFC in BI2X mode


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
n/a

## Description of change
Both games take the address returned by `aioNMgrIob2_Create` and reads values offset from that address as part of the I/O routine. This means that the I/O routines of these games have been accessing random variables in data/bss segments for years, they just happened to get a value that doesn't lead to a crash.

Stumbled upon this while trying to add a new feature that required adding more globals, but suddenly the game stopped polling I/O when I changed a value of my global. Scary.

## Testing
Tested both games I/O
