### PR TITLE
utils: log primary display adapter

### DIFF
--- a/src/spice2x/util/sysutils.cpp
+++ b/src/spice2x/util/sysutils.cpp
@@ -235,6 +235,12 @@ namespace sysutils {
             } else {
                 log_misc("gpuinfo", "EnumDisplaySettingsA failed");
             }
+
+            log_misc(
+                "gpuinfo", "{} {} is primary    : {}",
+                prefix.c_str(),
+                index,
+                (adapter->StateFlags & DISPLAY_DEVICE_PRIMARY_DEVICE) ? "yes" : "no");
         }
     }
 


### PR DESCRIPTION
## Description of change
Log a message so you can tell which display adapter is primary.
