### PR TITLE
io: fix bi2x_hook implementation in various games

### DIFF
--- a/src/spice2x/games/ccj/bi2x_hook.cpp
+++ b/src/spice2x/games/ccj/bi2x_hook.cpp
@@ -1,5 +1,7 @@
 #include "bi2x_hook.h"
 
+#if SPICE64
+
 #include <cstdint>
 #include "util/detour.h"
 #include "util/logging.h"
@@ -16,15 +18,19 @@ namespace games::ccj {
      */
 
     struct AIO_SCI_COMM {
+        uint8_t data[0xf8];
     };
 
     struct AIO_NMGR_IOB2 {
+        uint8_t data[0xe30];
     };
 
     struct AIO_IOB2_BI2X_TBS {
+        uint8_t data[0x4680];
     };
 
     struct AIO_IOB2_BI2X_WRFIRM {
+        uint8_t data[0x20f48];
     };
 
     struct AIO_NMGR_IOB__NODEINFO {
@@ -71,6 +77,12 @@ namespace games::ccj {
         AIO_IOB2_BI2X_AC1__INPUTDATA InputData;
         AIO_IOB2_BI2X_AC1__OUTPUTDATA OutputData;
     };
+
+    // checked with UJK-001-2024060400
+    static_assert(sizeof(AIO_SCI_COMM) == 0xf8);
+    static_assert(sizeof(AIO_NMGR_IOB2) == 0xe30);
+    static_assert(sizeof(AIO_IOB2_BI2X_TBS) == 0x4680);
+    static_assert(sizeof(AIO_IOB2_BI2X_WRFIRM) == 0x20f48);
 
     static void write_iccr_led(Lights::ccj_lights_t light, uint8_t value);
 
@@ -622,3 +634,5 @@ namespace games::ccj {
                                aioNodeCtl_IsError, &aioNodeCtl_IsError_orig);
     }
 }
+
+#endif

--- a/src/spice2x/games/ccj/bi2x_hook.h
+++ b/src/spice2x/games/ccj/bi2x_hook.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#if SPICE64
+
 namespace games::ccj {
     void bi2x_hook_init();
 }
+
+#endif

--- a/src/spice2x/games/ccj/ccj.cpp
+++ b/src/spice2x/games/ccj/ccj.cpp
@@ -68,8 +68,12 @@ namespace games::ccj {
         detour::trampoline_try("execexe.dll", MAKEINTRESOURCE(11),
                                (void*)execexe_CreateFileW_hook,(void**)&execexe_CreateFileW_orig);
 
+#if SPICE64
+
         // insert BI2X hooks
         bi2x_hook_init();
+
+#endif
 
         // insert trackball hooks
         trackball_hook_init();

--- a/src/spice2x/games/gitadora/bi2x_hook.cpp
+++ b/src/spice2x/games/gitadora/bi2x_hook.cpp
@@ -1,5 +1,7 @@
 #include "bi2x_hook.h"
 
+#if SPICE64
+
 #include <optional>
 #include <cstdint>
 #include "util/detour.h"
@@ -18,24 +20,29 @@ namespace games::gitadora {
     //  */
 
     struct AIO_NMGR_IOB2 {
+        uint8_t data[0xe18];
     };
 
     struct AIO_IOB2_BI2X_AC1__SETTING {
     };
 
     struct AIO_NMGR_IOB5 {
+        uint8_t data[0xb10];
     };
 
     struct AIO_SCI_COMM {
+        uint8_t data[0x100];
     };
 
     struct AIO_IOB5_Y32D {
+        uint8_t data[0x2e8];
     };
 
     // struct AIO_IOB5_Y33I {
     // };
 
     struct AIO_IOB2_BI2X_AC1 {
+        uint8_t data[0x4570];
     };
 
     struct AIO_NMGR_IOB__NODEINFO {
@@ -43,6 +50,7 @@ namespace games::gitadora {
     };
 
     struct AIO_IOB2_BI2X_WRFIRM {
+        uint8_t data[0x20f48];
     };
 
     struct AIO_SCI_COMM_T {
@@ -158,6 +166,14 @@ namespace games::gitadora {
     struct AIO_IOB5_Y32D__DEVSTATUS {
         uint8_t unk[0xB1];
     };
+
+    // verified with M32-007-2025092400
+    static_assert(sizeof(AIO_NMGR_IOB2) == 0xe18);
+    static_assert(sizeof(AIO_NMGR_IOB5) == 0xb10);
+    static_assert(sizeof(AIO_SCI_COMM) == 0x100);
+    static_assert(sizeof(AIO_IOB5_Y32D) == 0x2e8);
+    static_assert(sizeof(AIO_IOB2_BI2X_AC1) == 0x4570);
+    static_assert(sizeof(AIO_IOB2_BI2X_WRFIRM) == 0x20f48);
 
      /*
       * typedefs
@@ -702,3 +718,5 @@ namespace games::gitadora {
                                aioNodeCtl_UpdateDevicesStatus, &aioNodeCtl_UpdateDevicesStatus_orig);
     }
 }
+
+#endif

--- a/src/spice2x/games/gitadora/bi2x_hook.h
+++ b/src/spice2x/games/gitadora/bi2x_hook.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#if SPICE64
+
 namespace games::gitadora {
     void bi2x_hook_init();
 }
+
+#endif

--- a/src/spice2x/games/pc/bi2x_hook.h
+++ b/src/spice2x/games/pc/bi2x_hook.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#if SPICE64
+
 namespace games::pc {
     void bi2x_hook_init();
 }
+
+#endif

--- a/src/spice2x/games/pc/pc.cpp
+++ b/src/spice2x/games/pc/pc.cpp
@@ -12,10 +12,12 @@
 #include "misc/wintouchemu.h"
 #include "hooks/graphics/graphics.h"
 #include "rawinput/rawinput.h"
+#include "util/socd_cleaner.h"
 
 namespace games::pc {
     std::string PC_INJECT_ARGS = "";
     bool PC_NO_IO = false;
+    bool PC_KNOB_MODE = false;
 
     static acioemu::ACIOHandle *acioHandle = nullptr;
     static std::wstring portName = L"COM1";
@@ -61,6 +63,11 @@ namespace games::pc {
         return ERROR_NOT_SUPPORTED;
     }
 
+    void PCGame::pre_attach() {
+        // SOCD
+        socd::ALGORITHM = socd::SocdAlgorithm::PreferRecent;
+    }
+
     void PCGame::attach() {
         Game::attach();
 
@@ -78,9 +85,14 @@ namespace games::pc {
             execexe::load_library("libaio-iob2_video.dll");
             execexe::load_library("win10actlog.dll");
 
+#if SPICE64
+
             if (!PC_NO_IO) {
                 bi2x_hook_init();
             }
+
+#endif
+
         });
 
         const auto user32Dll = "user32.dll";

--- a/src/spice2x/games/pc/pc.h
+++ b/src/spice2x/games/pc/pc.h
@@ -11,6 +11,7 @@ namespace games::pc {
     public:
         PCGame() : Game("Polaris Chord") {}
 
+        virtual void pre_attach() override;
         virtual void attach() override;
         virtual void detach() override;
     };

--- a/src/spice2x/games/qks/bi2x_hook.cpp
+++ b/src/spice2x/games/qks/bi2x_hook.cpp
@@ -1,5 +1,7 @@
 #include "bi2x_hook.h"
 
+#if SPICE64
+
 #include "util/detour.h"
 #include "util/logging.h"
 #include "rawinput/rawinput.h"
@@ -15,15 +17,19 @@ namespace games::qks {
      */
 
     struct AIO_SCI_COMM {
+        uint8_t data[0xf8];
     };
 
     struct AIO_NMGR_IOB {
+        uint8_t data[0xa00];
     };
 
     struct AIO_IOB2_BI2X_AC1 {
+        uint8_t data[0x3908];
     };
 
     struct AIO_IOB2_BI2X_WRFIRM {
+        uint8_t data[0x20f48];
     };
 
     struct AIO_NMGR_IOB__NODEINFO {
@@ -173,6 +179,12 @@ namespace games::qks {
         AIO_IOB2_BI2X_AC1__ICNPIN ICnPinHist[17];
         AIO_IOB2_BI2X_AC1__SETTING Setting;
     };
+
+    // verified with UKS-001-2024030600
+    static_assert(sizeof(AIO_IOB2_BI2X_AC1) == 0x3908);
+    static_assert(sizeof(AIO_SCI_COMM) == 0xf8);
+    static_assert(sizeof(AIO_NMGR_IOB) == 0xa00);
+    static_assert(sizeof(AIO_IOB2_BI2X_WRFIRM) == 0x20f48);
 
     /*
      * typedefs
@@ -603,3 +615,5 @@ namespace games::qks {
                                aioNodeCtl_IsError, &aioNodeCtl_IsError_orig);
     }
 }
+
+#endif

--- a/src/spice2x/games/qks/bi2x_hook.h
+++ b/src/spice2x/games/qks/bi2x_hook.h
@@ -1,7 +1,11 @@
 #pragma once
 
+#if SPICE64
+
 #include <stdint.h>
 
 namespace games::qks {
     void bi2x_hook_init();
 }
+
+#endif

--- a/src/spice2x/games/qks/qks.cpp
+++ b/src/spice2x/games/qks/qks.cpp
@@ -86,8 +86,12 @@ namespace games::qks {
         detour::trampoline_try("execexe.dll", MAKEINTRESOURCE(9),
                                execexe_CreateFileA_hook,&execexe_CreateFileA_orig);
 
+#if SPICE64
+
         // insert BI2X hooks
         bi2x_hook_init();
+
+#endif
 
         // add card reader
         acioHandle = new acioemu::ACIOHandle(portName.c_str());


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
similar issue as #499

## Description of change
Fix broken bi2x_hook implementations that did not properly allocate I/O buffers with correct sizes.

People keep copy-pasting other implementation that allocate 0 bytes of memory, but we run the risk of memory corruption or/or game crashes if we keep doing this.

We've seen some mystery crashes with CCJ for example, maybe this will fix that.

While I'm here, implement SOCD cleaner for Polaris Chord.

## Testing
Tested I/O menu with CCJ, play through tutorial (didn't test matches)
Tested GWDelta (test menu and a few songs in guitar)
Tested PC (played a credit)
Tested QKS (still can't get past the title screen)

