### PR TITLE
gitadora: prevent window resize

### DIFF
--- a/src/spice2x/hooks/graphics/graphics.cpp
+++ b/src/spice2x/hooks/graphics/graphics.cpp
@@ -711,9 +711,8 @@ static BOOL WINAPI SetWindowPos_hook(HWND hWnd, HWND hWndInsertAfter,
         return TRUE;
     }
 
-    // prevent gitadora from shifting windows around if the user has preferences
-    if (avs::game::is_model({"J32", "J33", "K32", "K33", "L32", "L33", "M32"}) &&
-        GRAPHICS_WINDOWED &&
+    // prevent gitadora arena model from shifting windows around if the user has preferences
+    if (GRAPHICS_WINDOWED && games::gitadora::is_arena_model() &&
         GRAPHICS_WINDOW_MAIN.has_value() && hWnd == GRAPHICS_WINDOW_MAIN.value() &&
         cfg::SCREENRESIZE->enable_window_resize) {
         return TRUE;

--- a/src/spice2x/hooks/graphics/graphics.h
+++ b/src/spice2x/hooks/graphics/graphics.h
@@ -102,4 +102,5 @@ void graphics_update_window_style(HWND hWnd);
 void graphics_update_z_order(HWND hWnd, bool always_on_top);
 void graphics_move_resize_window(HWND hWnd);
 bool graphics_window_change_crashes_game();
+bool graphics_window_resize_breaks_game();
 void graphics_load_windowed_subscreen_parameters();

--- a/src/spice2x/overlay/windows/screen_resize.cpp
+++ b/src/spice2x/overlay/windows/screen_resize.cpp
@@ -233,6 +233,14 @@ namespace overlay::windows {
         bool changed = false;
         const uint32_t step = 1;
         const uint32_t step_fast = 10;
+
+        if (graphics_window_resize_breaks_game()) {
+            ImGui::TextColored(ImVec4(1, 0.5f, 0.5f, 1.f),
+            "GITADORA tends to hang or have graphical\n"
+            "glitches when window is resized; resize\n"
+            "controls are disabled.");
+        }
+        ImGui::BeginDisabled(graphics_window_resize_breaks_game());
         ImGui::BeginDisabled(cfg::SCREENRESIZE->client_keep_aspect_ratio);
         ImGui::InputScalar(
             "Width",
@@ -248,6 +256,7 @@ namespace overlay::windows {
             &cfg::SCREENRESIZE->client_height,
             &step, &step_fast, nullptr);
         changed |= ImGui::IsItemDeactivatedAfterEdit();
+        ImGui::EndDisabled();
 
         ImGui::InputScalar(
             "X Offset",


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
n/a

## Description of change
Gitadora (pre-Delta) tends to soft lock, have graphical issues (menu bg render as black), or take a long time (minutes) between scene transitions when window is resized.

