### PR TITLE
graphics: fix window resize not working properly in some games

### DIFF
--- a/src/spice2x/hooks/graphics/graphics.h
+++ b/src/spice2x/hooks/graphics/graphics.h
@@ -31,7 +31,6 @@ extern bool GRAPHICS_SHOW_CURSOR;
 extern bool GRAPHICS_WINDOWED;
 extern graphics_orientation GRAPHICS_ADJUST_ORIENTATION;
 extern std::vector<HWND> GRAPHICS_WINDOWS;
-extern std::optional<HWND> GRAPHICS_WINDOW_MAIN;
 extern UINT GRAPHICS_FORCE_REFRESH;
 extern std::optional<uint32_t> GRAPHICS_FORCE_REFRESH_SUB;
 extern std::optional<int> GRAPHICS_FORCE_VSYNC_BUFFER;

--- a/src/spice2x/hooks/graphics/graphics_windowed.cpp
+++ b/src/spice2x/hooks/graphics/graphics_windowed.cpp
@@ -70,8 +70,9 @@ void graphics_capture_initial_window(HWND hWnd) {
     RECT rect;
     if (!GetClientRect(hWnd, &rect)) {
         log_warning(
-            "graphics",
-            "graphics_capture_initial_window - GetClientRect failed, GLE: {}",
+            "graphics-windowed",
+            "[{}] graphics_capture_initial_window - GetClientRect failed, GLE: {}",
+            fmt::ptr(hWnd),
             GetLastError());
         return;
     }
@@ -83,7 +84,8 @@ void graphics_capture_initial_window(HWND hWnd) {
     cfg::SCREENRESIZE->init_client_aspect_ratio = (float)client_w / (float)client_h;
     log_debug(
         "graphics-windowed",
-        "graphics_capture_initial_window initial window size {}x{}, ratio {}",
+        "[{}] graphics_capture_initial_window initial window size {}x{}, ratio {}",
+        fmt::ptr(hWnd),
         client_w, client_h, cfg::SCREENRESIZE->init_client_aspect_ratio);
 
     // ensure frame size is captured
@@ -108,7 +110,8 @@ void graphics_capture_initial_window(HWND hWnd) {
     // resize must be done before applying the border
     if (cfg::SCREENRESIZE->enable_window_resize) {
         log_info(
-            "graphics-windowed", "change window rect - window offset: {}x{}, client size: {}x{}",
+            "graphics-windowed", "[{}] change window rect - window offset: {}x{}, client size: {}x{}",
+            fmt::ptr(hWnd),
             cfg::SCREENRESIZE->window_offset_x,
             cfg::SCREENRESIZE->window_offset_y,
             cfg::SCREENRESIZE->client_width,
@@ -118,12 +121,13 @@ void graphics_capture_initial_window(HWND hWnd) {
     // ddr hangs when window frame doesn't have overlapped
     if (cfg::SCREENRESIZE->window_decoration != cfg::WindowDecorationMode::Default) {
         log_info(
-            "graphics-windowed", "change window style - decoration: {}",
+            "graphics-windowed", "[{}] change window style - decoration: {}",
+            fmt::ptr(hWnd),
             cfg::SCREENRESIZE->window_decoration);
         graphics_update_window_style(hWnd);
     }
     if (cfg::SCREENRESIZE->window_always_on_top) {
-        log_info("graphics-windowed", "change window z-order - always on top");
+        log_info("graphics-windowed", "[{}] change window z-order - always on top", fmt::ptr(hWnd));
         graphics_update_z_order(hWnd, true);
     }
 

--- a/src/spice2x/overlay/windows/screen_resize.cpp
+++ b/src/spice2x/overlay/windows/screen_resize.cpp
@@ -27,14 +27,12 @@ namespace overlay::windows {
     }
 
     HWND ScreenResize::get_first_window() {
-        // hack for gitadora arena model which races to create many windows
-        // so [0] is not always the main one
-        if (GRAPHICS_WINDOW_MAIN.has_value()) {
-            return GRAPHICS_WINDOW_MAIN.value();
-        }
+        // this is ideal
         if (GRAPHICS_HOOKED_WINDOW.has_value()) {
             return GRAPHICS_HOOKED_WINDOW.value();
         }
+        // we typically do not want to check GRAPHICS_WINDOWS because it may include
+        // system windows (e.g., CicMarshalWnd)
         if (GRAPHICS_WINDOWS.size() == 0) {
             return NULL;
         }


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
n/a

## Description of change
Need to filter out system-created windows (such as `CicMarshalWnd`) when looking up which window to mess with when user interacts with F11 menu.

While I'm here, clean up the hack for gfdm arena model that remembers the main window.

## Testing
Tested:

DDR
gfdm arena 4 / 1 window modes
iidx (windowed mode, with/without nosub option)
sdvx with sub windows

Need to check:
full screen games
