### PR TITLE
gitadora: fix order of drums in Buttons tab

### DIFF
--- a/src/spice2x/games/gitadora/io.cpp
+++ b/src/spice2x/games/gitadora/io.cpp
@@ -65,17 +65,18 @@ std::vector<Button> &games::gitadora::get_buttons() {
                 "Drum Help",
                 "Drum Button Extra 1",
                 "Drum Button Extra 2",
+
+                "Drum Left Cymbal",
                 "Drum Hi-Hat",
-                "Drum Hi-Hat Closed",
-                "Drum Hi-Hat Half-Open",
+                "Drum Left Pedal",
                 "Drum Snare",
                 "Drum Hi-Tom",
-                "Drum Low-Tom",
-                "Drum Right Cymbal",
                 "Drum Bass Pedal",
-                "Drum Left Cymbal",
-                "Drum Left Pedal",
-                "Drum Floor Tom"
+                "Drum Low-Tom",
+                "Drum Floor Tom",
+                "Drum Right Cymbal",
+                "Drum Hi-Hat Closed",
+                "Drum Hi-Hat Half-Open"
         );
     }
 
@@ -125,8 +126,6 @@ std::string games::gitadora::get_buttons_help() {
         " -------------------------------------------------------\n"
         "             Left          Bass\n"
         "             Pedal         Pedal\n"
-        "\n"
-        " Drums are NOT velocity-sensitive!\n"
         "\n"
         " For MIDI drums with Open/Closed HiHat configurations or pads with\n"
         " multiple hit zones, ensure you bind all variation using the Pages\n"

--- a/src/spice2x/games/gitadora/io.h
+++ b/src/spice2x/games/gitadora/io.h
@@ -66,18 +66,21 @@ namespace games::gitadora {
             DrumHelp,
             DrumButtonExtra1,
             DrumButtonExtra2,
-            // note: this is the order they appear in the test menu
+            // note: this is the order of drums in the default layout
+            DrumLeftCymbal,
             DrumHiHat,
-            DrumHiHatClosed,
-            DrumHiHatHalfOpen,
+            DrumLeftPedal,
             DrumSnare,
             DrumHiTom,
-            DrumLowTom,
-            DrumRightCymbal,
             DrumBassPedal,
-            DrumLeftCymbal,
-            DrumLeftPedal,
-            DrumFloorTom
+            DrumLowTom,
+            DrumFloorTom,
+            DrumRightCymbal,
+
+            // these only exist for back compat
+            // (created before it was possible to map multiple input to a button)
+            DrumHiHatClosed,
+            DrumHiHatHalfOpen
         };
     }
 


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
n/a

## Description of change
Before this PR, drums were in the order they appear in test menu.

This is really confusing. Change it so that they appear in the order they do in default drummania layout.

## Testing
validated manually in gw
