### PR TITLE
Build scripts: support paths with spaces

### DIFF
--- a/src/spice2x/CMakeLists.txt
+++ b/src/spice2x/CMakeLists.txt
@@ -170,8 +170,8 @@ else()
         set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -DNDEBUG")
 
         # file prefix map for relative working directory
-        set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -ffile-prefix-map=${CMAKE_SOURCE_DIR}=.")
-        set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -ffile-prefix-map=${CMAKE_SOURCE_DIR}=.")
+        set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -ffile-prefix-map=\"${CMAKE_SOURCE_DIR}=.\"")
+        set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -ffile-prefix-map=\"${CMAKE_SOURCE_DIR}=.\"")
     endif()
 
     # release with debug info flags

--- a/src/spice2x/build_all.sh
+++ b/src/spice2x/build_all.sh
@@ -74,7 +74,7 @@ then
 	BUILD_TYPE="Debug"
 	BUILDDIR_32=${BUILDDIR_32_DEBUG}
 	BUILDDIR_64=${BUILDDIR_64_DEBUG}
-	DIST_NAME=$(echo ${DIST_NAME} | sed 's/\.[^.]*$/-dbg&/')
+	DIST_NAME=$(echo "${DIST_NAME}" | sed 's/\.[^.]*$/-dbg&/')
 fi
 
 # determine number of cores
@@ -114,7 +114,7 @@ time (
 	fi
 	mkdir -p ${BUILDDIR_32}
 	pushd ${BUILDDIR_32} > /dev/null
-	cmake -G "Ninja" -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_32} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} $OLDPWD && ninja ${TARGETS_32}
+	cmake -G "Ninja" -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_32} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} "$OLDPWD" && ninja ${TARGETS_32}
 	popd > /dev/null
 
 	# 64 bit
@@ -127,7 +127,7 @@ time (
 	fi
 	mkdir -p ${BUILDDIR_64}
 	pushd ${BUILDDIR_64} > /dev/null
-	cmake -G "Ninja" -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_64} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} $OLDPWD && ninja ${TARGETS_64}
+	cmake -G "Ninja" -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_64} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} "$OLDPWD" && ninja ${TARGETS_64}
 	popd > /dev/null
 
 	echo ""
@@ -234,7 +234,7 @@ mkdir -p ${OUTDIR}/src
 if ((INCLUDE_SRC > 0))
 then
 	echo "Generating source file archive..."
-	git archive --format tar.gz --prefix=spice2x/ HEAD ./ > ${OUTDIR}/src/spice2x-${GIT_BRANCH}.tar.gz 2>/dev/null || \
+	git archive --format tar.gz --prefix=spice2x/ HEAD ./ > "${OUTDIR}/src/spice2x-${GIT_BRANCH}.tar.gz" 2>/dev/null || \
 		echo "WARNING: Couldn't get git to create the archive. Is this a git repository?"
 fi
 
@@ -249,11 +249,11 @@ if ((DIST_ENABLE > 0))
 then
 	echo "Building dist..."
 	mkdir -p ${DIST_FOLDER}
-	rm -rf ${DIST_FOLDER}/${DIST_NAME}
+	rm -rf "${DIST_FOLDER}/${DIST_NAME}"
 	pushd ${OUTDIR}/.. > /dev/null
-	zip -qrXT9 $OLDPWD/${DIST_FOLDER}/${DIST_NAME} spice2x -x "spice2x/extras/*" -z <<< "$DIST_COMMENT"
+	zip -qrXT9 "$OLDPWD/${DIST_FOLDER}/${DIST_NAME}" spice2x -x "spice2x/extras/*" -z <<< "$DIST_COMMENT"
 	echo "Building extras..."
-	zip -qrXT9 $OLDPWD/${DIST_FOLDER}/${DIST_NAME_EXTRAS} spice2x -z <<< "$DIST_COMMENT"
+	zip -qrXT9 "$OLDPWD/${DIST_FOLDER}/${DIST_NAME_EXTRAS}" spice2x -z <<< "$DIST_COMMENT"
 	popd > /dev/null
 fi
 

--- a/src/spice2x/build_docker.sh
+++ b/src/spice2x/build_docker.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-docker build --pull $PWD/external/docker -t spicetools/deps --platform linux/x86_64
-docker build --build-context gitroot=$PWD/../../.git . -t spicetools/spice:latest
-docker run --rm -v $PWD/dist:/src/src/spice2x/dist -v $PWD/bin:/src/src/spice2x/bin -v $PWD/.ccache:/src/src/spice2x/.ccache spicetools/spice "$@"
+docker build --pull "$PWD/external/docker" -t spicetools/deps --platform linux/x86_64
+docker build --build-context gitroot="$PWD/../../.git" . -t spicetools/spice:latest
+docker run --rm -v "$PWD/dist:/src/src/spice2x/dist" -v "$PWD/bin:/src/src/spice2x/bin" -v "$PWD/.ccache:/src/src/spice2x/.ccache" spicetools/spice "$@"


### PR DESCRIPTION
Doing dumb things and building inside a path that contains spaces. Quoted the relevant bits in the build script (and a couple more shellcheck brought up that realistically won't ever be an issue, but the squigglies annoy me.