### PR TITLE
api: fix unbounded access in getting analog state

### DIFF
--- a/src/spice2x/cfg/api.cpp
+++ b/src/spice2x/cfg/api.cpp
@@ -644,10 +644,12 @@ float GameAPI::Analogs::getState(rawinput::Device *device, Analog &analog) {
         case rawinput::HID: {
 
             // get value
-            if (inverted) {
-                value = 1.f - device->hidInfo->value_states[index];
-            } else {
-                value = device->hidInfo->value_states[index];
+            if (index < device->hidInfo->value_states.size()) {
+                if (inverted) {
+                    value = 1.f - device->hidInfo->value_states[index];
+                } else {
+                    value = device->hidInfo->value_states[index];
+                }
             }
 
             // deadzone

--- a/src/spice2x/overlay/windows/config.cpp
+++ b/src/spice2x/overlay/windows/config.cpp
@@ -1743,6 +1743,7 @@ namespace overlay::windows {
                     auto analog_name = analog.getName();
                     auto analog_display = analog.getDisplayString(RI_MGR.get());
                     auto analog_state = GameAPI::Analogs::getState(RI_MGR, analog);
+                    analog_state = std::clamp(analog_state, 0.f, 1.f);
 
                     // list entry
                     ImGui::ProgressBar(analog_state, ImVec2(32.f, 0));


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
#0

## Description of change
Occasionally we would read a bad "vKey" for an analog axis and end up accessing invalid memory (beyond the size of a vector) and potentially crash or read junk values. 

## Testing
Fixed based on minidump, this was a rare repro though.