### PR TITLE
overlay: add hover delay to tooltip

### DIFF
--- a/src/spice2x/overlay/imgui/extensions.cpp
+++ b/src/spice2x/overlay/imgui/extensions.cpp
@@ -26,7 +26,7 @@ namespace ImGui {
 
     void HelpMarker(const char* desc) {
         ImGui::TextDisabled("(?)");
-        if (ImGui::IsItemHovered()) {
+        if (ImGui::IsItemHovered(TOOLTIP_FLAGS)) {
             HelpTooltip(desc);
         }
     }
@@ -59,7 +59,7 @@ namespace ImGui {
         ImGui::PushStyleColor(ImGuiCol_TextDisabled, ImVec4(1.f, 1.f, 0.f, 1.f));
         ImGui::TextDisabled("(!)");
         ImGui::PopStyleColor();
-        if (ImGui::IsItemHovered()) {
+        if (ImGui::IsItemHovered(TOOLTIP_FLAGS)) {
             WarnTooltip(desc, warn);
         }
     }
@@ -129,7 +129,7 @@ namespace ImGui {
         }
         bool truncated = false;
         ImGui::TextUnformatted(TruncateText(p_text, p_truncated_width, truncated).c_str());
-        if (truncated && ImGui::IsItemHovered()) {
+        if (truncated && ImGui::IsItemHovered(TOOLTIP_FLAGS)) {
             ImGui::HelpTooltip(p_text.c_str());
         }
     }
@@ -144,7 +144,7 @@ namespace ImGui {
         bool clicked = ImGui::SmallButton("+");
         ImGui::PopStyleVar();
         ImGui::PopStyleColor(4);
-        if (!tooltip.empty() && ImGui::IsItemHovered()) {
+        if (!tooltip.empty() && ImGui::IsItemHovered(TOOLTIP_FLAGS)) {
             ImGui::SameLine();
             ImGui::HelpTooltip(tooltip.c_str());
         }
@@ -159,7 +159,7 @@ namespace ImGui {
         bool clicked = ImGui::SmallButton("\u00D7"); // multiplication sign (×)
         ImGui::PopStyleVar();
         ImGui::PopStyleColor();
-        if (!tooltip.empty() && ImGui::IsItemHovered()) {
+        if (!tooltip.empty() && ImGui::IsItemHovered(TOOLTIP_FLAGS)) {
             ImGui::SameLine();
             ImGui::HelpTooltip(tooltip.c_str());
         }
@@ -176,7 +176,7 @@ namespace ImGui {
         ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.97f, 0.97f, 0.97f, 1.00f));
         bool clicked = ImGui::Button("\u00D7"); // multiplication sign (×)
         ImGui::PopStyleColor(4);
-        if (!tooltip.empty() && ImGui::IsItemHovered()) {
+        if (!tooltip.empty() && ImGui::IsItemHovered(TOOLTIP_FLAGS)) {
             ImGui::SameLine();
             ImGui::HelpTooltip(tooltip.c_str());
         }

--- a/src/spice2x/overlay/imgui/extensions.h
+++ b/src/spice2x/overlay/imgui/extensions.h
@@ -1,8 +1,12 @@
 #pragma once
 
 #include <string>
+#include "external/imgui/imgui.h"
 
 namespace ImGui {
+
+    constexpr ImGuiHoveredFlags TOOLTIP_FLAGS =
+        (ImGuiHoveredFlags_ForTooltip | ImGuiHoveredFlags_AllowWhenDisabled);
 
     void HelpTooltip(const char* desc);
     void HelpMarker(const char* desc);

--- a/src/spice2x/overlay/windows/config.cpp
+++ b/src/spice2x/overlay/windows/config.cpp
@@ -298,7 +298,7 @@ namespace overlay::windows {
                     buttons_many_index = -1;
                     buttons_many_delay = 0;
                 }
-                if (ImGui::IsItemHovered()) {
+                if (ImGui::IsItemHovered(ImGui::TOOLTIP_FLAGS)) {
                     ImGui::HelpTooltip(
                         "Bind many keys in a row without having to click on Bind or Naive button.");
                 }
@@ -803,7 +803,7 @@ namespace overlay::windows {
                 }
             }
         }
-        if (ImGui::IsItemHovered()) {
+        if (ImGui::IsItemHovered(ImGui::TOOLTIP_FLAGS)) {
             ImGui::HelpTooltip("Bind a button to a device using Windows RawInput API.");
         }
 
@@ -830,7 +830,7 @@ namespace overlay::windows {
                 buttons_keyboard_state[i] = GetAsyncKeyState(i) != 0;
             }
         }
-        if (ImGui::IsItemHovered()) {
+        if (ImGui::IsItemHovered(ImGui::TOOLTIP_FLAGS)) {
             ImGui::HelpTooltip(
                 "Uses GetAsyncKeyState to check for any keyboard / mouse input. "
                 "For best performance, Bind should be preferred, but this can be used when:\n"
@@ -881,7 +881,7 @@ namespace overlay::windows {
         }
         ImGui::Checkbox("Allow Multiple Binds", &io_allow_multi_binding);
         ImGui::EndDisabled();
-        if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+        if (ImGui::IsItemHovered(ImGui::TOOLTIP_FLAGS)) {
             std::string text =
                 "Check this and press the green + button to bind multiple input to the same action.";
             if (io_has_valid_alternatives) {
@@ -2965,7 +2965,7 @@ namespace overlay::windows {
                     ImGui::TextUnformatted(definition.title.c_str());
                 }
                 ImGui::Unindent(INDENT);
-                if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+                if (ImGui::IsItemHovered(ImGui::TOOLTIP_FLAGS)) {
                     ImGui::HelpTooltip(definition.desc.c_str());
                 }
 
@@ -2979,7 +2979,7 @@ namespace overlay::windows {
                     param += definition.display_name;
                 }
                 ImGui::TextColored(ImVec4(0.5f, 0.5f, 0.5f, 1.f), "%s", param.c_str());
-                if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+                if (ImGui::IsItemHovered(ImGui::TOOLTIP_FLAGS)) {
                     const auto help =
                         param +
                         "\n\nClick to copy the parameter to the clipboard.\n\n"
@@ -3007,7 +3007,7 @@ namespace overlay::windows {
                             option.value = state ? "/ENABLED" : "";
                             ::Config::getInstance().updateBinding(games_list[games_selected], option);
                         }
-                        if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+                        if (ImGui::IsItemHovered(ImGui::TOOLTIP_FLAGS)) {
                             ImGui::HelpTooltip(definition.desc.c_str());
                         }
                         break;
@@ -3036,7 +3036,7 @@ namespace overlay::windows {
                             option.value = buffer;
                             ::Config::getInstance().updateBinding(games_list[games_selected], option);
                         }
-                        if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+                        if (ImGui::IsItemHovered(ImGui::TOOLTIP_FLAGS)) {
                             ImGui::HelpTooltip(definition.desc.c_str());
                         }
                         break;
@@ -3072,7 +3072,7 @@ namespace overlay::windows {
                             option.value = buffer;
                             ::Config::getInstance().updateBinding(games_list[games_selected], option);
                         }
-                        if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+                        if (ImGui::IsItemHovered(ImGui::TOOLTIP_FLAGS)) {
                             ImGui::HelpTooltip(definition.desc.c_str());
                         }
                         break;
@@ -3092,7 +3092,7 @@ namespace overlay::windows {
                             option.value = buffer;
                             ::Config::getInstance().updateBinding(games_list[games_selected], option);
                         }
-                        if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+                        if (ImGui::IsItemHovered(ImGui::TOOLTIP_FLAGS)) {
                             ImGui::HelpTooltip(definition.desc.c_str());
                         }
                         break;
@@ -3129,7 +3129,7 @@ namespace overlay::windows {
                             }
                             ImGui::EndCombo();
                         }
-                        if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+                        if (ImGui::IsItemHovered(ImGui::TOOLTIP_FLAGS)) {
                             ImGui::HelpTooltip(definition.desc.c_str());
                         }
                         break;

--- a/src/spice2x/overlay/windows/iopanel.cpp
+++ b/src/spice2x/overlay/windows/iopanel.cpp
@@ -81,7 +81,7 @@ namespace overlay::windows {
         {
             ImGui::SetCursorPosY(ImGui::GetCursorPosY() - ImGui::GetFrameHeightWithSpacing());
             this->build_button("+", tall, this->test_button, this->service_button);
-            if (ImGui::IsItemHovered()) {
+            if (ImGui::IsItemHovered(ImGui::TOOLTIP_FLAGS)) {
                 ImGui::HelpTooltip("SERVICE + TEST");
             }
         }

--- a/src/spice2x/overlay/windows/iopanel_gfdm.cpp
+++ b/src/spice2x/overlay/windows/iopanel_gfdm.cpp
@@ -136,7 +136,7 @@ namespace overlay::windows {
             ImGui::SetCursorPosY(ImGui::GetCursorPosY() + ImGui::GetFrameHeightWithSpacing());
             this->build_button("<", leftright_size, this->left[p], nullptr, this->leftright_light[p]);
             this->build_button("+", tiny_size, this->help[p], this->start[p], nullptr);
-            if (ImGui::IsItemHovered()) {
+            if (ImGui::IsItemHovered(ImGui::TOOLTIP_FLAGS)) {
                 ImGui::HelpTooltip("HELP + START");
             }
         }
@@ -167,7 +167,7 @@ namespace overlay::windows {
         ImGui::BeginGroup();
         {
             this->build_button("?", tiny_size, this->help[p], nullptr, this->help_light[p]);
-            if (ImGui::IsItemHovered()) {
+            if (ImGui::IsItemHovered(ImGui::TOOLTIP_FLAGS)) {
                 ImGui::HelpTooltip("HELP");
             }
             this->build_button(">", leftright_size, this->right[p], nullptr, this->leftright_light[p]);

--- a/src/spice2x/overlay/windows/patch_manager.cpp
+++ b/src/spice2x/overlay/windows/patch_manager.cpp
@@ -721,7 +721,7 @@ namespace overlay::windows {
                     if (style_color_pushed) {
                         ImGui::PopStyleColor(style_color_pushed);
                     }
-                    if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+                    if (ImGui::IsItemHovered(ImGui::TOOLTIP_FLAGS)) {
                         show_patch_tooltip(patch);
                     }
 
@@ -762,7 +762,7 @@ namespace overlay::windows {
                         patch.last_status = is_patch_active(patch);
                     }
                     ImGui::EndDisabled();
-                    if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+                    if (ImGui::IsItemHovered(ImGui::TOOLTIP_FLAGS)) {
                         show_patch_tooltip(patch);
                     }
 
@@ -791,7 +791,7 @@ namespace overlay::windows {
                                     }
                                     ImGui::EndCombo();
                                 }
-                                if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+                                if (ImGui::IsItemHovered(ImGui::TOOLTIP_FLAGS)) {
                                     show_patch_tooltip(patch);
                                 }
                             } else if (patch.type == PatchType::Integer) {
@@ -807,7 +807,7 @@ namespace overlay::windows {
                                     apply_patch(patch, true);
                                     config_dirty = true;
                                 }
-                                if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+                                if (ImGui::IsItemHovered(ImGui::TOOLTIP_FLAGS)) {
                                     show_patch_tooltip(patch);
                                 }
                             }
@@ -824,7 +824,7 @@ namespace overlay::windows {
                                 ImGui::InputInt("##dummy_int_input", &patch.patch_number.value);
                             }
                             ImGui::EndDisabled();
-                            if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+                            if (ImGui::IsItemHovered(ImGui::TOOLTIP_FLAGS)) {
                                 show_patch_tooltip(patch);
                             }
                         }


### PR DESCRIPTION
Clean up flags used for tooltip display, which adds a tiny delay by default.