### PR TITLE
audio: option for overriding default audio device for WASAPI

### DIFF
--- a/src/spice2x/hooks/audio/audio.cpp
+++ b/src/spice2x/hooks/audio/audio.cpp
@@ -46,8 +46,6 @@ namespace hooks::audio {
     bool ASIO_FORCE_UNLOAD_ON_STOP = false;
 
     std::optional<std::string> DEFAULT_IMM_DEVICE_ID = std::nullopt;
-    std::mutex DEFAULT_IMM_DEVICE_MUTEX;
-    void *DEFAULT_IMM_DEVICE = nullptr;
 
     // private globals
     IAudioClient *CLIENT = nullptr;

--- a/src/spice2x/hooks/audio/audio.cpp
+++ b/src/spice2x/hooks/audio/audio.cpp
@@ -45,6 +45,10 @@ namespace hooks::audio {
     size_t ASIO_DRIVER_ID = 0;
     bool ASIO_FORCE_UNLOAD_ON_STOP = false;
 
+    std::optional<std::string> DEFAULT_IMM_DEVICE_ID = std::nullopt;
+    std::mutex DEFAULT_IMM_DEVICE_MUTEX;
+    void *DEFAULT_IMM_DEVICE = nullptr;
+
     // private globals
     IAudioClient *CLIENT = nullptr;
     std::mutex INITIALIZE_LOCK; // for asio

--- a/src/spice2x/hooks/audio/audio.h
+++ b/src/spice2x/hooks/audio/audio.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+#include <mutex>
 #include <optional>
 
 #include <windows.h>
@@ -24,6 +26,10 @@ namespace hooks::audio {
     extern bool ASIO_FORCE_UNLOAD_ON_STOP;
     extern bool LOW_LATENCY_SHARED_WASAPI;
 
+    extern std::optional<std::string> DEFAULT_IMM_DEVICE_ID;
+    extern std::mutex DEFAULT_IMM_DEVICE_MUTEX;
+    extern void *DEFAULT_IMM_DEVICE;
+    
     void init();
     void stop();
 

--- a/src/spice2x/hooks/audio/audio.h
+++ b/src/spice2x/hooks/audio/audio.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <string>
-#include <mutex>
 #include <optional>
 
 #include <windows.h>
@@ -27,8 +26,6 @@ namespace hooks::audio {
     extern bool LOW_LATENCY_SHARED_WASAPI;
 
     extern std::optional<std::string> DEFAULT_IMM_DEVICE_ID;
-    extern std::mutex DEFAULT_IMM_DEVICE_MUTEX;
-    extern void *DEFAULT_IMM_DEVICE;
     
     void init();
     void stop();

--- a/src/spice2x/hooks/audio/backends/mmdevice/device_enumerator.cpp
+++ b/src/spice2x/hooks/audio/backends/mmdevice/device_enumerator.cpp
@@ -2,6 +2,7 @@
 #include "device_collection.h"
 #include "device.h"
 #include "util/utils.h"
+#include "hooks/audio/audio.h"
 
 #ifdef _MSC_VER
 DEFINE_GUID(IID_IMMDeviceEnumerator,
@@ -50,11 +51,144 @@ HRESULT STDMETHODCALLTYPE WrappedIMMDeviceEnumerator::EnumAudioEndpoints(
     return hr;
 }
 
+IMMDevice *WrappedIMMDeviceEnumerator::get_default_device(EDataFlow dataFlow) {
+    IMMDeviceCollection *ppDevices = nullptr;
+    IMMDevice *pDevice = nullptr;
+    const auto hr = pReal->EnumAudioEndpoints(dataFlow, DEVICE_STATE_ACTIVE, &ppDevices);
+    if (FAILED(hr)) {
+        return nullptr;
+    }
+
+    UINT count = 0;
+    ppDevices->GetCount(&count);
+    if (FAILED(hr) || count == 0) {
+        ppDevices->Release();
+        return nullptr;
+    }
+    log_info("audio", "found {} active audio devices from EnumAudioEndpoints", count);
+
+    // dump info about devices
+    for (UINT i = 0; i < count; i++) {
+        if (SUCCEEDED(ppDevices->Item(i, &pDevice))) {
+            log_info("audio", "device [{}]:", i);
+            dump_device_info(pDevice);
+            pDevice->Release();
+            pDevice = nullptr;
+        }
+    }
+    log_info(
+        "audio",
+        "if you want to use -defaultaudio option, copy the ID above, NOT the friendly name");
+
+    // match on ID
+    for (UINT i = 0; i < count; i++) {
+        LPWSTR id = nullptr;
+        if (FAILED(ppDevices->Item(i, &pDevice))) {
+            continue;
+        }
+
+        // grab the device ID
+        if (FAILED(pDevice->GetId(&id))) {
+            pDevice->Release();
+            pDevice = nullptr;
+            continue;
+        }
+        const std::string device_id = ws2s(std::wstring(id));
+        CoTaskMemFree(id);
+
+        // check for substring match
+        if (device_id.find(hooks::audio::DEFAULT_IMM_DEVICE_ID.value()) != std::string::npos) {
+            log_info(
+                "audio",
+                "found matching device for -defaultaudio option: [{}] {}",
+                i,
+                device_id);
+            break;
+        }
+
+        // not matched, clean up
+        pDevice->Release();
+        pDevice = nullptr;
+    }
+
+    if (pDevice == nullptr) {
+        log_fatal(
+            "audio",
+            "could not find any device matches this ID - {} -"
+            "check -defaultaudio option and try again, it should look something like this: "
+            "{{0.0.0.00000000}}.{{00000000-0000-0000-0000-000000000000}}",
+            hooks::audio::DEFAULT_IMM_DEVICE_ID.value());
+    }
+
+    ppDevices->Release();
+    return pDevice;
+}
+
+#include <functiondiscoverykeys_devpkey.h>
+
+void WrappedIMMDeviceEnumerator::dump_device_info(IMMDevice *pDevice) {
+    // dump friendly name of audio endpoint
+    // https://learn.microsoft.com/en-us/windows/win32/coreaudio/device-properties?redirectedfrom=MSDN
+    IPropertyStore *pProps = nullptr;
+    HRESULT hr;
+
+    hr = pDevice->OpenPropertyStore(STGM_READ, &pProps);
+    if (SUCCEEDED(hr)) {
+        PROPVARIANT varName;
+        PROPERTYKEY key;
+
+        // from functiondiscoverykeys_devpkey.h
+        // instead of including giant windows headers, hardcoding the GUID here
+        // get friendly name
+        GUID IDevice_FriendlyName = { 0xa45c254e, 0xdf1c, 0x4efd, { 0x80, 0x20, 0x67, 0xd1, 0x46, 0xa8, 0x50, 0xe0 } }; // 14
+        key.pid = 14;
+        key.fmtid = IDevice_FriendlyName;
+        PropVariantInit(&varName);
+        hr = pProps->GetValue(key, &varName);
+        if (SUCCEEDED(hr) && varName.vt != VT_EMPTY) {
+            log_info("audio", "    friendly name: {}", ws2s(varName.pwszVal));
+        }
+        PropVariantClear(&varName);
+    }
+    if (pProps) {
+        pProps->Release();
+        pProps = nullptr;
+    }
+
+    // print device instance ID
+    LPWSTR id = nullptr;
+    if (SUCCEEDED(pDevice->GetId(&id))) {
+        log_info("audio", "    ID: {}", ws2s(std::wstring(id)));
+        CoTaskMemFree(id);
+    }
+}
+
 HRESULT STDMETHODCALLTYPE WrappedIMMDeviceEnumerator::GetDefaultAudioEndpoint(
     EDataFlow dataFlow,
     ERole role,
     IMMDevice **ppEndpoint)
 {
+
+    // user override
+    if (hooks::audio::DEFAULT_IMM_DEVICE_ID.has_value()) {
+        std::lock_guard<std::mutex> lock(hooks::audio::DEFAULT_IMM_DEVICE_MUTEX);
+        if (hooks::audio::DEFAULT_IMM_DEVICE == nullptr) {
+            const auto device = get_default_device(dataFlow);
+            if (device != nullptr) {
+                // wrap interface
+                hooks::audio::DEFAULT_IMM_DEVICE = new WrappedIMMDevice(device);
+            }
+        }
+        if (hooks::audio::DEFAULT_IMM_DEVICE != nullptr) {
+            *ppEndpoint = reinterpret_cast<IMMDevice *>(hooks::audio::DEFAULT_IMM_DEVICE);
+            log_info("audio", "IMMDeviceEnumerator::GetDefaultAudioEndpoint is returning user-preferred device:");
+            dump_device_info(*ppEndpoint);
+            return S_OK;
+        }
+        // if not found, fallthrough to normal behavior and call
+        // the real GetDefaultAudioEndpoint below
+    }
+
     // call orignal
     HRESULT ret = this->pReal->GetDefaultAudioEndpoint(dataFlow, role, ppEndpoint);
 
@@ -64,37 +198,8 @@ HRESULT STDMETHODCALLTYPE WrappedIMMDeviceEnumerator::GetDefaultAudioEndpoint(
         return ret;
     }
 
-    // dump friendly name of audio endpoint
-    // https://learn.microsoft.com/en-us/windows/win32/coreaudio/device-properties?redirectedfrom=MSDN
-    {
-        IPropertyStore *pProps = nullptr;
-        HRESULT hr;
-
-        hr = (*ppEndpoint)->OpenPropertyStore(STGM_READ, &pProps);
-        if (SUCCEEDED(hr)) {
-            PROPVARIANT varName;
-
-            // instead of including giant windows headers, hardcoding the GUID here
-            PROPERTYKEY key;
-            GUID IDevice_FriendlyName = { 0xa45c254e, 0xdf1c, 0x4efd, { 0x80, 0x20, 0x67, 0xd1, 0x46, 0xa8, 0x50, 0xe0 } };
-            key.pid = 14;
-            key.fmtid = IDevice_FriendlyName;
-
-            // get friendly name
-            PropVariantInit(&varName);
-            hr = pProps->GetValue(key, &varName);
-            if (SUCCEEDED(hr) && varName.vt != VT_EMPTY) {
-                log_info("audio", "IMMDeviceEnumerator::GetDefaultAudioEndpoint: using {}", ws2s(varName.pwszVal));
-            }
-
-            // cleanup
-            PropVariantClear(&varName);
-        }
-        if (pProps) {
-            pProps->Release();
-            pProps = nullptr;
-        }
-    }
+    log_info("audio", "IMMDeviceEnumerator::GetDefaultAudioEndpoint is returning system default device:");
+    dump_device_info(*ppEndpoint);
 
     // wrap interface
     *ppEndpoint = new WrappedIMMDevice(*ppEndpoint);

--- a/src/spice2x/hooks/audio/backends/mmdevice/device_enumerator.cpp
+++ b/src/spice2x/hooks/audio/backends/mmdevice/device_enumerator.cpp
@@ -1,3 +1,5 @@
+#include <mutex>
+
 #include "device_enumerator.h"
 #include "device_collection.h"
 #include "device.h"

--- a/src/spice2x/hooks/audio/backends/mmdevice/device_enumerator.h
+++ b/src/spice2x/hooks/audio/backends/mmdevice/device_enumerator.h
@@ -31,6 +31,7 @@ struct WrappedIMMDeviceEnumerator : IMMDeviceEnumerator {
 private:
     IMMDeviceEnumerator *const pReal;
 
-    IMMDevice *get_default_device(EDataFlow dataFlow);
+    IMMDevice *get_default_device();
+    void dump_devices();
     void dump_device_info(IMMDevice *pDevice);
 };

--- a/src/spice2x/hooks/audio/backends/mmdevice/device_enumerator.h
+++ b/src/spice2x/hooks/audio/backends/mmdevice/device_enumerator.h
@@ -30,4 +30,7 @@ struct WrappedIMMDeviceEnumerator : IMMDeviceEnumerator {
 
 private:
     IMMDeviceEnumerator *const pReal;
+
+    IMMDevice *get_default_device(EDataFlow dataFlow);
+    void dump_device_info(IMMDevice *pDevice);
 };

--- a/src/spice2x/hooks/audio/backends/mmdevice/device_enumerator.h
+++ b/src/spice2x/hooks/audio/backends/mmdevice/device_enumerator.h
@@ -33,5 +33,6 @@ private:
 
     IMMDevice *get_default_device();
     void dump_devices();
-    void dump_device_info(IMMDevice *pDevice);
+    std::string get_device_id(IMMDevice *pDevice);
+    std::string get_device_friendly_name(IMMDevice *pDevice);
 };

--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -1145,6 +1145,10 @@ int main_implementation(int argc, char *argv[]) {
     if (options[launcher::Options::spice2x_LowLatencySharedAudio].value_bool()) {
         hooks::audio::LOW_LATENCY_SHARED_WASAPI = true;
     }
+    if (options[launcher::Options::DefaultAudioDeviceOverride].is_active()) {
+        hooks::audio::DEFAULT_IMM_DEVICE_ID = strtrim(
+            options[launcher::Options::DefaultAudioDeviceOverride].value_text());
+    }
     if (options[launcher::Options::spice2x_TapeLedAlgorithm].is_active()) {
         const auto text = options[launcher::Options::spice2x_TapeLedAlgorithm].value_text();
         if (text == "off") {

--- a/src/spice2x/launcher/options.cpp
+++ b/src/spice2x/launcher/options.cpp
@@ -2321,17 +2321,18 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
     },
     {
         // DefaultAudioDeviceOverride
-        .title = "WASAPI Default Audio Device ID",
-        .name = "defaultaudio",
+        .title = "WASAPI Default Audio Device",
+        .name = "wasapidefault",
         .desc = "Use a specific audio device as the default audio device instead of what is "
-            "set as the Windows default device.\n\n"
+            "set as the Windows default device. Only works for WASAPI Exclusive or Shared games; "
+            "for legacy DirectSound, use the Windows volume mixer, for ASIO, use ASIO options.\n\n"
+            "You can use the name of the device or the ID. Partial match is allowed. "
+            "If the name contains non-Latin characters, you must use the device ID instead.\n\n"
             "To obtain the device ID, launch the game once, and look for "
             "'active audio devices from EnumAudioEndpoints', and copy the ID of your device. "
-            "If you don't see this, either the game does not use WASAPI, or you disabled audio hooks.\n\n"
-            "Only works for WASAPI Exclusive or Shared games; for legacy DirectSound games, use "
-            "the Windows volume mixer, for ASIO, use ASIO options.",
+            "If you don't see this, either the game does not use WASAPI, or you disabled audio hooks."
+            "",
         .type = OptionType::Text,
-        .setting_name = "{0.0.0.00000000}.{00000000-0000-0000-0000-000000000000}",
         .category = "Audio",
     },
     {

--- a/src/spice2x/launcher/options.cpp
+++ b/src/spice2x/launcher/options.cpp
@@ -2326,9 +2326,10 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Use a specific audio device as the default audio device instead of what is "
             "set as the Windows default device.\n\n"
             "To obtain the device ID, launch the game once, and look for "
-            "'active audio devices from EnumAudioEndpoints', and copy the ID of your device\n\n"
+            "'active audio devices from EnumAudioEndpoints', and copy the ID of your device. "
+            "If you don't see this, either the game does not use WASAPI, or you disabled audio hooks.\n\n"
             "Only works for WASAPI Exclusive or Shared games; for legacy DirectSound games, use "
-            "the Windows volume mixer, for ASIO, use ASIO options",
+            "the Windows volume mixer, for ASIO, use ASIO options.",
         .type = OptionType::Text,
         .setting_name = "{0.0.0.00000000}.{00000000-0000-0000-0000-000000000000}",
         .category = "Audio",

--- a/src/spice2x/launcher/options.cpp
+++ b/src/spice2x/launcher/options.cpp
@@ -2320,6 +2320,20 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .category = "Audio",
     },
     {
+        // DefaultAudioDeviceOverride
+        .title = "WASAPI Default Audio Device ID",
+        .name = "defaultaudio",
+        .desc = "Use a specific audio device as the default audio device instead of what is "
+            "set as the Windows default device.\n\n"
+            "To obtain the device ID, launch the game once, and look for "
+            "'active audio devices from EnumAudioEndpoints', and copy the ID of your device\n\n"
+            "Only works for WASAPI Exclusive or Shared games; for legacy DirectSound games, use "
+            "the Windows volume mixer, for ASIO, use ASIO options",
+        .type = OptionType::Text,
+        .setting_name = "{0.0.0.00000000}.{00000000-0000-0000-0000-000000000000}",
+        .category = "Audio",
+    },
+    {
         // spice2x_TapeLedAlgorithm
         .title = "Tape LED Avg Algorithm",
         .name = "sp2x-tapeledalgo",

--- a/src/spice2x/launcher/options.h
+++ b/src/spice2x/launcher/options.h
@@ -243,6 +243,7 @@ namespace launcher {
             spice2x_IIDXEmulateSubscreenKeypadTouch,
             spice2x_AutoCard,
             spice2x_LowLatencySharedAudio,
+            DefaultAudioDeviceOverride,
             spice2x_TapeLedAlgorithm,
             spice2x_NoNVAPI,
             spice2x_NoD3D9DeviceHook,


### PR DESCRIPTION
## Description of change
For WASAPI games, add an option to override what is returned by `GetDefaultAudioEndpoint`.

## Testing
Tested with SDVX EG Final.
