### PR TITLE
signal: avoid spamming log with hook hit messages

### DIFF
--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -1385,6 +1385,18 @@ int main_implementation(int argc, char *argv[]) {
             );
     }
 
+    if (launcher::signal::DISABLE && !cfg::CONFIGURATOR_STANDALONE) {
+        log_warning(
+            "launcher",
+            "WARNING - user specified -signaldisable option\n\n\n"
+            "!!!                                                              !!!\n"
+            "!!! Using -signaldisable option disables all exception handling, !!!\n"
+            "!!! which means when the game crashes it will likely just vanish !!!\n"
+            "!!! without troubleshooting information in the logs.             !!!\n"
+            "!!!                                                              !!!\n"
+            );
+    }
+
     if (options[launcher::Options::FullscreenResolution].is_active()) {
         std::pair<uint32_t, uint32_t> result;
         if (parse_width_height(options[launcher::Options::FullscreenResolution].value_text(), result)) {

--- a/src/spice2x/launcher/signal.cpp
+++ b/src/spice2x/launcher/signal.cpp
@@ -185,21 +185,30 @@ static LONG WINAPI TopLevelExceptionFilter(struct _EXCEPTION_POINTERS *Exception
 }
 
 static BOOL WINAPI SetConsoleCtrlHandler_hook(PHANDLER_ROUTINE pHandlerRoutine, BOOL Add) {
-    log_misc("signal", "SetConsoleCtrlHandler hook hit");
+    static std::once_flag printed;
+    std::call_once(printed, []() {
+        log_misc("signal", "SetConsoleCtrlHandler hook hit (printing once)");
+    });
 
     return TRUE;
 }
 
 static LPTOP_LEVEL_EXCEPTION_FILTER WINAPI SetUnhandledExceptionFilter_hook(
-    LPTOP_LEVEL_EXCEPTION_FILTER lpTopLevelExceptionFilter)
-{
-    log_info("signal", "SetUnhandledExceptionFilter hook hit");
+    LPTOP_LEVEL_EXCEPTION_FILTER lpTopLevelExceptionFilter) {
+
+    static std::once_flag printed;
+    std::call_once(printed, []() {
+        log_info("signal", "SetUnhandledExceptionFilter hook hit (printing once)");
+    });
 
     return nullptr;
 }
 
 static PVOID WINAPI AddVectoredExceptionHandler_hook(ULONG First, PVECTORED_EXCEPTION_HANDLER Handler) {
-    log_info("signal", "AddVectoredExceptionHandler hook hit");
+    static std::once_flag printed;
+    std::call_once(printed, []() {
+        log_info("signal", "AddVectoredExceptionHandler hook hit (printing once)");
+    });
 
     return launcher::signal::USE_VEH_WORKAROUND ? INVALID_HANDLE_VALUE : nullptr;
 }


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
n/a

## Description of change
Some people have weird DLLs that keep calling `AddVectoredExceptionHandler` which ends up spamming the log.

## Testing
Tested IIDX with error + signaldisable to confirm the warning message being shown, ran Polaris Chord once to check "hook hit" message.
