### PR TITLE
api: fix for setting drs touch state

### DIFF
--- a/src/spice2x/api/modules/drs.cpp
+++ b/src/spice2x/api/modules/drs.cpp
@@ -34,7 +34,7 @@ namespace api::modules {
     void DRS::touch_set(Request &req, Response &res) {
 
         // get all touch points
-        games::drs::drs_touch_t touches[16];
+        auto touches = std::make_unique<games::drs::drs_touch_t[]>(req.params.Size());
         size_t i = 0;
         for (Value &param : req.params.GetArray()) {
 
@@ -86,6 +86,6 @@ namespace api::modules {
         }
 
         // apply touch points
-        games::drs::fire_touches(touches, i);
+        games::drs::fire_touches(touches.get(), i);
     }
 }


### PR DESCRIPTION
## Link to GitHub Issue, if one exists
N/A

## Description of change
Changes the array size used for collecting touch inputs from the API to be dynamic according to the size of the input data, rather than fixed. This fixes a crash.

## Testing
An API client was made sending touch states, both valid and invalid (oversized). The valid states are handled identically in the test menu while the oversized states no longer crash.