### PR TITLE
sdvx, touch: account for 270 degree monitor rotation in wintouchemu

### DIFF
--- a/src/spice2x/misc/wintouchemu.cpp
+++ b/src/spice2x/misc/wintouchemu.cpp
@@ -20,6 +20,7 @@
 #include "util/logging.h"
 #include "util/time.h"
 #include "util/utils.h"
+#include "rawinput/touch.h"
 
 #include "avs/game.h"
 
@@ -126,6 +127,11 @@ namespace wintouchemu {
         WINDOW_TITLE_END = window_title_end;
     }
 
+    static void flip_touch_points(PTOUCHINPUT point) {
+        point->x = rawinput::touch::DISPLAY_SIZE_X * 100 - point->x;
+        point->y = rawinput::touch::DISPLAY_SIZE_Y * 100 - point->y;
+    }
+
     static BOOL WINAPI GetTouchInputInfoHook(HANDLE hTouchInput, UINT cInputs, PTOUCHINPUT pInputs, int cbSize) {
 
         // check if original should be called
@@ -219,6 +225,12 @@ namespace wintouchemu {
                 touch_input->dwExtraInfo = 0;
                 touch_input->cxContact = 0;
                 touch_input->cyContact = 0;
+
+                if (avs::game::is_model("KFC") &&
+                    rawinput::touch::DISPLAY_INITIALIZED &&
+                    rawinput::touch::DISPLAY_ORIENTATION == DMDO_270) {
+                    flip_touch_points(touch_input);
+                }
 
             } else if (USE_MOUSE && !mouse_used) {
 


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
#558 

## Description of change
Same as #558 but this PR fixes the non-native touch cases (when wintouchemu is active).

## Testing
Tested 90 and 270 degree rotation, 1080p and 1440p.
