### PR TITLE
ddr p3io: fix neon pulse mapping

### DIFF
--- a/src/spice2x/games/ddr/p3io/p3io.cpp
+++ b/src/spice2x/games/ddr/p3io/p3io.cpp
@@ -282,7 +282,7 @@ int games::ddr::DDRP3IOHandle::write(LPCVOID lpBuffer, DWORD nNumberOfBytesToWri
                 }
 
                 // use both sat spots for a neon pulse
-                float value_neon = (light_bits & hd_mapping_bits[0] && hd_mapping_bits[1]) ? 1.f : 0.f;
+                float value_neon = (light_bits & hd_mapping_bits[0] && light_bits & hd_mapping_bits[1]) ? 1.f : 0.f;
                 GameAPI::Lights::writeLight(RI_MGR, lights[Lights::NEON], value_neon);
             }
 


### PR DESCRIPTION
Logic was wrong; caught by compiling with a newer clang and it raising a warning about the useless expression (since the second clause always eval'd as true).

Changed to the intended functionality, but I have no ddr3 with p3io so I can't test it. But it seems nobody ever really noticed this.