### PR TITLE
fix various minor issues causing compilation failure with clang

### DIFF
--- a/src/spice2x/cfg/api.h
+++ b/src/spice2x/cfg/api.h
@@ -6,24 +6,20 @@
 #include <windows.h>
 #include "option.h"
 
+#include "button.h"
+#include "analog.h"
+#include "light.h"
+
 namespace rawinput {
     class RawInputManager;
     struct Device;
 }
 
-class Button;
-class Analog;
-class Light;
 class Game;
 class Option;
 
 namespace GameAPI {
     namespace Buttons {
-        enum State {
-            BUTTON_PRESSED = true,
-            BUTTON_NOT_PRESSED = false
-        };
-
         /**
          * Parses the config and returns the buttons set by the user.
          *
@@ -152,7 +148,3 @@ namespace GameAPI {
         void sortOptions(std::vector<Option> &, const std::vector<OptionDefinition> &);
     }
 }
-
-#include "button.h"
-#include "analog.h"
-#include "light.h"

--- a/src/spice2x/cfg/button.h
+++ b/src/spice2x/cfg/button.h
@@ -1,13 +1,21 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <utility>
 #include <vector>
 
-#include "api.h"
-
 namespace rawinput {
     class RawInputManager;
+}
+
+namespace GameAPI {
+    namespace Buttons {
+        enum State {
+            BUTTON_PRESSED = true,
+            BUTTON_NOT_PRESSED = false
+        };
+    }
 }
 
 enum ButtonAnalogType {

--- a/src/spice2x/games/iidx/iidx.cpp
+++ b/src/spice2x/games/iidx/iidx.cpp
@@ -473,7 +473,7 @@ namespace games::iidx {
                 "!!! please do the following instead:                              !!!\n"
                 "!!!                                                               !!!\n"
                 "!!! Revert your changes to XML file so it says                    !!!\n"
-                "!!!     <model __type=\"str\">LDJ</model>                         !!!\n" 
+                "!!!     <model __type=\"str\">LDJ</model>                         !!!\n"
                 "!!!                                                               !!!\n"
                 "!!! In SpiceCfg, enable 'IIDX TDJ Mode' or provide -iidxtdj flag  !!!\n"
                 "!!! in command line                                               !!!\n"
@@ -818,7 +818,7 @@ namespace games::iidx {
     }
 
     bool is_tdj_fhd() {
-        return TDJ_MODE && avs::game::is_ext(2022101900, MAXINT);
+        return TDJ_MODE && avs::game::is_ext(2022101900, INT_MAX);
     }
 
     void apply_audio_hacks() {
@@ -884,12 +884,12 @@ namespace games::iidx {
 
         // patch iidx32+ for asio compatibility
         // only do this if NOT wasapi (as opposed to checking if it's asio)
-        // the patch is only really needed for (some) non-XONAR devices but since people sometimes disguise 
+        // the patch is only really needed for (some) non-XONAR devices but since people sometimes disguise
         // other devices as a XONAR, don't check for the exact string (common ASIO workaround for INF)
-        if (avs::game::is_ext(2024090100, MAXINT) &&
+        if (avs::game::is_ext(2024090100, INT_MAX) &&
             !(SOUND_OUTPUT_DEVICE_IN_EFFECT.has_value() &&
               SOUND_OUTPUT_DEVICE_IN_EFFECT.value() == "wasapi")) {
-                
+
             // in iidx32 final:
             // ff 50 08      call   QWORD PTR [rax+0x8]     ; ASIO instance AddRef
             // 48 8b 4b 08   mov    rcx,QWORD PTR [rbx+0x8]

--- a/src/spice2x/games/iidx/local_camera.h
+++ b/src/spice2x/games/iidx/local_camera.h
@@ -89,7 +89,7 @@ namespace games::iidx {
     protected:
         virtual ~IIDXLocalCamera() {};
 
-        ULONG m_nRefCount;
+        LONG m_nRefCount;
         CRITICAL_SECTION m_critsec;
 
         std::string m_name;

--- a/src/spice2x/hooks/graphics/backends/d3d9/d3d9_backend.cpp
+++ b/src/spice2x/hooks/graphics/backends/d3d9/d3d9_backend.cpp
@@ -278,7 +278,7 @@ static bool is_dx9_on_12_enabled() {
     }
 
     if (GRAPHICS_9_ON_12_STATE == DX9ON12_FORCE_ON) {
-        if (avs::game::is_model("LDJ") && avs::game::is_ext(2023091500, MAXINT)) {
+        if (avs::game::is_model("LDJ") && avs::game::is_ext(2023091500, INT_MAX)) {
             deferredlogs::defer_error_messages({
                 "dx9on12 was force enabled by user (-dx9on12)",
                 "    IIDX31+ is known to be incompatible with DX 9on12, leading to blank screen or crashes",

--- a/src/spice2x/hooks/graphics/backends/d3d9/d3d9_device.cpp
+++ b/src/spice2x/hooks/graphics/backends/d3d9/d3d9_device.cpp
@@ -593,7 +593,7 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DDevice9::UpdateTexture(
     WRAP_DEBUG;
 
     if (CUSTOM_RESET) {
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 
         // Do a pointer compare rather than `QueryInterface` because it is a lot cheaper than incrementing
         // the reference count
@@ -768,7 +768,7 @@ void SurfaceHook(IDirect3DDevice9 *pReal) {
         pReal->ColorFill(topSurface, nullptr, D3DCOLOR_XRGB(0, 0, 0));
         cfg::SCREENRESIZE->need_surface_clean = false;
     }
-    
+
     D3DLOCKED_RECT rect;
     HRESULT hr;
     topSurface->LockRect(&rect, NULL, D3DLOCK_DONOTWAIT);

--- a/src/spice2x/overlay/windows/config.cpp
+++ b/src/spice2x/overlay/windows/config.cpp
@@ -3182,7 +3182,7 @@ namespace overlay::windows {
         } else if (filter != nullptr) {
             cat = "Search results";
         }
-        ImGui::TextColored(ImVec4(1.f, 0.7f, 0, 1), cat.c_str());
+        ImGui::TextColored(ImVec4(1.f, 0.7f, 0, 1), "%s", cat.c_str());
         ImGui::Separator();
 
         // render table

--- a/src/spice2x/overlay/windows/iopanel.h
+++ b/src/spice2x/overlay/windows/iopanel.h
@@ -2,6 +2,7 @@
 
 #include "overlay/window.h"
 #include "cfg/button.h"
+#include "cfg/light.h"
 
 namespace overlay::windows {
 

--- a/src/spice2x/overlay/windows/patch_manager.cpp
+++ b/src/spice2x/overlay/windows/patch_manager.cpp
@@ -235,9 +235,9 @@ namespace overlay::windows {
 #ifdef _MSC_VER
                 static_cast<PLDR_DLL_NOTIFICATION_FUNCTION>([]
 #else
-                                                            [] CALLBACK
+                                                            []
 #endif
-            (ULONG reason, PCLDR_DLL_NOTIFICATION_DATA data, PVOID ctx) {
+            (ULONG reason, PCLDR_DLL_NOTIFICATION_DATA data, PVOID ctx) CALLBACK {
                 if (reason == LDR_DLL_NOTIFICATION_REASON_LOADED) {
                     auto const dll = strtolower(std::filesystem::path({
                         data->Loaded.FullDllName->Buffer,
@@ -432,7 +432,7 @@ namespace overlay::windows {
                 }
             }
         }
-        
+
         bool url_entered = false;
         bool is_valid_url = false;
         bool patches_imported = false;
@@ -635,7 +635,7 @@ namespace overlay::windows {
                 const auto search_str_in_lower = strtolower(patch_name_filter);
                 size_t patches_shown = 0;
                 for (auto &patch : patches) {
-                    
+
                     // get patch status
                     PatchStatus patch_status = is_patch_active(patch);
                     patch.last_status = patch_status;
@@ -836,7 +836,7 @@ namespace overlay::windows {
                     }
                     ImGui::PopID();
                 }
-                
+
                 if (patches_shown == 0) {
                     ImGui::TableNextRow();
                     ImGui::TableNextColumn();
@@ -981,7 +981,7 @@ namespace overlay::windows {
                                         "patchmanager",
                                         "matched auto apply entry by full game identifier: {}",
                                         entry_id);
-                                
+
                                 } else if (is_game_id_wildcard_matched(entry_id)) {
                                     // match on model and ext, ignoring dest/spec/rev
                                     // sample: LDJ:J:E:A:2025011400
@@ -1208,7 +1208,7 @@ namespace overlay::windows {
                 identifier,
                 time);
         }
-        
+
         return identifier;
     }
 
@@ -2000,7 +2000,7 @@ namespace overlay::windows {
                     };
 
                     // get data offset
-                    memory_patch_data.data_offset = 
+                    memory_patch_data.data_offset =
                         parse_json_data_offset(patch_data.name, memory_patch);
                     if (memory_patch_data.data_offset == 0) {
                         continue;
@@ -2155,7 +2155,7 @@ namespace overlay::windows {
                     }
 
                     // get offset
-                    uint64_t union_offset = 
+                    uint64_t union_offset =
                         parse_json_data_offset(patch_data.name, union_patch_it->value);
                     if (union_offset == 0) {
                         continue;
@@ -2193,7 +2193,7 @@ namespace overlay::windows {
                     // move to list
                     patch_data.patches_union.emplace_back(union_patch_data);
                 }
-                
+
                 if (setting_union_patches_enabled.contains(patch_data.hash)) {
                     patch_data.selected_union_name = setting_union_patches_enabled[patch_data.hash];
                 }
@@ -2742,7 +2742,7 @@ namespace overlay::windows {
                             union_patch.data_len);
                 }
             }
-            
+
             if (union_patch.data_offset_ptr == nullptr) {
                 return false;
             }

--- a/src/spice2x/overlay/windows/screen_resize.h
+++ b/src/spice2x/overlay/windows/screen_resize.h
@@ -10,8 +10,8 @@ namespace overlay::windows {
         ~ScreenResize() override;
 
         void build_content() override;
-        void update();
-        
+        void update() override;
+
     private:
         size_t toggle_screen_resize = ~0u;
         bool toggle_screen_resize_state = false;

--- a/src/spice2x/util/threadpool.h
+++ b/src/spice2x/util/threadpool.h
@@ -56,8 +56,8 @@ public:
 
     template<class T, class... Args>
     auto add(T&& func, Args&&... args)
-    -> std::future<typename std::result_of<T(Args...)>::type> {
-        using ret_t = typename std::result_of<T(Args...)>::type;
+    -> std::future<typename std::invoke_result<T, Args...>::type> {
+        using ret_t = typename std::invoke_result<T, Args...>::type;
         auto task = std::make_shared<std::packaged_task<ret_t()>>(
                 std::bind(std::forward<T>(func), std::forward<Args>(args)...));
         std::future<ret_t> fut = task->get_future();


### PR DESCRIPTION
- Include order and forward decls were breaking button.h because a declared but not defined struct can't be initiated (honestly this file was cooked, crazy include order).
- `MAXINT` is GCC specific, `INT_MAX` is portable.
- InterlockedDecrement takes a LONG, not ULONG
- an imgui printf-style call using a direct string instead of %s (let's ignore the fact that it's actually safe based on how the str is constructed)
- missing `override` on a virtual subclass
- `CALLBACK` on a lambda threw me for a loop, but I believe moving it after the arg list is the correct approach (see if it builds on gcc I guess)
- `std::result_of` was removed in C++20, which the project is built with