### PR TITLE
add some more _WIN32_WINNT defines to hook Win vista+ APIs when compiler is targeting XP

### DIFF
--- a/src/spice2x/games/pc/pc.cpp
+++ b/src/spice2x/games/pc/pc.cpp
@@ -1,3 +1,6 @@
+// QueryDisplayConfig
+#define _WIN32_WINNT 0x0601
+
 #include "pc.h"
 
 #include <format>
@@ -32,10 +35,10 @@ namespace games::pc {
         if (pRawInputDevices &&
             (uiNumDevices > 0) &&
             (pRawInputDevices[0].hwndTarget == RI_MGR->input_hwnd)) {
-            
+
             return RegisterRawInputDevices_orig(pRawInputDevices, uiNumDevices, cbSize);
         }
-        
+
         // otherwise, it must be the game; prevent the game from registering for raw input
         // and hijacking WM_INPUT messages.
         SetLastError(0xDEADBEEF);
@@ -58,7 +61,7 @@ namespace games::pc {
     }
 
     LONG WINAPI QueryDisplayConfig_hook(UINT32, UINT32*, DISPLAYCONFIG_PATH_INFO*, UINT32*, DISPLAYCONFIG_MODE_INFO*, DISPLAYCONFIG_TOPOLOGY_ID*) {
-        // make unity fallback to EnumDisplaySettingsW as I don't 
+        // make unity fallback to EnumDisplaySettingsW as I don't
         // want to deal with this api which is way more complex
         return ERROR_NOT_SUPPORTED;
     }
@@ -98,9 +101,9 @@ namespace games::pc {
         const auto user32Dll = "user32.dll";
         detour::trampoline_try(user32Dll, "RegisterRawInputDevices",
                                RegisterRawInputDevices_hook, &RegisterRawInputDevices_orig);
-        detour::trampoline_try(user32Dll, "QueryDisplayConfig", 
+        detour::trampoline_try(user32Dll, "QueryDisplayConfig",
                                QueryDisplayConfig_hook, &QueryDisplayConfig_orig);
-        detour::trampoline_try(user32Dll, "EnumDisplaySettingsW", 
+        detour::trampoline_try(user32Dll, "EnumDisplaySettingsW",
                                EnumDisplaySettingsW_hook, &EnumDisplaySettingsW_orig);
 
         if (GRAPHICS_SHOW_CURSOR) {

--- a/src/spice2x/hooks/lang.cpp
+++ b/src/spice2x/hooks/lang.cpp
@@ -1,3 +1,6 @@
+// GetLocaleInfoEx
+#define _WIN32_WINNT 0x0600
+
 #include "lang.h"
 
 #define WIN32_NO_STATUS

--- a/src/spice2x/hooks/winuser.cpp
+++ b/src/spice2x/hooks/winuser.cpp
@@ -1,3 +1,6 @@
+// DisplayConfigSetDeviceInfo
+#define _WIN32_WINNT 0x0601
+
 #include "winuser.h"
 
 #include "util/detour.h"

--- a/src/spice2x/util/cpuutils.cpp
+++ b/src/spice2x/util/cpuutils.cpp
@@ -1,3 +1,6 @@
+// GetCurrentProcessorNumberEx
+#define _WIN32_WINNT 0x0601
+
 #include "cpuutils.h"
 
 #include <thread>
@@ -98,7 +101,7 @@ namespace cpuutils {
         log_misc("cpuutils", "detected {} processors", PROCESSOR_COUNT);
 
         done = true;
-        
+
         // init processor states
         get_load();
     }
@@ -144,11 +147,11 @@ namespace cpuutils {
         // dump cpu id
         log_misc("cpuinfo", "{}, {} ({})",
             cpu.vendor,
-            cpu.brand_string, 
+            cpu.brand_string,
             GetX86MicroarchitectureName(GetX86Microarchitecture(&cpu)));
         log_misc("cpuinfo", "family 0x{:x}, model 0x{:x}, stepping 0x{:x}", cpu.family, cpu.model, cpu.stepping);
 
-        // dump features        
+        // dump features
         std::string features = "";
         for (size_t i = 0; i < X86_LAST_; ++i) {
             if (GetX86FeaturesEnumValue(&cpu.features, static_cast<X86FeaturesEnum>(i))) {
@@ -253,7 +256,7 @@ namespace cpuutils {
         if (GetLogicalProcessorInformationEx == nullptr) {
             return;
         }
-        
+
         // determine buffer size
         returned_length = 0;
         result = GetLogicalProcessorInformationEx(


### PR DESCRIPTION
There's already a bunch of these in the codebase, this just catches a few locations where they were missed when the compiler is targeting XP.