### PR TITLE
overlay: minor UI fixes for clear all / reset all

### DIFF
--- a/src/spice2x/cfg/analog.h
+++ b/src/spice2x/cfg/analog.h
@@ -91,6 +91,7 @@ public:
         setMultiplier(1);
         setRelativeMode(false);
         setDelayBufferDepth(0);
+        setLastState(0.5f);
     }
 
     inline void clearBindings() {

--- a/src/spice2x/overlay/windows/config.cpp
+++ b/src/spice2x/overlay/windows/config.cpp
@@ -593,9 +593,11 @@ namespace overlay::windows {
         ImGui::AlignTextToFramePadding();
         ImGui::TextColored(ImVec4(1.f, 0.7f, 0, 1), "%s Buttons", name.c_str());
 
-        std::string reset_button_str = "Reset all";
+        std::string reset_button_str = "Clear All";
         if (name == "Keypad") {
             reset_button_str = "Use Preset";
+        } else if (name == "Overlay") {
+            reset_button_str = "Reset All";
         }
 
         const float clear_w = ImGui::CalcTextSize(reset_button_str.c_str()).x
@@ -2001,7 +2003,6 @@ namespace overlay::windows {
                     // explicitly not checking for analog.isSet() here
                     // since it doesn't account for a binding with valid device but invalid index
                     analog.clearBindings();
-                    analog.setLastState(0.f);
                     ::Config::getInstance().updateBinding(games_list[games_selected], analog);
                 }
                 ImGui::CloseCurrentPopup();
@@ -2066,7 +2067,6 @@ namespace overlay::windows {
                         ImGui::SameLine();
                         if (ImGui::DeleteButton("Remove")) {
                             analog.clearBindings();
-                            analog.setLastState(0.f);
                             ::Config::getInstance().updateBinding(
                                     games_list[games_selected], analog);
                         }


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
#578 

## Description of change
Use `Clear All` when there are no defaults, and `Reset All` when there are defaults.

Clearing analogs should reset values to 0.5, not 0.


