### PR TITLE
build: flatten file structure in release archives

### DIFF
--- a/src/spice2x/build_all.sh
+++ b/src/spice2x/build_all.sh
@@ -334,10 +334,10 @@ then
 	echo "Building dist..."
 	mkdir -p ${DIST_FOLDER}
 	rm -rf "${DIST_FOLDER}/${DIST_NAME}"
-	pushd ${OUTDIR}/.. > /dev/null
-	zip -qrXT9 "$OLDPWD/${DIST_FOLDER}/${DIST_NAME}" spice2x -x "spice2x/extras/*" -z <<< "$DIST_COMMENT"
+	pushd ${OUTDIR} > /dev/null
+	zip -qrXT9 "$OLDPWD/${DIST_FOLDER}/${DIST_NAME}" . -x "extras/*" -z <<< "$DIST_COMMENT"
 	echo "Building extras..."
-	zip -qrXT9 "$OLDPWD/${DIST_FOLDER}/${DIST_NAME_EXTRAS}" spice2x -z <<< "$DIST_COMMENT"
+	zip -qrXT9 "$OLDPWD/${DIST_FOLDER}/${DIST_NAME_EXTRAS}" . -z <<< "$DIST_COMMENT"
 	popd > /dev/null
 fi
 


### PR DESCRIPTION
Before:

```
.\spice2x\spice.exe
.\spice2x\spicecfg.exe
.\spice2x\spice64.exe
.\spice2x\stubs\..
.\spice2x\extras\..
```

after:

```
.\spice.exe
.\spicecfg.exe
.\spice64.exe
.\stubs\..
.\extras\..
```