### PR TITLE
popn: boot with 3 monitors

### DIFF
--- a/src/spice2x/games/popn/popn.cpp
+++ b/src/spice2x/games/popn/popn.cpp
@@ -232,6 +232,7 @@ namespace games::popn {
                             // TODO: is this what the game expects for subscreen?
                             // TODO: what if there are 3+ monitors?
                             targetName->outputTechnology = DISPLAYCONFIG_OUTPUT_TECHNOLOGY_HDMI;
+                            targetName->connectorInstance = 0;
                         }
                         break;
                     }
@@ -633,6 +634,8 @@ namespace games::popn {
             wintouchemu::INJECT_MOUSE_AS_WM_TOUCH = true;
             wintouchemu::hook_title_ends("", "Main Screen", avs::game::DLL_INSTANCE);
         }
+
+        sysutils::hook_EnumDisplayDevicesA();
 
 #endif
 

--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -594,6 +594,9 @@ int main_implementation(int argc, char *argv[]) {
         GRAPHICS_FORCE_SINGLE_ADAPTER = true;
         GRAPHICS_PREVENT_SECONDARY_WINDOW = true;
     }
+    if (options[launcher::Options::PopnSubMonitorOverride].is_active()) {
+        sysutils::SECOND_MONITOR_OVERRIDE = options[launcher::Options::PopnSubMonitorOverride].value_text();
+    }
     if (options[launcher::Options::LoadMetalGearArcadeModule].value_bool()) {
         attach_mga = true;
     }

--- a/src/spice2x/launcher/options.cpp
+++ b/src/spice2x/launcher/options.cpp
@@ -998,6 +998,17 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .category = "Game Options",
     },
     {
+        // PopnSubMonitorOverride
+        .title = "Pop'n Music PikaPika Subscreen Monitor Override",
+        .name = "popnsubmonitor",
+        .desc = "If you have three or more monitors, this option can be set to tell the game which monitor is the subscreen.",
+        .type = OptionType::Text,
+        .setting_name = "\\\\.\\DISPLAY3",
+        .game_name = "Pop'n Music",
+        .category = "Monitor",
+        .picker = OptionPickerType::Monitor,
+    },
+    {
         .title = "Force Load HELLO! Pop'n Music Module",
         .name = "hpm",
         .desc = "Manually enable HELLO! Pop'n Music module.",

--- a/src/spice2x/launcher/options.h
+++ b/src/spice2x/launcher/options.h
@@ -100,6 +100,7 @@ namespace launcher {
             PopnMusicForceHDMode,
             PopnMusicForceSDMode,
             PopnNoSub,
+            PopnSubMonitorOverride,
             LoadHelloPopnMusicModule,
             LoadGitaDoraModule,
             GitaDoraTwoChannelAudio,

--- a/src/spice2x/util/sysutils.cpp
+++ b/src/spice2x/util/sysutils.cpp
@@ -576,7 +576,13 @@ namespace sysutils {
     }
 
     void hook_EnumDisplayDevicesA() {
-        EnumDisplayDevicesA_orig = detour::iat_try(
-             "EnumDisplayDevicesA", EnumDisplayDevicesA_hook, avs::game::DLL_INSTANCE);
+        // the goal is to trick DX9 into thinking that some monitors are not attached
+        // so we need to trampoline hook at user32 instead of IAT at game level
+        log_misc("sysutils", "hooking EnumDisplayDevicesA to hide if there are more than 3 monitors...");
+        detour::trampoline_try(
+            "user32.dll",
+            "EnumDisplayDevicesA",
+            (void*)EnumDisplayDevicesA_hook,
+            (void**)&EnumDisplayDevicesA_orig);
     }
 }


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
#618 

## Description of change
Take the monitor hooks added for IIDX/SDVX #612  and apply it to popn as well now that popn has a subscreen.

There is a debug option in game that actually uses three monitors, which can be activated via hex edits. This will prevent that from working.

## Testing
Tested with 3 monitors, fs and windowed.