### PR TITLE
grpahics: fix borderless for ddr/gitadora

### DIFF
--- a/src/spice2x/hooks/graphics/graphics.h
+++ b/src/spice2x/hooks/graphics/graphics.h
@@ -101,7 +101,7 @@ std::string graphics_screenshot_genpath();
 // graphics_windowed.cpp
 void graphics_windowed_wndproc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 void graphics_capture_initial_window(HWND hWnd);
-void graphics_update_window_style(HWND hWnd);
+void graphics_update_window_style(HWND hWnd, bool force_update=false);
 void graphics_update_z_order(HWND hWnd, bool always_on_top);
 void graphics_move_resize_window(HWND hWnd);
 bool graphics_window_options_breaks_game();

--- a/src/spice2x/hooks/graphics/graphics_windowed.cpp
+++ b/src/spice2x/hooks/graphics/graphics_windowed.cpp
@@ -121,13 +121,12 @@ void graphics_capture_initial_window(HWND hWnd) {
             cfg::SCREENRESIZE->client_height);
         graphics_move_resize_window(hWnd);
     }
-    // ddr hangs when window frame doesn't have overlapped
     if (cfg::SCREENRESIZE->window_decoration != cfg::WindowDecorationMode::Default) {
         log_info(
             "graphics-windowed", "[{}] change window style - decoration: {}",
             fmt::ptr(hWnd),
             cfg::SCREENRESIZE->window_decoration);
-        graphics_update_window_style(hWnd);
+        graphics_update_window_style(hWnd, true); // force
     }
     if (cfg::SCREENRESIZE->window_always_on_top) {
         log_info("graphics-windowed", "[{}] change window z-order - always on top", fmt::ptr(hWnd));
@@ -385,11 +384,11 @@ void graphics_wm_sizing_aspect_ratio(int edge, RECT& rect) {
     log_debug("graphics-windowed", "graphics_wm_sizing_aspect_ratio returned");
 }
 
-void graphics_update_window_style(HWND hWnd) {
+void graphics_update_window_style(HWND hWnd, bool force_update) {
     if (!GRAPHICS_WINDOWED) {
         return;
     }
-    if (graphics_window_decoration_change_crashes_game()) {
+    if (!force_update && graphics_window_decoration_change_crashes_game()) {
         return;
     }
 
@@ -504,7 +503,14 @@ bool graphics_window_decoration_change_crashes_game() {
     static bool result = false;
     std::call_once(flag, []() {
         // ddr crashes when frame style changes
-        result = avs::game::is_model("MDX");
+        if (avs::game::is_model("MDX")) {
+            result = true;
+        }
+
+        // arena model hangs immediately when decoration changes
+        if (games::gitadora::is_arena_model()) {
+            result = true;
+        }
 
         // changing window decoration also changes dimensions and position
         // so this must be prevented

--- a/src/spice2x/overlay/windows/screen_resize.cpp
+++ b/src/spice2x/overlay/windows/screen_resize.cpp
@@ -213,7 +213,7 @@ namespace overlay::windows {
         ImGui::SameLine();
         ImGui::HelpMarker(
             "Change window decoration. Resizable Window may not cause your mouse cursor to change, "
-            "but you can still drag to resize. Disabled for some games due to incompatibility.");
+            "but you can still drag to resize. Disabled for some games due to incompatibility; change in spicecfg instead.");
 
         if (ImGui::Checkbox("Always On Top", &cfg::SCREENRESIZE->window_always_on_top) ) {
             graphics_update_z_order(window, cfg::SCREENRESIZE->window_always_on_top);


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
n/a

## Description of change
Allow DDR to be launched in borderless window (honor the spicecfg option).

Prevent Gitadora arena model from changing the window decoration once launched as it hangs the game.

## Testing
Tested 32/64bit ddr, gitadora arena.