### PR TITLE
util: fix dangling pointer issues with improper std::stringstream usage

### DIFF
--- a/src/spice2x/launcher/shutdown.cpp
+++ b/src/spice2x/launcher/shutdown.cpp
@@ -86,13 +86,12 @@ namespace launcher {
         if (LAUNCHER_ARGC > 0) {
 
             // build cmd line
-            std::stringstream cmd_line;
-            cmd_line << "START \"\" ";
+            std::string cmd_line = "START \"\" ";
             for (int i = 0; i < LAUNCHER_ARGC; i++)
-                cmd_line << " \"" << LAUNCHER_ARGV[i] << "\"";
+                cmd_line += " \"" + std::string(LAUNCHER_ARGV[i]) + "\"";
 
             // run command
-            system(cmd_line.str().c_str());
+            system(cmd_line.c_str());
         }
     }
 

--- a/src/spice2x/overlay/windows/control.cpp
+++ b/src/spice2x/overlay/windows/control.cpp
@@ -628,13 +628,12 @@ namespace overlay::windows {
                             ImGui::Text("Wheel: %ld", mouse->pos_wheel);
 
                             // keys
-                            std::stringstream keys;
-                            keys << "[";
+                            std::string keys = "[";
                             for (auto key : mouse->key_states) {
-                                keys << (key ? "1," : "0,");
+                                keys += (key ? "1," : "0,");
                             }
-                            keys << "]";
-                            ImGui::Text("Keys: %s", keys.str().c_str());
+                            keys += "]";
+                            ImGui::Text("Keys: %s", keys.c_str());
 
                             break;
                         }
@@ -643,15 +642,14 @@ namespace overlay::windows {
                             ImGui::Text("Type: Keyboard");
 
                             // keys
-                            std::stringstream keys;
-                            keys << "[";
+                            std::string keys = "[";
                             for (size_t i = 0; i < std::size(keyboard->key_states); i++) {
                                 if (keyboard->key_states[i]) {
-                                    keys << i << ",";
+                                    keys += std::to_string(i) + ",";
                                 }
                             }
-                            keys << "]";
-                            ImGui::Text("Keys: %s", keys.str().c_str());
+                            keys += "]";
+                            ImGui::Text("Keys: %s", keys.c_str());
 
                             break;
                         }

--- a/src/spice2x/util/sigscan.cpp
+++ b/src/spice2x/util/sigscan.cpp
@@ -219,20 +219,21 @@ intptr_t replace_pattern(HMODULE module, const std::string &signature,
     strreplace(pattern_str, "??", "00");
     auto pattern_bin = std::make_unique<uint8_t[]>(signature.length() / 2);
     if (!hex2bin(pattern_str.c_str(), pattern_bin.get())) {
-        return false;
+        return 0;
     }
 
     // build signature mask
-    std::ostringstream signature_mask;
+    std::string signature_mask;
+    signature_mask.reserve(signature.size() / 2);
     for (size_t i = 0; i < signature.length(); i += 2) {
         if (signature[i] == '?') {
             if (signature[i + 1] == '?') {
-                signature_mask << '?';
+                signature_mask += '?';
             } else {
-                return false;
+                return 0;
             }
         } else {
-            signature_mask << 'X';
+            signature_mask += 'X';
         }
     }
 
@@ -241,20 +242,21 @@ intptr_t replace_pattern(HMODULE module, const std::string &signature,
     strreplace(replace_data_str, "??", "00");
     auto replace_data_bin = std::make_unique<uint8_t[]>(replacement.length() / 2);
     if (!hex2bin(replace_data_str.c_str(), replace_data_bin.get())) {
-        return false;
+        return 0;
     }
 
     // build replace mask
-    std::ostringstream replace_mask;
+    std::string replace_mask;
+    replace_mask.reserve(replacement.size() / 2);
     for (size_t i = 0; i < replacement.length(); i += 2) {
         if (replacement[i] == '?') {
             if (replacement[i + 1] == '?') {
-                replace_mask << '?';
+                replace_mask += '?';
             } else {
-                return false;
+                return 0;
             }
         } else {
-            replace_mask << 'X';
+            replace_mask += 'X';
         }
     }
 
@@ -262,11 +264,11 @@ intptr_t replace_pattern(HMODULE module, const std::string &signature,
     return replace_pattern(
             module,
             pattern_bin.get(),
-            signature_mask.str().c_str(),
+            signature_mask.c_str(),
             offset,
             usage,
             replace_data_bin.get(),
-            replace_mask.str().c_str()
+            replace_mask.c_str()
     );
 }
 


### PR DESCRIPTION
## Description of change
`std::ostringstream.str()` returns a temporary string so it's invalid to obtain c_str from it and pass it around.

## Testing
wip
