### PR TITLE
iidx: fix crash when ASIO compatibility fix patching fails

### DIFF
--- a/src/spice2x/games/iidx/iidx.cpp
+++ b/src/spice2x/games/iidx/iidx.cpp
@@ -915,8 +915,7 @@ namespace games::iidx {
                 log_warning(
                     "iidx",
                     "Failed to apply ASIO compatibility fix for iidx32+. "
-                    "Unless patches are applied, your ASIO device ({}) may hang or fail to work",
-                    ASIO_DRIVER->c_str());
+                    "Unless patches are applied, your ASIO device may hang or fail to work");
             } else {
                 log_info(
                     "iidx",


### PR DESCRIPTION
Logging method was crashing when the patching failed.