### PR TITLE
ftt: allow windowed mode resize options, add title

### DIFF
--- a/src/spice2x/hooks/graphics/graphics.cpp
+++ b/src/spice2x/hooks/graphics/graphics.cpp
@@ -476,6 +476,14 @@ static HWND WINAPI CreateWindowExW_hook(DWORD dwExStyle, LPCWSTR lpClassName, LP
         }
     }
 
+    // FTT
+    if (avs::game::is_model("MMD")) {
+        // set window name
+        if (!lpWindowName) {
+            lpWindowName = L"Future TomTom";
+        }
+    }
+
     if (GRAPHICS_WINDOWED) {
         graphics_window_check_bounds_before_creation(x, y, nWidth, nHeight);
     }

--- a/src/spice2x/hooks/graphics/graphics_windowed.cpp
+++ b/src/spice2x/hooks/graphics/graphics_windowed.cpp
@@ -532,8 +532,8 @@ bool graphics_window_decoration_change_crashes_game() {
     static std::once_flag flag;
     static bool result = false;
     std::call_once(flag, []() {
-        // ddr crashes when frame style changes
-        if (avs::game::is_model("MDX")) {
+        // ddr and ftt crash when frame style changes
+        if (avs::game::is_model("MDX") || avs::game::is_model("MMD")) {
             result = true;
         }
 

--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -1835,9 +1835,7 @@ int main_implementation(int argc, char *argv[]) {
                 attach_ftt = true;
 
                 // the game is windowed by default unless we set the env
-                if (GRAPHICS_WINDOWED) {
-                    GRAPHICS_WINDOWED = false;
-                } else {
+                if (!GRAPHICS_WINDOWED) {
                     SetEnvironmentVariable("DAMAC_VIEWER_FULLSCREEN", "0");
                 }
 


### PR DESCRIPTION
## Description of change
This code adds a window title to FutureTomTom when running in windowed mode and allows the windowed graphics hooks to take effect.

## Testing
I ran the game and made sure fullscreen mode still worked as well as all window move/resize functionality.