### PR TITLE
audio: deal with missing DirectSoundI3DL2ReverbDMO better

### DIFF
--- a/src/spice2x/hooks/audio/audio.cpp
+++ b/src/spice2x/hooks/audio/audio.cpp
@@ -67,7 +67,8 @@ static HRESULT STDAPICALLTYPE CoCreateInstance_hook(
         if (IsEqualCLSID(rclsid, CLSID_MMDeviceEnumerator)) {
             log_warning("audio", "CoCreateInstance failed for CLSID_MMDeviceEnumerator, hr={}", FMT_HRESULT(ret));
         } else if (IsEqualCLSID(rclsid, CLSID_DirectSoundI3DL2ReverbDMO)) {
-            // deal with reverb DMO missing from dsdmo.dll (usually fails with 0x80040154)
+            // deal with reverb DMO missing from dsdmo.dll
+            // it usually fails with 0x80040154 (REGDB_E_CLASSNOTREG), but we have also seen 0x8007007e (ERROR_MOD_NOT_FOUND) 
             static std::once_flag printed;
             std::call_once(printed, [ret]() {
                 log_warning(

--- a/src/spice2x/hooks/audio/audio.cpp
+++ b/src/spice2x/hooks/audio/audio.cpp
@@ -66,14 +66,15 @@ static HRESULT STDAPICALLTYPE CoCreateInstance_hook(
     if (FAILED(ret)) {
         if (IsEqualCLSID(rclsid, CLSID_MMDeviceEnumerator)) {
             log_warning("audio", "CoCreateInstance failed for CLSID_MMDeviceEnumerator, hr={}", FMT_HRESULT(ret));
-        }
-        
-        // Windows 11 KB5052093 issue - reverb DMO went missing from dsdmo.dll (fails with 0x80040154)
-        if (IsEqualCLSID(rclsid, CLSID_DirectSoundI3DL2ReverbDMO) && ret == (HRESULT)0x80040154) {
-            log_warning(
-                "audio",
-                "CoCreateInstance for CLSID_DirectSoundI3DL2ReverbDMO failed with 0x80040154, swap with CLSID_DirectSoundWavesReverbDMO "
-                "(workaround for Windows 11 KB5052093 issue); REVERB EX replaced with REVERB");
+        } else if (IsEqualCLSID(rclsid, CLSID_DirectSoundI3DL2ReverbDMO)) {
+            // deal with reverb DMO missing from dsdmo.dll (usually fails with 0x80040154)
+            static std::once_flag printed;
+            std::call_once(printed, [ret]() {
+                log_warning(
+                    "audio",
+                    "CoCreateInstance for CLSID_DirectSoundI3DL2ReverbDMO failed with {}, swap with CLSID_DirectSoundWavesReverbDMO...",
+                    FMT_HRESULT(ret));
+            });
             ret = CoCreateInstance_orig(CLSID_DirectSoundWavesReverbDMO, pUnkOuter, dwClsContext, riid, ppv);
             if (FAILED(ret)) {
                 log_warning("audio", "CoCreateInstance(CLSID_DirectSoundWavesReverbDMO...) failed, hr={}", FMT_HRESULT(ret));


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
n/a

## Description of change
On some Win11 systems, `CoCreateInstance(CLSID_DirectSoundI3DL2ReverbDMO)` started to fail with `ERROR_MOD_NOT_FOUND` instead of `REGDB_E_CLASSNOTREG` for some reason.

## Testing
User tested.