### PR TITLE
ea3: fix boot failure when -e is specified to override ea3-config path

### DIFF
--- a/src/spice2x/avs/ea3.cpp
+++ b/src/spice2x/avs/ea3.cpp
@@ -217,8 +217,10 @@ namespace avs {
                 ea3_config_name = "prop/eamuse-config.xml";
             }
 
-            if (avs::core::file_exists(ea3_config_name)) {
-                log_info("avs-ea3", "booting (using {})", ea3_config_name);
+            if (fileutils::file_exists(ea3_config_name)) {
+                log_info("avs-ea3", "found {} on disk", ea3_config_name);
+            } else if (CFG_PATH.size()) {
+                log_fatal("avs-ea3", "user-specified ea3 config file is missing: {}", ea3_config_name);
             } else {
                 log_warning("avs-ea3", "looked for the following files in order:");
                 log_warning("avs-ea3", "  * prop/ea3-config.xml");


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
Regression introduced by #595 

## Description of change
`avs::core::file_exists` fails if you use `\` as path separator... what I meant to use was `fileutils::file_exists`.

This would have caused failures - mostly for gitadora players - if they used `prop\ea3-config2.xml` for example.

## Testing
