### PR TITLE
sdvx: work around bad logger configuration

### DIFF
--- a/src/spice2x/avs/core.cpp
+++ b/src/spice2x/avs/core.cpp
@@ -1921,6 +1921,15 @@ namespace avs {
             // create nvram and raw directories if possible for mounttable configurations
             create_avs_config_fs_table(config, config_node);
 
+#if !SPICE64
+            // sdvx4 bad log config fix
+            if (avs::game::DLL_NAME == "soundvoltex.dll" &&  // it's too early for avs::game::is_model
+                property_search_safe(config, config_node, "/log/enable_console")) {
+                log_info("avs-core", "applying SDVX4 avs-config.xml fix for <log><enable_console>");
+                property_search_remove_safe(config, config_node, "/log/enable_console");
+            }
+#endif
+
             // set log level
             if (!LOG_LEVEL_CUSTOM.empty()) {
                 property_search_remove_safe(config, config_node, "/log/level");


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
#345 

## Description of change
SDVX4 data from certain private forum has bad logger configuration and crashes on boot. Add an explicit workaround to fix up that broken `avs-config.xml` file, scoped to `soundvoltex.dll` + 32-bit.

## Testing
Tested HH.
