### PR TITLE
Try and preserve the wideness of std::filesystem::path more

### DIFF
--- a/src/spice2x/api/modules/memory.cpp
+++ b/src/spice2x/api/modules/memory.cpp
@@ -58,7 +58,7 @@ namespace api::modules {
 
         // check if file exists in modules
         if (!fileutils::file_exists(dll_path)) {
-            return error(res, "Couldn't find " + dll_path.string());
+            return error(res, fmt::format("Couldn't find {}", dll_path));
         }
 
         // get module
@@ -118,7 +118,7 @@ namespace api::modules {
 
         // check if file exists in modules
         if (!fileutils::file_exists(dll_path)) {
-            return error(res, "Couldn't find " + dll_path.string());
+            return error(res, fmt::format("Couldn't find {}", dll_path));
         }
 
         // get module
@@ -196,7 +196,7 @@ namespace api::modules {
 
         // check if file exists in modules
         if (!fileutils::file_exists(dll_path)) {
-            return error(res, "Couldn't find " + dll_path.string());
+            return error(res, fmt::format("Couldn't find {}", dll_path));
         }
 
         // get module

--- a/src/spice2x/avs/core.cpp
+++ b/src/spice2x/avs/core.cpp
@@ -1168,7 +1168,7 @@ namespace avs {
             // Ongaku Paradise
             {"arkjc9.dll", 0xA00000},
 
-            // KAMUNITY 
+            // KAMUNITY
             {"kamunity.dll", 33554432},
         };
 
@@ -1516,7 +1516,7 @@ namespace avs {
                         "    * It's also possible that you have incomplete game data\n"
                         "    * Do NOT copy over random DLLs from another game installation; DLL must match game version\n"
                         "\n"
-                    , DLL_NAME, MODULE_PATH.string()) };
+                    , DLL_NAME, MODULE_PATH) };
                     log_warning("avs-ea3", "{}", info_str);
                     log_fatal("avs-ea3", "Failed to find critical avs DLL on disk (avs2-core.dll OR {})", DLL_NAME);
                 }
@@ -1757,9 +1757,9 @@ namespace avs {
         {
             deferredlogs::defer_error_messages({
                 "AVS filesystem initialization failure was previously detected during boot!",
-                fmt::format("    ERROR: directory could not be created: {}", src_path.string().c_str()),
-                fmt::format("    if you see a crash, it may have been caused by bad <mounttable> contents in {}", avs::core::CFG_PATH.c_str()),
-                "    fix the XML file and try again"  
+                fmt::format("    ERROR: directory could not be created: {}", src_path),
+                fmt::format("    if you see a crash, it may have been caused by bad <mounttable> contents in {}", avs::core::CFG_PATH),
+                "    fix the XML file and try again"
             });
         }
 
@@ -1780,14 +1780,14 @@ namespace avs {
             auto created = std::filesystem::create_directories(real_path, err);
 
             if (created) {
-                log_info("avs-core", "created '{}' at '{}'", avs_path, real_path.string());
+                log_info("avs-core", "created '{}' at '{}'", avs_path, real_path);
             }
 
             if (err) {
                 avs_dir_err(real_path);
                 log_warning("avs-core", "failed to create '{}' folder at '{}': {}",
                         avs_path,
-                        real_path.string(),
+                        real_path,
                         err.message());
             }
         }

--- a/src/spice2x/avs/ea3.cpp
+++ b/src/spice2x/avs/ea3.cpp
@@ -151,8 +151,8 @@ namespace avs {
                         "    * It's also possible that you have incomplete game data\n"
                         "    * Do NOT copy over random DLLs from another game installation; DLL must match game version\n"
                         "\n"
-                    , DLL_NAME, MODULE_PATH.string()) };
-                    
+                    , DLL_NAME, MODULE_PATH) };
+
                     log_warning("avs-ea3", "{}", info_str);
                     log_fatal("avs-ea3", "Failed to find critical ea3 DLL on disk (avs2-ea3.dll OR {})", DLL_NAME);
                 }

--- a/src/spice2x/avs/game.cpp
+++ b/src/spice2x/avs/game.cpp
@@ -73,11 +73,10 @@ namespace avs {
 
             // load game instance
             const auto dll_path = MODULE_PATH / DLL_NAME;
-            const auto dll_path_s = dll_path.string();
-            log_info("avs-game", "DLL path: {}", dll_path_s.c_str());
+            log_info("avs-game", "DLL path: {}", dll_path);
 
             // MAX_PATH is 260
-            if (130 <= dll_path_s.length()) {
+            if (const auto dll_path_len = dll_path.wstring().length(); 130 <= dll_path_len) {
                 log_warning(
                     "avs-game",
                     "PATH TOO LONG WARNING\n\n"
@@ -93,7 +92,7 @@ namespace avs {
                     "long, often resulting in random crashes. Move the game contents to\n"
                     "a directory with shorter path.\n"
                     "-------------------------------------------------------------------\n\n",
-                    dll_path_s, dll_path_s.length());
+                    dll_path, dll_path_len);
             }
 
             // ddr gamemdx.dll user error
@@ -112,7 +111,7 @@ namespace avs {
 
             // file not found on disk
             if (!fileutils::file_exists(dll_path)) {
-                log_warning("avs-game", "game DLL could not be found on disk: {}", dll_path.string().c_str());
+                log_warning("avs-game", "game DLL could not be found on disk: {}", dll_path);
                 log_warning("avs-game", "double check -exec and -modules parameters; unless you know what you're doing, leave them blank");
             }
 

--- a/src/spice2x/cfg/config.cpp
+++ b/src/spice2x/cfg/config.cpp
@@ -28,7 +28,7 @@ Config::Config() {
     this->status = false;
     if (CONFIG_PATH_OVERRIDE.length() > 0) {
         this->configLocation = CONFIG_PATH_OVERRIDE;
-        log_info("cfg", "using custom config file: {}", this->configLocation.string());
+        log_info("cfg", "using custom config file: {}", this->configLocation);
     } else {
         this->configLocation = std::filesystem::path(_wgetenv(L"APPDATA")) / L"spicetools.xml";
         // avoids logging the expanded appdata path as it contains user name
@@ -57,7 +57,7 @@ Config::Config() {
                 this->firstFillConfigFile();
                 break;
             case tinyxml2::XMLError::XML_ERROR_FILE_COULD_NOT_BE_OPENED:
-                log_fatal("cfg", "could not open config file: {}", this->configLocation.string());
+                log_fatal("cfg", "could not open config file: {}", this->configLocation);
                 break;
             case tinyxml2::XMLError::XML_ERROR_FILE_NOT_FOUND:
                 this->createConfigFile();
@@ -72,7 +72,7 @@ Config::Config() {
             case tinyxml2::XMLError::XML_ERROR_PARSING_UNKNOWN:
             case tinyxml2::XMLError::XML_ERROR_MISMATCHED_ELEMENT:
             case tinyxml2::XMLError::XML_ERROR_PARSING:
-                log_warning("cfg", "Couldn't read config file: {}", this->configLocation.string());
+                log_warning("cfg", "Couldn't read config file: {}", this->configLocation);
                 this->createConfigFile();
                 this->firstFillConfigFile();
                 break;
@@ -1327,7 +1327,7 @@ void Config::saveConfigFile() {
     // create a .tmp file and write to it...
     const auto xml_result = this->configFile.SaveFile(this->configLocationTemp.c_str(), false);
     if (xml_result != tinyxml2::XMLError::XML_SUCCESS) {
-        log_info("cfg", "failed to write file: {}", this->configLocationTemp.string());
+        log_info("cfg", "failed to write file: {}", this->configLocationTemp);
         return;
     }
     // copy the .tmp file to the main file...

--- a/src/spice2x/cfg/screen_resize.cpp
+++ b/src/spice2x/cfg/screen_resize.cpp
@@ -21,7 +21,7 @@ namespace cfg {
         if (SCREEN_RESIZE_CFG_PATH_OVERRIDE.has_value()) {
             this->config_path = SCREEN_RESIZE_CFG_PATH_OVERRIDE.value();
             if (fileutils::file_exists(this->config_path)) {
-                log_info("ScreenResize", "loading config from: {}", this->config_path.string());
+                log_info("ScreenResize", "loading config from: {}", this->config_path);
                 file_exists = true;
             }
         } else {
@@ -35,7 +35,7 @@ namespace cfg {
 
     ScreenResize::~ScreenResize() {
     }
-    
+
     void ScreenResize::config_load() {
         std::string config = fileutils::text_read(this->config_path);
         if (config.empty()) {
@@ -78,7 +78,7 @@ namespace cfg {
             eamuse_get_game(),
             use_game_setting,
             root);
-        
+
         load_bool_value(doc, root + "enable_screen_resize", this->enable_screen_resize);
         if (this->enable_screen_resize) {
             log_misc("ScreenResize", "enabled by config file");

--- a/src/spice2x/games/ddr/ddr.cpp
+++ b/src/spice2x/games/ddr/ddr.cpp
@@ -23,6 +23,7 @@
 #include "p3io/usbmem.h"
 
 #include "p4io/p4io.h"
+#include <cstring>
 
 using namespace acioemu;
 
@@ -53,9 +54,9 @@ namespace games::ddr {
         return SendMessage_real(hWnd, Msg, wParam, lParam);
     }
 
-    bool contains_only_ascii(const std::string& str) {
+    bool contains_only_ascii(const std::wstring& str) {
         for (auto c: str) {
-            if (static_cast<unsigned char>(c) > 127) {
+            if (c > 127) {
                 return false;
             }
         }
@@ -80,24 +81,24 @@ namespace games::ddr {
         }
 
         if (fileutils::dir_exists(dir)) {
-            log_info("ddr", "looking for codecs in this directory: {}", dir.string());
+            log_info("ddr", "looking for codecs in this directory: {}", dir);
         } else {
-            log_info("ddr", "codecs directory not found: {}", dir.string());
+            log_info("ddr", "codecs directory not found: {}", dir);
             return;
         }
 
         for (const auto &file : std::filesystem::directory_iterator(dir)) {
             const auto &filename = file.path().filename();
-            const auto extension = strtolower(filename.extension().string());
+            const auto extension = filename.extension().wstring();
 
-            if (extension != ".dll") {
+            if (wcsicmp(extension.c_str(), L".dll") != 0) {
                 continue;
             }
 
-            log_info("ddr", "found DLL: {}, size: {} bytes", filename.string(), file.file_size());
-            if (filename == "k-clvsd.dll" || filename.string().find("xactengine") == 0) {
+            log_info("ddr", "found DLL: {}, size: {} bytes", filename, file.file_size());
+            if (filename == "k-clvsd.dll" || filename.wstring().find(L"xactengine") == 0) {
                 const std::wstring wcmd = L"regsvr32.exe /s \"" + file.path().wstring() + L"\"";
-                const std::string cmd = "regsvr32.exe /s \"" + file.path().string() + "\"";
+                const std::string cmd = fmt::format("regsvr32.exe /s \"{}\"", file.path());
 
                 int result = 0;
                 std::thread t([wcmd, &result]() {
@@ -111,12 +112,12 @@ namespace games::ddr {
                     log_warning("ddr", "`{}` failed, returned {}", cmd, result);
                     deferredlogs::defer_error_messages({
                         "DDR codec registration failure",
-                        fmt::format("    {} failed to register with error {}", filename.string(), result)});
+                        fmt::format("    {} failed to register with error {}", filename, result)});
                 }
 
                 static std::once_flag printed;
                 std::call_once(printed, [file]() {
-                    if (!contains_only_ascii(file.path().string())) {
+                    if (!contains_only_ascii(file.path().wstring())) {
                         log_warning(
                             "ddr",
                             "BAD PATH ERROR\n\n"

--- a/src/spice2x/games/jb/jb.cpp
+++ b/src/spice2x/games/jb/jb.cpp
@@ -167,7 +167,7 @@ namespace games::jb {
     void JBGame::pre_attach() {
         if (!cfg::CONFIGURATOR_STANDALONE) {
             const auto current_path = std::filesystem::current_path();
-            log_misc("jubeat", "current working directory: {}", current_path.string());
+            log_misc("jubeat", "current working directory: {}", current_path);
             if (current_path.parent_path() == current_path.root_path()) {
                 log_warning(
                     "jubeat",
@@ -178,7 +178,7 @@ namespace games::jb {
                     "    c:\\jubeat\\contents\\spice.exe  <- OK\n\n"
                     "To fix this, create a new directory and move ALL game files there.\n\n"
                     "Your current working directory: {}\n",
-                    current_path.string());
+                    current_path);
 
                 log_fatal(
                     "jubeat",

--- a/src/spice2x/hooks/avshook.cpp
+++ b/src/spice2x/hooks/avshook.cpp
@@ -291,7 +291,7 @@ static int avs_fs_mount(const char *mountpoint, const char *fsroot, const char *
         std::filesystem::create_directories(mapped_path, err);
 
         if (err) {
-            log_warning("hooks::avs", "failed to create '{}': {}", mapped_path.string(), err.message());
+            log_warning("hooks::avs", "failed to create '{}': {}", mapped_path, err.message());
         } else {
 
             // if this is the `e:\`, then create the special directories
@@ -305,7 +305,7 @@ static int avs_fs_mount(const char *mountpoint, const char *fsroot, const char *
 
             log_misc("hooks::avs", "source directory '{}' remapped to '{}'",
                     fsroot,
-                    mapped_path.string());
+                    mapped_path);
         }
 
         new_fs_root = mapped_path.string();

--- a/src/spice2x/misc/eamuse.cpp
+++ b/src/spice2x/misc/eamuse.cpp
@@ -87,7 +87,7 @@ bool eamuse_get_card(const std::filesystem::path &path, uint8_t *card, int index
     std::unique_lock<std::mutex> lock(CARD_OVERRIDES_LOCK);
     const auto card_override = CARD_OVERRIDES[index];
     lock.unlock();
-    
+
     // Check if card overrides are present
     if (!card_override.empty()) {
 
@@ -131,7 +131,7 @@ bool eamuse_get_card_from_file(const std::filesystem::path &path, uint8_t *card,
     // open file
     std::ifstream f(path);
     if (!f) {
-        log_warning("eamuse", "{} can not be opened!", path.string());
+        log_warning("eamuse", "{} can not be opened!", path);
         return false;
     }
 
@@ -142,7 +142,7 @@ bool eamuse_get_card_from_file(const std::filesystem::path &path, uint8_t *card,
 
     // check size
     if (length < 16) {
-        log_warning("eamuse", "{} is too small (must be at least 16 characters)", path.string());
+        log_warning("eamuse", "{} is too small (must be at least 16 characters)", path);
         return false;
     }
 
@@ -160,14 +160,14 @@ bool eamuse_get_card_from_file(const std::filesystem::path &path, uint8_t *card,
         if (!digit && !character_big && !character_small) {
             log_warning("eamuse",
                 "{} contains an invalid character sequence at byte {} (16 characters, 0-9/A-F only)",
-                path.string(), n);
+                path, n);
 
             return false;
         }
     }
 
     // info
-    log_info("eamuse", "[P{}] Inserted {}: {}", index+1, path.string(), buffer);
+    log_info("eamuse", "[P{}] Inserted {}: {}", index+1, path, buffer);
 
     // convert hex to bytes
     hex2bin(buffer, card);
@@ -454,7 +454,7 @@ uint16_t eamuse_get_keypad_state(size_t unit) {
     if (unit >= std::size(KEYPAD_STATE)) {
         return 0;
     }
-    
+
     // reset
     KEYPAD_STATE[unit] = KEYPAD_STATE_OVERRIDES[unit];
     KEYPAD_STATE[unit] |= KEYPAD_STATE_OVERRIDES_BT5[unit];

--- a/src/spice2x/overlay/overlay.cpp
+++ b/src/spice2x/overlay/overlay.cpp
@@ -733,13 +733,13 @@ void overlay::SpiceOverlay::add_font(const char* font, ImFontConfig* config, con
     full_path += font;
 
     if (fileutils::file_exists(full_path)) {
-        log_misc("overlay", "loading font: {}", full_path.string());
+        log_misc("overlay", "loading font: {}", full_path);
         ImGui::GetIO().Fonts->AddFontFromFileTTF(
             full_path.string().c_str(),
             13.0f,
             config,
             glyphs);
     } else {
-        log_misc("overlay", "font not found: {}", full_path.string());
+        log_misc("overlay", "font not found: {}", full_path);
     }
 }

--- a/src/spice2x/overlay/windows/patch_manager.cpp
+++ b/src/spice2x/overlay/windows/patch_manager.cpp
@@ -95,6 +95,10 @@ namespace overlay::windows {
     }
 
     // utility
+    std::string displayPath(const std::filesystem::path &path) {
+        return fmt::format(FMT_STRING("{}"), path);
+    }
+
     std::string getFromUrl(const std::string& dll_name, const std::string& url) {
         log_info("patchmanager", "getting patches from URL: {}, for file: {}", url, dll_name);
         std::string result;
@@ -226,7 +230,7 @@ namespace overlay::windows {
 
         if (PATCH_MANAGER_CFG_PATH_OVERRIDE.has_value()) {
             this->config_path = PATCH_MANAGER_CFG_PATH_OVERRIDE.value();
-            log_info("patchmanager", "using custom config file path: {}", this->config_path.string().c_str());
+            log_info("patchmanager", "using custom config file path: {}", this->config_path);
         } else {
             this->config_path =
                 fileutils::get_config_file_path("patchmanager", "spicetools_patch_manager.json");
@@ -330,7 +334,7 @@ namespace overlay::windows {
             "Wrong path? Run spicecfg from the correct directory, or fix your modules parameter before launching spicecfg.\n"
             "Make sure you're not using a different one when launching the game.");
         ImGui::SameLine();
-        ImGui::Text("Modules Path: %s", MODULE_PATH.string().c_str());
+        ImGui::Text("Modules Path: %s", displayPath(MODULE_PATH).c_str());
 
         ImGui::AlignTextToFramePadding();
         ImGui::DummyMarker();
@@ -878,7 +882,7 @@ namespace overlay::windows {
     }
 
     void PatchManager::hard_apply_patches() {
-        std::vector<std::string> written_list;
+        std::vector<std::filesystem::path> written_list;
         for (auto& patch : patches) {
             switch (patch.type) {
             case PatchType::Memory:
@@ -1218,7 +1222,7 @@ namespace overlay::windows {
             log_info(
                 "patchmanager",
                 "file: {}, patch id: {}, build timestamp of dll: {:%Y-%m-%d %H:%M}",
-                dll_path.has_filename() ? dll_path.filename().string() : dll_path.string(),
+                dll_path.has_filename() ? dll_path.filename() : dll_path,
                 identifier,
                 time);
         }
@@ -1623,7 +1627,7 @@ namespace overlay::windows {
                 // save to file
                 std::filesystem::path save_path = LOCAL_PATCHES_PATH / (identifier + ".json");
                 fileutils::text_write(save_path, patches_json);
-                log_info("patchmanager", "remotely fetched JSON saved to: {}", save_path.string());
+                log_info("patchmanager", "remotely fetched JSON saved to: {}", save_path);
                 return true;
             } else {
                 log_warning("patchmanager", "failed to fetch patches JSON for {}", dll_name);
@@ -1675,19 +1679,19 @@ namespace overlay::windows {
         const size_t patches_size_previous = patches.size();
         for (const std::filesystem::path& patches_json_path: LOCAL_PATCHES_JSON_PATHS) {
             if (!fileutils::file_exists(patches_json_path)) {
-                log_misc("patchmanager", "file does not exist, skipping: {}", patches_json_path.string());
+                log_misc("patchmanager", "file does not exist, skipping: {}", patches_json_path);
                 continue;
             }
 
-            log_misc("patchmanager", "reading from patches.json: {}", patches_json_path.string());
+            log_misc("patchmanager", "reading from patches.json: {}", patches_json_path);
             std::string content = fileutils::text_read(patches_json_path);
             append_patches(content, apply_patches, filter);
 
             const auto new_patches = patches.size() - patches_size_previous;
-            log_info("patchmanager", "loaded {} patches from: {}", new_patches, patches_json_path.string());
+            log_info("patchmanager", "loaded {} patches from: {}", new_patches, patches_json_path);
             if (0 < new_patches) {
                 ret = true;
-                ACTIVE_JSON_FILE = patches_json_path.string();
+                ACTIVE_JSON_FILE = displayPath(patches_json_path);
                 break;
             }
         }
@@ -1723,21 +1727,21 @@ namespace overlay::windows {
 
         if (fileutils::file_exists(firstPath) || !extraDlls.empty()) {
             if (fileutils::file_exists(firstPath)) {
-                log_info("patchmanager", "loaded patches for {} from {}", firstDll, firstPath.string());
+                log_info("patchmanager", "loaded patches for {} from {}", firstDll, firstPath);
                 std::string content = fileutils::text_read(firstPath);
                 append_patches(content, apply_patches, nullptr, first_id);
-                ACTIVE_JSON_FILE = firstPath.string();
+                ACTIVE_JSON_FILE = displayPath(firstPath);
             }
             for (const std::string& dll : extraDlls) {
                 auto extraId = get_game_identifier(MODULE_PATH / dll);
                 auto extraPath = std::filesystem::path(fmt::format("patches/{}.json", extraId));
-                log_info("patchmanager", "loaded patches for {} from {}", dll, extraPath.string());
+                log_info("patchmanager", "loaded patches for {} from {}", dll, extraPath);
                 std::string content = fileutils::text_read(extraPath);
                 append_patches(content, apply_patches, nullptr, extraId);
                 if (ACTIVE_JSON_FILE.empty()) {
-                    ACTIVE_JSON_FILE = extraPath.string();
+                    ACTIVE_JSON_FILE = displayPath(extraPath);
                 } else {
-                    ACTIVE_JSON_FILE += ", " + extraPath.string();
+                    ACTIVE_JSON_FILE += ", " + displayPath(extraPath);
                 }
             }
         } else {
@@ -3024,22 +3028,23 @@ namespace overlay::windows {
     }
 
     void create_dll_backup(
-        std::vector<std::string>& written_list, const std::filesystem::path& dll_path) {
+        std::vector<std::filesystem::path>& written_list, const std::filesystem::path& dll_path) {
 
         // if dll_path is not in written_list, create a file backup.
-        if (std::find(written_list.begin(), written_list.end(), dll_path.string()) == written_list.end()) {
-            written_list.push_back(dll_path.string());
-            auto dll_bak_path = std::filesystem::path(dll_path.string() + ".bak");
+        if (std::find(written_list.begin(), written_list.end(), dll_path) == written_list.end()) {
+            written_list.push_back(dll_path);
+            auto dll_bak_path = dll_path;
+            dll_bak_path += ".bak";
             try {
                 if (!fileutils::file_exists(dll_bak_path)) {
                     std::filesystem::copy(dll_path, dll_bak_path);
                 }
-                log_info("patchmanager", "created DLL backup for: {}", dll_path.string());
+                log_info("patchmanager", "created DLL backup for: {}", dll_path);
             } catch (const std::filesystem::filesystem_error& e) {
                 log_warning(
                     "patchmanager",
                     "filesystem error while creating DLL backup for {}, error: {}",
-                    dll_path.string(), e.what());
+                    dll_path, e.what());
             }
         }
     }
@@ -3065,14 +3070,14 @@ namespace overlay::windows {
         /// check if file exists
         auto dll_path = MODULE_PATH / dll_name;
         if (!fileutils::file_exists(dll_path)) {
-            log_warning("patchmanager", "{} does not exist", dll_path.string());
+            log_warning("patchmanager", "{} does not exist", dll_path);
             return nullptr;
         }
 
         // get module
         auto module = libutils::try_module(dll_path);
         if (!module) {
-            log_warning("patchmanager", "cannot get module: {}", dll_path.string());
+            log_warning("patchmanager", "cannot get module: {}", dll_path);
             return nullptr;
         }
 
@@ -3081,7 +3086,7 @@ namespace overlay::windows {
         if (offset == -1) {
             log_warning(
                 "patchmanager", "cannot convert offset to RVA: {}, {}",
-                dll_path.string(), data_offset);
+                dll_path, data_offset);
             return nullptr;
         }
 
@@ -3095,7 +3100,7 @@ namespace overlay::windows {
 
             log_warning(
                 "patchmanager", "GetModuleInformation failed for {}, gle: {}",
-                dll_path.string(), GetLastError());
+                dll_path, GetLastError());
 
             return nullptr;
         }

--- a/src/spice2x/overlay/windows/patch_manager.h
+++ b/src/spice2x/overlay/windows/patch_manager.h
@@ -162,11 +162,11 @@ namespace overlay::windows {
         uint8_t* destination, const std::string& dll_name, size_t offset, size_t size);
 
     void create_dll_backup(
-        std::vector<std::string>& written_list, const std::filesystem::path& dll_path);
+        std::vector<std::filesystem::path>& written_list, const std::filesystem::path& dll_path);
     std::string fix_up_dll_name(const std::string& dll_name);
     uint8_t* get_dll_offset_for_patch_apply(
         const std::string& dll_name, const uint64_t data_offset, const size_t size_in_bytes);
- 
+
     uint64_t parse_json_data_offset(
         const std::string &patch_name, const rapidjson::Value &value);
 

--- a/src/spice2x/util/fileutils.cpp
+++ b/src/spice2x/util/fileutils.cpp
@@ -82,14 +82,14 @@ bool fileutils::verify_header_pe(const std::filesystem::path &file_path) {
                 if (!valid) {
                     log_fatal("fileutils",
                             "{} (32 bit) can't be loaded using spice64.exe - please use spice.exe for this game.",
-                            file_path.string());
+                            file_path);
                 }
 #else
                 valid = dll_file_header->Machine == IMAGE_FILE_MACHINE_I386;
                 if (!valid) {
                     log_fatal("fileutils",
                             "{} (64 bit) can't be loaded using spice.exe - please use spice64.exe for this game.",
-                            file_path.string());
+                            file_path);
                 }
 #endif
             }
@@ -156,9 +156,9 @@ bool fileutils::dir_create_log(const std::string_view &module, const std::filesy
     auto ret = std::filesystem::create_directory(dir_path, err);
 
     if (err) {
-        log_warning(module, "failed to create directory '{}': {}", dir_path.string(), err.message());
+        log_warning(module, "failed to create directory '{}': {}", dir_path, err.message());
     } else if (ret) {
-        log_misc(module, "created directory '{}'", dir_path.string());
+        log_misc(module, "created directory '{}'", dir_path);
     }
 
     return ret && !err;
@@ -178,37 +178,12 @@ bool fileutils::dir_create_recursive_log(const std::string_view &module, const s
     auto ret = std::filesystem::create_directories(dir_path, err);
 
     if (err) {
-        log_warning(module, "failed to create directory (recursive) '{}': {}", dir_path.string(), err.message());
+        log_warning(module, "failed to create directory (recursive) '{}': {}", dir_path, err.message());
     } else if (ret) {
-        log_misc(module, "created directory (recursive) '{}'", dir_path.string());
+        log_misc(module, "created directory (recursive) '{}'", dir_path);
     }
 
     return ret && !err;
-}
-
-void fileutils::dir_scan(const std::string &path, std::vector<std::string> &vec, bool recursive) {
-
-    // check directory
-    if (std::filesystem::exists(path) && std::filesystem::is_directory(path)) {
-        if (recursive) {
-            for (const auto &entry : std::filesystem::recursive_directory_iterator(path)) {
-                if (!std::filesystem::is_directory(entry)) {
-                    auto path = entry.path().string();
-                    vec.emplace_back(std::move(path));
-                }
-            }
-        } else {
-            for (const auto &entry : std::filesystem::directory_iterator(path)) {
-                if (!std::filesystem::is_directory(entry)) {
-                    auto path = entry.path().string();
-                    vec.emplace_back(std::move(path));
-                }
-            }
-        }
-    }
-
-    // determinism
-    std::sort(vec.begin(), vec.end());
 }
 
 bool fileutils::text_write(const std::filesystem::path &file_path, std::string text) {
@@ -296,22 +271,24 @@ std::filesystem::path fileutils::get_config_file_path(const std::string module, 
 
 bool fileutils::write_config_file(const std::string_view &module, const std::filesystem::path path, std::string text) {
     // attempt to undo %appdata% expansion to hide user name
-    const auto appdata = std::filesystem::path(_wgetenv(L"APPDATA")).string();
-    auto censored = path.string();
+    const auto appdata = std::filesystem::path(_wgetenv(L"APPDATA")).wstring();
+    auto censored = path.wstring();
     const auto substr_offset = censored.find(appdata);
     if (substr_offset != std::string::npos) {
-        censored.replace(substr_offset, appdata.length(), "%appdata%");
+        censored.replace(substr_offset, appdata.length(), L"%appdata%");
     }
+
+    auto censored_display = fmt::detail::to_utf8<wchar_t>(censored, fmt::detail::to_utf8_error_policy::replace);
 
     // create directory path up to where the config file lives
     if (!path.parent_path().empty() && !std::filesystem::exists(path.parent_path())) {
-        log_misc(module, "creating directory path to config file: {}", censored);
+        log_misc(module, "creating directory path to config file: {}", censored_display);
         if (!fileutils::dir_create_recursive(path.parent_path())) {
             return false;
         }
     }
 
     // save file
-    log_info(module, "saving config file: {}", censored);
+    log_info(module, "saving config file: {}", censored_display);
     return fileutils::text_write(path, text);
 }

--- a/src/spice2x/util/fileutils.h
+++ b/src/spice2x/util/fileutils.h
@@ -26,7 +26,6 @@ namespace fileutils {
     bool dir_create_log(const std::string_view &module, const std::filesystem::path &dir_path);
     bool dir_create_recursive(const std::filesystem::path &dir_path);
     bool dir_create_recursive_log(const std::string_view &module, const std::filesystem::path &dir_path);
-    void dir_scan(const std::string &path, std::vector<std::string> &vec, bool recursive);
 
     // IO
     bool text_write(const std::filesystem::path &file_path, std::string text);

--- a/src/spice2x/util/libutils.cpp
+++ b/src/spice2x/util/libutils.cpp
@@ -1,5 +1,6 @@
 #include "libutils.h"
 
+#include <cstring>
 #include <windows.h>
 #include <psapi.h>
 #include <shlwapi.h>
@@ -38,7 +39,7 @@ std::filesystem::path libutils::module_file_name(HMODULE module) {
     return std::filesystem::path(std::move(buf));
 }
 
-static inline void load_library_fail(const std::string &file_name, bool fatal) {
+static inline void load_library_fail(const std::filesystem::path &file_name, bool fatal) {
     std::string info_str { fmt::format(
         "DLL failed to load - this is a common error. Please carefully read ALL of the following steps for a fix:\n"
         " 1. Confirm if the file ({}) exists on the disk and check the file permissions.\n"
@@ -76,9 +77,9 @@ HMODULE libutils::load_library(const std::filesystem::path &path, bool fatal) {
     HMODULE module = LoadLibraryW(path.c_str());
 
     if (!module) {
-        log_warning("libutils", "'{}' couldn't be loaded: {}", path.string(), get_last_error_string());
+        log_warning("libutils", "'{}' couldn't be loaded: {}", path, get_last_error_string());
         dependencies::walk(path);
-        load_library_fail(path.filename().string(), fatal);
+        load_library_fail(path.filename(), fatal);
     }
 
     return module;
@@ -236,7 +237,7 @@ intptr_t libutils::rva2offset(const std::filesystem::path &path, intptr_t rva) {
     HANDLE dll_mapping = CreateFileMappingW(dll_file, nullptr, PAGE_READONLY, 0, 0, nullptr);
     if (!dll_mapping) {
         CloseHandle(dll_file);
-        log_warning("libutils", "could not create file mapping for {}", path.string());
+        log_warning("libutils", "could not create file mapping for {}", path);
         return -1;
     }
 
@@ -245,7 +246,7 @@ intptr_t libutils::rva2offset(const std::filesystem::path &path, intptr_t rva) {
     if (!dll_file_base) {
         CloseHandle(dll_file);
         CloseHandle(dll_mapping);
-        log_warning("libutils", "could not map view of file for {}", path.string());
+        log_warning("libutils", "could not map view of file for {}", path);
         return -1;
     }
 
@@ -306,7 +307,7 @@ intptr_t libutils::offset2rva(const std::filesystem::path &path, intptr_t offset
     // create file mapping
     HANDLE dll_mapping = CreateFileMappingW(dll_file, nullptr, PAGE_READONLY, 0, 0, nullptr);
     if (!dll_mapping) {
-        log_warning("libutils", "could not create file mapping for {}: {}", path.string(), get_last_error_string());
+        log_warning("libutils", "could not create file mapping for {}: {}", path, get_last_error_string());
         CloseHandle(dll_file);
         return -1;
     }
@@ -314,7 +315,7 @@ intptr_t libutils::offset2rva(const std::filesystem::path &path, intptr_t offset
     // map view of file
     LPVOID dll_file_base = MapViewOfFile(dll_mapping, FILE_MAP_READ, 0, 0, 0);
     if (!dll_file_base) {
-        log_warning("libutils", "could not map view of file for {}: {}", path.string(), get_last_error_string());
+        log_warning("libutils", "could not map view of file for {}: {}", path, get_last_error_string());
         CloseHandle(dll_file);
         CloseHandle(dll_mapping);
         return -1;
@@ -344,9 +345,9 @@ void libutils::check_duplicate_dlls() {
 
     for (const auto &file : std::filesystem::directory_iterator(MODULE_PATH)) {
         const auto &filename = file.path().filename();
-        const auto extension = strtolower(filename.extension().string());
+        const auto extension = filename.extension().wstring();
 
-        if (extension == ".dll" &&
+        if (wcsicmp(extension.c_str(), L".dll") == 0 &&
             fileutils::file_exists(spice_bin_path / filename)) {
             log_warning(
                 "libutils",
@@ -361,9 +362,9 @@ void libutils::check_duplicate_dlls() {
                 "this has unintended consequences and may crash your game!\n"
                 "resolve the conflict by deleting the stale copy of the DLL\n"
                 "-------------------------------------------------------------------\n\n\n",
-                filename.string(),
-                (spice_bin_path / filename).string(),
-                (MODULE_PATH / filename).string());
+                filename,
+                (spice_bin_path / filename),
+                (MODULE_PATH / filename));
         }
     }
 }
@@ -384,22 +385,22 @@ void libutils::warn_if_dll_exists(const std::string &file_name) {
 
 void libutils::print_dll_info(std::filesystem::path filename) {
     DWORD handle;
-    const auto size = GetFileVersionInfoSizeA(filename.string().c_str(), &handle);
+    const auto size = GetFileVersionInfoSizeW(filename.wstring().c_str(), &handle);
     if (size == 0) {
         log_debug(
             "libutils",
             "GetFileVersionInfoSizeA failed for {}: {}",
-            filename.filename().string(),
+            filename.filename(),
             get_last_error_string());
         return;
     }
 
     auto data = util::make_unique_plain<VOID>(size);
-    if (!GetFileVersionInfoA(filename.string().c_str(), handle, size, data.get())) {
+    if (!GetFileVersionInfoW(filename.wstring().c_str(), handle, size, data.get())) {
         log_debug(
             "libutils",
             "GetFileVersionInfoA failed for {}: {}",
-            filename.filename().string(),
+            filename.filename(),
             get_last_error_string());
         return;
     }
@@ -414,7 +415,7 @@ void libutils::print_dll_info(std::filesystem::path filename) {
         log_debug(
             "libutils",
             "VerQueryValueA failed for {}: {}",
-            filename.filename().string(),
+            filename.filename(),
             get_last_error_string());
         return;
     }
@@ -422,7 +423,7 @@ void libutils::print_dll_info(std::filesystem::path filename) {
         log_debug(
             "libutils",
             "VerQueryValueA returned invalid results for {}",
-            filename.filename().string());
+            filename.filename());
         return;
     }
 
@@ -457,7 +458,7 @@ void libutils::print_dll_info(std::filesystem::path filename) {
             "libutils",
             "VerQueryValueA({}) failed for {}: {}",
             subBlock,
-            filename.filename().string(),
+            filename.filename(),
             get_last_error_string());
         return "";
     };
@@ -469,7 +470,7 @@ void libutils::print_dll_info(std::filesystem::path filename) {
     log_info(
         "libutils",
         "DLL info for {}: CompanyName = {}, ProductName = {}, Version = {}",
-        filename.filename().string(),
+        filename.filename(),
         company_name.empty() ? "?" : company_name,
         product_name.empty() ? "?" : product_name,
         version_str.empty() ? "?" : version_str);

--- a/src/spice2x/util/logging.h
+++ b/src/spice2x/util/logging.h
@@ -10,6 +10,7 @@
 
 #include "external/fmt/include/fmt/format.h"
 #include "external/fmt/include/fmt/compile.h"
+#include "external/fmt/include/fmt/std.h"
 
 #include "launcher/launcher.h"
 #include "launcher/logger.h"
@@ -75,7 +76,7 @@ void show_popup_for_fatal_error(std::string message);
 // misc log
 #define LOG_FORMAT(level, module, fmt_str, ...) fmt::format(FMT_COMPILE("{}" fmt_str "\n"), \
     fmt_log { std::time(nullptr), level, module }, ## __VA_ARGS__)
-   
+
 #define LOG_FORMAT_POPUP(module, fmt_str, ...) fmt::format(FMT_COMPILE("{}: " fmt_str "\n"), module, ## __VA_ARGS__)
 
 #define log_misc(module, format_str, ...) logger::push( \

--- a/src/spice2x/util/sigscan.cpp
+++ b/src/spice2x/util/sigscan.cpp
@@ -275,7 +275,7 @@ intptr_t replace_pattern(HMODULE module, const std::string &signature,
 bool get_pe_identifier(const std::filesystem::path& dll_path, uint32_t* time_date_stamp, uint32_t* address_of_entry_point) {
     std::ifstream file(dll_path, std::ios::binary);
     if (!file) {
-        log_warning("sigscan", "Failed to open file: {}", dll_path.string().c_str());
+        log_warning("sigscan", "Failed to open file: {}", dll_path);
         return false;
     }
 
@@ -283,7 +283,7 @@ bool get_pe_identifier(const std::filesystem::path& dll_path, uint32_t* time_dat
     IMAGE_DOS_HEADER dos_header;
     file.read(reinterpret_cast<char*>(&dos_header), sizeof(dos_header));
     if (dos_header.e_magic != IMAGE_DOS_SIGNATURE) {
-        log_warning("sigscan", "Invalid DOS signature: {}", dll_path.string().c_str());
+        log_warning("sigscan", "Invalid DOS signature: {}", dll_path);
         return false;
     }
 
@@ -294,7 +294,7 @@ bool get_pe_identifier(const std::filesystem::path& dll_path, uint32_t* time_dat
     IMAGE_NT_HEADERS nt_headers;
     file.read(reinterpret_cast<char*>(&nt_headers), sizeof(nt_headers));
     if (nt_headers.Signature != IMAGE_NT_SIGNATURE) {
-        log_warning("sigscan", "Invalid NT signature: {}", dll_path.string().c_str());
+        log_warning("sigscan", "Invalid NT signature: {}", dll_path);
         return false;
     }
 


### PR DESCRIPTION
As noted in #567, a filesystem path that contains non-ascii will break a lot if using a clang toolchain.

Luckily, fmtlib has a lossy utf8 convert when you use it to print a path (after including `fmt/std.h`). The vast majority of this diff is just removing `.string()` from paths inside loggings calls.

There are some callsites I _didn't_ touch, mainly the options, because it would be an ABI break to change those to be wide strings and I cbf looking into settings upgrades. There are also some spots (avs mountpath remapping, for example) where the path is guaranteed to be ascii, so I didn't modify them.

ImGui doesn't appear to easily support wide strings (I mean, surely it does, but I'm not gonna look too far into it) so I mostly just left those alone too, with a few spots modified to re-use fmtlib's lossy utf8.

Some of the changes are basically never gonna be hit IRL, like who would put a file with a non-ascii _extension_ along with their modules? But the diff is (I hope) pretty easy to validate as OK.

Testing has been somewhat minimal, I fired up the GCC build of spice2x in a dodgy folder name, got mojibake (running via wine in linux so take that as you will), ran the unmodified clang spice and crashed the same way the reporter did. After modification, I get the exact same mojibake so I assume if the terminal enjoys utf8 it'll display OK.

Claude (only used for review) thinks the commit is fine but is annoyed that I use `fmt::detail` in the appdata censoring, which is part of the private API; personally I don't care because it's pretty stable.