### PR TITLE
rawinput: remove experimental analog features (delay and relative axis mode)

### DIFF
--- a/src/spice2x/build/controller_presets.xml
+++ b/src/spice2x/build/controller_presets.xml
@@ -39,8 +39,8 @@
             <button name="VEFX" vkey="10" analogtype="0" devid="Player 1" invert="false" debounce_up="0" debounce_down="0" velocity_threshold="0"/>
         </buttons>
         <analogs>
-            <analog name="Turntable P1" devid="Player 1" index="4" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
-            <analog name="Turntable P2" devid="Player 2" index="4" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
+            <analog name="Turntable P1" devid="Player 1" index="4" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
+            <analog name="Turntable P2" devid="Player 2" index="4" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
         </analogs>
         <lights>
             <light name="P1 1" devid="Player 1" index="0"/>
@@ -117,8 +117,8 @@
         <keypad_buttons/>
         <!-- Assumes analog mode. Need to invert direction since this FW is designed for INF. -->
         <analogs>
-            <analog name="Turntable P1" devid="arcin (1p)" index="0" sensivity="1" deadzone="0" deadzone_mirror="false" invert="true" smoothing="false" multiplier="1" relative="false" delay="0"/>
-            <analog name="Turntable P2" devid="arcin (2p)" index="0" sensivity="1" deadzone="0" deadzone_mirror="false" invert="true" smoothing="false" multiplier="1" relative="false" delay="0"/>
+            <analog name="Turntable P1" devid="arcin (1p)" index="0" sensivity="1" deadzone="0" deadzone_mirror="false" invert="true" smoothing="false" multiplier="1"/>
+            <analog name="Turntable P2" devid="arcin (2p)" index="0" sensivity="1" deadzone="0" deadzone_mirror="false" invert="true" smoothing="false" multiplier="1"/>
         </analogs>
         <lights>
             <light name="P1 1" devid="arcin (1p)" index="0"/>
@@ -144,34 +144,34 @@
         <buttons/>
         <keypad_buttons/>
         <analogs>
-            <analog name="Key 1" devid="Analogs key 01-28" index="4" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
-            <analog name="Key 2" devid="Analogs key 01-28" index="5" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
-            <analog name="Key 3" devid="Analogs key 01-28" index="6" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
-            <analog name="Key 4" devid="Analogs key 01-28" index="7" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
-            <analog name="Key 5" devid="Analogs key 01-28" index="8" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
-            <analog name="Key 6" devid="Analogs key 01-28" index="9" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
-            <analog name="Key 7" devid="Analogs key 01-28" index="10" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
-            <analog name="Key 8" devid="Analogs key 01-28" index="11" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
-            <analog name="Key 9" devid="Analogs key 01-28" index="12" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
-            <analog name="Key 10" devid="Analogs key 01-28" index="13" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
-            <analog name="Key 11" devid="Analogs key 01-28" index="14" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
-            <analog name="Key 12" devid="Analogs key 01-28" index="15" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
-            <analog name="Key 13" devid="Analogs key 01-28" index="16" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
-            <analog name="Key 14" devid="Analogs key 01-28" index="17" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
-            <analog name="Key 15" devid="Analogs key 01-28" index="18" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
-            <analog name="Key 16" devid="Analogs key 01-28" index="19" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
-            <analog name="Key 17" devid="Analogs key 01-28" index="20" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
-            <analog name="Key 18" devid="Analogs key 01-28" index="21" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
-            <analog name="Key 19" devid="Analogs key 01-28" index="22" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
-            <analog name="Key 20" devid="Analogs key 01-28" index="23" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
-            <analog name="Key 21" devid="Analogs key 01-28" index="24" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
-            <analog name="Key 22" devid="Analogs key 01-28" index="25" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
-            <analog name="Key 23" devid="Analogs key 01-28" index="26" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
-            <analog name="Key 24" devid="Analogs key 01-28" index="27" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
-            <analog name="Key 25" devid="Analogs key 01-28" index="28" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
-            <analog name="Key 26" devid="Analogs key 01-28" index="29" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
-            <analog name="Key 27" devid="Analogs key 01-28" index="30" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
-            <analog name="Key 28" devid="Analogs key 01-28" index="31" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
+            <analog name="Key 1" devid="Analogs key 01-28" index="4" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
+            <analog name="Key 2" devid="Analogs key 01-28" index="5" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
+            <analog name="Key 3" devid="Analogs key 01-28" index="6" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
+            <analog name="Key 4" devid="Analogs key 01-28" index="7" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
+            <analog name="Key 5" devid="Analogs key 01-28" index="8" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
+            <analog name="Key 6" devid="Analogs key 01-28" index="9" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
+            <analog name="Key 7" devid="Analogs key 01-28" index="10" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
+            <analog name="Key 8" devid="Analogs key 01-28" index="11" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
+            <analog name="Key 9" devid="Analogs key 01-28" index="12" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
+            <analog name="Key 10" devid="Analogs key 01-28" index="13" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
+            <analog name="Key 11" devid="Analogs key 01-28" index="14" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
+            <analog name="Key 12" devid="Analogs key 01-28" index="15" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
+            <analog name="Key 13" devid="Analogs key 01-28" index="16" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
+            <analog name="Key 14" devid="Analogs key 01-28" index="17" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
+            <analog name="Key 15" devid="Analogs key 01-28" index="18" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
+            <analog name="Key 16" devid="Analogs key 01-28" index="19" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
+            <analog name="Key 17" devid="Analogs key 01-28" index="20" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
+            <analog name="Key 18" devid="Analogs key 01-28" index="21" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
+            <analog name="Key 19" devid="Analogs key 01-28" index="22" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
+            <analog name="Key 20" devid="Analogs key 01-28" index="23" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
+            <analog name="Key 21" devid="Analogs key 01-28" index="24" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
+            <analog name="Key 22" devid="Analogs key 01-28" index="25" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
+            <analog name="Key 23" devid="Analogs key 01-28" index="26" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
+            <analog name="Key 24" devid="Analogs key 01-28" index="27" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
+            <analog name="Key 25" devid="Analogs key 01-28" index="28" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
+            <analog name="Key 26" devid="Analogs key 01-28" index="29" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
+            <analog name="Key 27" devid="Analogs key 01-28" index="30" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
+            <analog name="Key 28" devid="Analogs key 01-28" index="31" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
         </analogs>
         <lights>
             <light name="Key 1 R" devid="Lights 01-14" index="0"/>
@@ -277,9 +277,9 @@
         </buttons>
         <keypad_buttons/>
         <analogs>
-            <analog name="Guitar P1 Wail X" devid="Gitaller P1" index="1" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
-            <analog name="Guitar P1 Wail Y" devid="Gitaller P1" index="0" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
-            <analog name="Guitar P1 Wail Z" devid="Gitaller P1" index="5" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
+            <analog name="Guitar P1 Wail X" devid="Gitaller P1" index="1" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
+            <analog name="Guitar P1 Wail Y" devid="Gitaller P1" index="0" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
+            <analog name="Guitar P1 Wail Z" devid="Gitaller P1" index="5" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
         </analogs>
         <lights/>
     <!-- Gen 1 FAUCETWO in HID mode; should also work for later gens -->
@@ -296,8 +296,8 @@
         </buttons>
         <keypad_buttons/>
         <analogs>
-            <analog name="VOL-L" devid="Buttons (MI_01)" index="1" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
-            <analog name="VOL-R" devid="Buttons (MI_01)" index="0" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1" relative="false" delay="0"/>
+            <analog name="VOL-L" devid="Buttons (MI_01)" index="1" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
+            <analog name="VOL-R" devid="Buttons (MI_01)" index="0" sensivity="1" deadzone="0" deadzone_mirror="false" invert="false" smoothing="false" multiplier="1"/>
         </analogs>
         <lights>
             <light name="BT-A" devid="Lights (MI_02)" index="24"/>

--- a/src/spice2x/cfg/analog.cpp
+++ b/src/spice2x/cfg/analog.cpp
@@ -237,8 +237,7 @@ float Analog::applyDeadzone(float raw_value) {
         deadzone = -deadzone;
     }
 
-    // relative mode assumes that user is using a stick, so center is neutral regardless of analog type
-    if (getType() != GameAPI::Analogs::AnalogType::LinearPositive || isRelativeMode()) {
+    if (getType() != GameAPI::Analogs::AnalogType::LinearPositive) {
 
         // calculate values
         const auto delta = value - 0.5f;

--- a/src/spice2x/cfg/analog.h
+++ b/src/spice2x/cfg/analog.h
@@ -63,14 +63,6 @@ private:
     float divisor_previous_value = 0.5f;
     unsigned short divisor_region = 0;
 
-    // relative input mode
-    float absolute_value_for_rel_mode = 0.5f;
-    bool relative_mode = false;
-
-    // circular buffer (delayed input)
-    int delay_buffer_depth = 0;
-    std::queue<float> delay_buffer;
-
     float calculateAngularDifference(float old_rads, float new_rads);
     float normalizeAngle(float rads);
     float normalizeAnalogValue(float value);
@@ -106,8 +98,6 @@ public:
         smoothing = false;
         deadzone_mirror = false;
         setMultiplier(1);
-        setRelativeMode(false);
-        setDelayBufferDepth(0);
         setLastState(0.5f);
     }
 
@@ -203,33 +193,6 @@ public:
 
     inline void setLastState(float last_state) {
         this->last_state = last_state;
-    }
-
-    inline bool isRelativeMode() const {
-        return this->relative_mode;
-    }
-
-    inline void setRelativeMode(bool relative_mode) {
-        this->relative_mode = relative_mode;
-        this->absolute_value_for_rel_mode = 0.5f;
-    }
-
-    inline float getAbsoluteValue(float relative_delta) {
-        this->absolute_value_for_rel_mode =
-            normalizeAnalogValue(this->absolute_value_for_rel_mode + relative_delta);
-        return this->absolute_value_for_rel_mode;
-    }
-
-    inline int getDelayBufferDepth() const {
-        return this->delay_buffer_depth;
-    }
-
-    inline void setDelayBufferDepth(int depth) {
-        this->delay_buffer_depth = depth;
-    }
-
-    inline std::queue<float> &getDelayBuffer() {
-        return this->delay_buffer;
     }
 
     inline GameAPI::Analogs::AnalogType getType() const {

--- a/src/spice2x/cfg/api.cpp
+++ b/src/spice2x/cfg/api.cpp
@@ -679,34 +679,12 @@ float GameAPI::Analogs::getState(rawinput::RawInputManager *manager, rawinput::D
             }
 
             // deadzone
-            // do not apply deadzone to circular analogs since it doesn't make sense (except in relative mode)
-            if (analog.isDeadzoneSet() &&
-                (analog.getType() != AnalogType::Circular || analog.isRelativeMode())) {
+            // do not apply deadzone to circular analogs since it doesn't make sense
+            if (analog.isDeadzoneSet() && analog.getType() != AnalogType::Circular) {
                 value = analog.applyDeadzone(value);
             }
 
-            if (analog.isRelativeMode()) {
-                float relative_delta = value - 0.5f;
-                // built-in scaling to make values reasonable
-                relative_delta /= 80.f;
-
-                // integer multiplier/divisor
-                const auto mult = analog.getMultiplier();
-                if (mult < -1) {
-                    relative_delta /= -mult;
-                } else if (1 < mult) {
-                    relative_delta *= mult;
-                }
-
-                // sensitivity (ranges from 0.0 to 4.0)
-                if (analog.isSensitivitySet()) {
-                    relative_delta *= analog.getSensitivity();
-                }
-
-                // translate relative movement to absolute value
-                value = analog.getAbsoluteValue(relative_delta);
-
-            } else if (analog.getType() == AnalogType::Circular) {
+            if (analog.getType() == AnalogType::Circular) {
                 // integer multiplier
                 value = analog.applyMultiplier(value);
 
@@ -782,29 +760,6 @@ float GameAPI::Analogs::getState(rawinput::RawInputManager *manager, rawinput::D
                     value = std::clamp(value, 0.f, 1.f);
                 }
             }
-
-            // delay
-            if (0 < analog.getDelayBufferDepth()) {
-                auto& queue = analog.getDelayBuffer();
-
-                // ensure the queue isn't too long; drop old values
-                while (analog.getDelayBufferDepth() <= (int)queue.size()) {
-                    queue.pop();
-                }
-
-                // always push new value
-                queue.push(value);
-
-                // get a new value to return
-                if ((int)queue.size() < analog.getDelayBufferDepth()) {
-                    // not enough in the queue, stall for now, shouldn't happen often
-                    value = analog.getLastState();
-                } else {
-                    value = queue.front();
-                    queue.pop();
-                }
-            }
-
             break;
         }
         case rawinput::MIDI: {

--- a/src/spice2x/cfg/config.cpp
+++ b/src/spice2x/cfg/config.cpp
@@ -252,8 +252,6 @@ bool Config::addGame(Game &game) {
                 bool invert = false;
                 bool smoothing = false;
                 int multiplier = 1;
-                bool relative_mode = false;
-                int delay_buffer_depth = 0;
                 tinyxml2::XMLError err1 = gameAnalogNode->QueryIntAttribute("index", &index);
                 gameAnalogNode->QueryFloatAttribute("sensivity", &sensitivity);
                 gameAnalogNode->QueryFloatAttribute("deadzone", &deadzone);
@@ -261,8 +259,6 @@ bool Config::addGame(Game &game) {
                 gameAnalogNode->QueryBoolAttribute("invert", &invert);
                 gameAnalogNode->QueryBoolAttribute("smoothing", &smoothing);
                 gameAnalogNode->QueryIntAttribute("multiplier", &multiplier);
-                gameAnalogNode->QueryBoolAttribute("relative", &relative_mode);
-                gameAnalogNode->QueryIntAttribute("delay", &delay_buffer_depth);
                 const char *devid = gameAnalogNode->Attribute("devid");
 
                 if (err1 != tinyxml2::XMLError::XML_SUCCESS || !devid) {
@@ -277,8 +273,6 @@ bool Config::addGame(Game &game) {
                     gameAnalogNode->SetAttribute("invert", it.getInvert());
                     gameAnalogNode->SetAttribute("smoothing", it.getSmoothing());
                     gameAnalogNode->SetAttribute("multiplier", it.getMultiplier());
-                    gameAnalogNode->SetAttribute("relative", it.isRelativeMode());
-                    gameAnalogNode->SetAttribute("delay", it.getDelayBufferDepth());
                     gameAnalogsNode->InsertEndChild(gameAnalogNode);
                 } else {
                     it.setIndex(static_cast<unsigned short int>(index));
@@ -289,8 +283,6 @@ bool Config::addGame(Game &game) {
                     it.setInvert(invert);
                     it.setSmoothing(smoothing);
                     it.setMultiplier(multiplier);
-                    it.setRelativeMode(relative_mode);
-                    it.setDelayBufferDepth(delay_buffer_depth);
                 }
             } else {
                 gameAnalogNode = this->configFile.NewElement("analog");
@@ -302,8 +294,6 @@ bool Config::addGame(Game &game) {
                 gameAnalogNode->SetAttribute("invert", it.getInvert());
                 gameAnalogNode->SetAttribute("smoothing", it.getSmoothing());
                 gameAnalogNode->SetAttribute("multiplier", it.getMultiplier());
-                gameAnalogNode->SetAttribute("relative", it.isRelativeMode());
-                gameAnalogNode->SetAttribute("delay", it.getDelayBufferDepth());
                 gameAnalogNode->SetAttribute("devid", it.getDeviceIdentifier().c_str());
                 gameAnalogsNode->InsertEndChild(gameAnalogNode);
             }
@@ -457,8 +447,6 @@ bool Config::addGame(Game &game) {
             gameAnalogNode->SetAttribute("invert", it.getInvert());
             gameAnalogNode->SetAttribute("smoothing", it.getSmoothing());
             gameAnalogNode->SetAttribute("multiplier", it.getMultiplier());
-            gameAnalogNode->SetAttribute("relative", it.isRelativeMode());
-            gameAnalogNode->SetAttribute("delay", it.getDelayBufferDepth());
             gameAnalogsNode->InsertEndChild(gameAnalogNode);
         }
 
@@ -691,8 +679,6 @@ bool Config::updateBinding(const Game &game, const Analog &analog) {
         gameAnalogNode->SetAttribute("invert", analog.getInvert());
         gameAnalogNode->SetAttribute("smoothing", analog.getSmoothing());
         gameAnalogNode->SetAttribute("multiplier", analog.getMultiplier());
-        gameAnalogNode->SetAttribute("relative", analog.isRelativeMode());
-        gameAnalogNode->SetAttribute("delay", analog.getDelayBufferDepth());
         gameAnalogNode->SetAttribute("devid", analog.getDeviceIdentifier().c_str());
     } else {
         gameAnalogNode = this->configFile.NewElement("analog");
@@ -703,8 +689,6 @@ bool Config::updateBinding(const Game &game, const Analog &analog) {
         gameAnalogNode->SetAttribute("invert", analog.getInvert());
         gameAnalogNode->SetAttribute("smoothing", analog.getSmoothing());
         gameAnalogNode->SetAttribute("multiplier", analog.getMultiplier());
-        gameAnalogNode->SetAttribute("relative", analog.isRelativeMode());
-        gameAnalogNode->SetAttribute("delay", analog.getDelayBufferDepth());
         gameAnalogNode->SetAttribute("devid", analog.getDeviceIdentifier().c_str());
         gameAnalogsNode->InsertEndChild(gameAnalogNode);
     }
@@ -1141,8 +1125,6 @@ std::vector<Analog> Config::getAnalogs(const std::string &gameName) {
                 bool invert = false;
                 bool smoothing = false;
                 int multiplier = 1;
-                bool relative_mode = false;
-                int delay_buffer_depth = 0;
                 gameAnalogNode->QueryIntAttribute("index", &index);
                 gameAnalogNode->QueryFloatAttribute("sensivity", &sensitivity);
                 gameAnalogNode->QueryFloatAttribute("deadzone", &deadzone);
@@ -1150,8 +1132,6 @@ std::vector<Analog> Config::getAnalogs(const std::string &gameName) {
                 gameAnalogNode->QueryBoolAttribute("invert", &invert);
                 gameAnalogNode->QueryBoolAttribute("smoothing", &smoothing);
                 gameAnalogNode->QueryIntAttribute("multiplier", &multiplier);
-                gameAnalogNode->QueryBoolAttribute("relative", &relative_mode);
-                gameAnalogNode->QueryIntAttribute("delay", &delay_buffer_depth);
                 const char *devid = gameAnalogNode->Attribute("devid");
 
                 // create analog and add to list
@@ -1163,8 +1143,6 @@ std::vector<Analog> Config::getAnalogs(const std::string &gameName) {
                 analog.setInvert(invert);
                 analog.setSmoothing(smoothing);
                 analog.setMultiplier(multiplier);
-                analog.setRelativeMode(relative_mode);
-                analog.setDelayBufferDepth(delay_buffer_depth);
                 if (devid) {
                     analog.setDeviceIdentifier(devid);
                 }

--- a/src/spice2x/cfg/controller_presets.cpp
+++ b/src/spice2x/cfg/controller_presets.cpp
@@ -69,8 +69,6 @@ namespace overlay::windows {
         el->SetAttribute("invert", analog.invert);
         el->SetAttribute("smoothing", analog.smoothing);
         el->SetAttribute("multiplier", analog.multiplier);
-        el->SetAttribute("relative", analog.relative_mode);
-        el->SetAttribute("delay", analog.delay_buffer_depth);
         parent->InsertEndChild(el);
     }
 
@@ -92,8 +90,6 @@ namespace overlay::windows {
         el->QueryBoolAttribute("invert", &a.invert);
         el->QueryBoolAttribute("smoothing", &a.smoothing);
         el->QueryIntAttribute("multiplier", &a.multiplier);
-        el->QueryBoolAttribute("relative", &a.relative_mode);
-        el->QueryIntAttribute("delay", &a.delay_buffer_depth);
 
         return a;
     }

--- a/src/spice2x/overlay/windows/config.cpp
+++ b/src/spice2x/overlay/windows/config.cpp
@@ -2522,9 +2522,9 @@ namespace overlay::windows {
                     }
                 }
 
-                // hide deadzone for circular analog since it doesn't make any sense (unless in relative mode)
+                // hide deadzone for circular analog since it doesn't make any sense
                 if ((device->type == rawinput::HID || device->type == rawinput::MIDI) &&
-                    ((analog.getType() != GameAPI::Analogs::AnalogType::Circular) || analog.isRelativeMode())) {
+                    analog.getType() != GameAPI::Analogs::AnalogType::Circular) {
                     auto deadzone = analog.getDeadzone();
 
                     // for back compat (before each analog had a type)
@@ -2568,46 +2568,16 @@ namespace overlay::windows {
                     if (analog.getType() == GameAPI::Analogs::AnalogType::Circular) {
                         // smoothing
                         bool smoothing = analog.getSmoothing();
-                        ImGui::BeginDisabled(analog.isRelativeMode());
                         ImGui::Checkbox("Smooth Axis (adds latency)", &smoothing);
                         ImGui::SameLine();
                         ImGui::HelpMarker(
                             "Apply a moving average algorithm; intended for angular input (knobs, turntables). "
                             "Adds a slight bit of latency to input as the algorithm averages out recent input. "
                             "Only use in dire situations where the input is too jittery for the game.");
-                        ImGui::EndDisabled();
                         if (smoothing != analog.getSmoothing()) {
                             analog.setSmoothing(smoothing);
                         }
                     }
-
-                    // relative input mode
-                    bool relative_analog = analog.isRelativeMode();
-                    ImGui::Checkbox("Relative Axis", &relative_analog);
-                    ImGui::SameLine();
-                    ImGui::HelpMarker(
-                        "Use relative directional input instead of positional values.\n\n"
-                        "Can be used to translate analog sticks to knob input, for example.\n\n"
-                        "WARNING: speed depends on how often the game polls for input! "
-                        "Strongly recommended that you go into the game's test menu instead "
-                        "of adjusting in spicecfg.");
-                    if (relative_analog != analog.isRelativeMode()) {
-                        analog.setRelativeMode(relative_analog);
-                    }
-
-                    // delay buffer
-                    int delay = analog.getDelayBufferDepth();
-                    if (ImGui::InputInt("Delay (experimental)", &delay, 1, 10)) {
-                        delay = CLAMP(delay, 0, 256);
-                        analog.setDelayBufferDepth(delay);
-                    }
-                    ImGui::SameLine();
-                    ImGui::HelpMarker(
-                        "Adds a delay to input. This is poll-based, not time-based.\n\n"
-                        "WARNING: delay depends on how often the game polls for input! "
-                        "Strongly recommended that you go into the game's test menu instead "
-                        "of adjusting in spicecfg. Close all overlays as that will affect "
-                        "how input delay is calculated.");
                 }
             }
 
@@ -5419,8 +5389,6 @@ namespace overlay::windows {
                         a.setInvert(ta.invert);
                         a.setSmoothing(ta.smoothing);
                         a.setMultiplier(ta.multiplier);
-                        a.setRelativeMode(ta.relative_mode);
-                        a.setDelayBufferDepth(ta.delay_buffer_depth);
                         ::Config::getInstance().updateBinding(game, a);
                         break;
                     }

--- a/src/spice2x/overlay/windows/controller_presets.h
+++ b/src/spice2x/overlay/windows/controller_presets.h
@@ -71,8 +71,6 @@ namespace overlay::windows {
         bool invert = false;
         bool smoothing = false;
         int multiplier = 1;
-        bool relative_mode = false;
-        int delay_buffer_depth = 0;
 
         bool is_device() const { return !device_identifier.empty(); }
         bool is_unbound() const { return device_identifier.empty() && index == 0xFF; }
@@ -89,8 +87,6 @@ namespace overlay::windows {
             invert = a.getInvert();
             smoothing = a.getSmoothing();
             multiplier = a.getMultiplier();
-            relative_mode = a.isRelativeMode();
-            delay_buffer_depth = a.getDelayBufferDepth();
         }
     };
 


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
Related to #181 

## Description of change
This PR removes two features marked as "experimental" for analog axis - `Delay` and `Relative Axis`.

They have been in spice as experimental option for almost 2 years.. but they have a fundamental problem of being tied to how often the analog is polled. Not just how often the game's I/O emulation code polls it, but literally any source (spice API, overlay, etc).

For `Delay`, the only real usage I'm aware of is for #181 which is delaying IIDX turntable input. For this, I will follow up with a separate PR that adds back the delay option specifically for IIDX.

For `Relative Axis` - I'm not quite sure if any one actually uses this. This could be implemented per-game if some game demands it. Polaris Chord already has one, for example.

## Testing

