### PR TITLE
overlay: setting button as always-on

### DIFF
--- a/src/spice2x/cfg/button.cpp
+++ b/src/spice2x/cfg/button.cpp
@@ -306,7 +306,10 @@ std::string Button::getDisplayString(rawinput::RawInputManager* manager) {
     std::string vKeyString = fmt::format("{:#x}", vKey);
 
     // device must be existing
-    if (this->device_identifier.empty() && vKey == INVALID_VKEY) {
+    if (this->isNaive() && vKey == INVALID_VKEY) {
+        if (this->getInvert()) {
+            return "(always on)";
+        }
         return "";
     }
 

--- a/src/spice2x/overlay/windows/config.cpp
+++ b/src/spice2x/overlay/windows/config.cpp
@@ -2070,11 +2070,27 @@ namespace overlay::windows {
                                 "This setting will add noticable input lag.");
             }
 
-            // invert
-            bool invert = button->getInvert();
-            if (ImGui::Checkbox("Invert Resulting Value", &invert)) {
-                button->setInvert(invert);
-                dirty = true;
+            // invert (widget hidden for naive + 0xff)
+            if (!(button->isNaive() && button->getVKey() == INVALID_VKEY)) {
+                bool invert = button->getInvert();
+                if (ImGui::Checkbox("Invert Resulting Value", &invert)) {
+                    button->setInvert(invert);
+                    dirty = true;
+                }
+            }
+            
+            // always on (naive + vkey 0xff + invert)
+            if (button->isNaive()) {
+                bool always_on = button->isNaive() && button->getVKey() == INVALID_VKEY && button->getInvert();
+                if (ImGui::Checkbox("Always On", &always_on)) {
+                    if (always_on) {
+                        button->setVKey(INVALID_VKEY);
+                        button->setInvert(true);
+                    } else {
+                        button->setInvert(false);
+                    }
+                    dirty = true;
+                }
             }
 
             // bat threshold

--- a/src/spice2x/overlay/windows/config.cpp
+++ b/src/spice2x/overlay/windows/config.cpp
@@ -2078,9 +2078,9 @@ namespace overlay::windows {
                     dirty = true;
                 }
             }
-            
+
             // always on (naive + vkey 0xff + invert)
-            if (button->isNaive()) {
+            if (button->isNaive() && alt_index == 0) {
                 bool always_on = button->isNaive() && button->getVKey() == INVALID_VKEY && button->getInvert();
                 if (ImGui::Checkbox("Always On", &always_on)) {
                     if (always_on) {

--- a/src/spice2x/overlay/windows/config.cpp
+++ b/src/spice2x/overlay/windows/config.cpp
@@ -2003,6 +2003,7 @@ namespace overlay::windows {
                 int vKey = button->getVKey();
                 if (ImGui::InputInt(button->isNaive() ? "Virtual Key" : "Index", &vKey, 1, 1)) {
                     button->setVKey(vKey);
+                    button->setInvert(false);
                 }
                 if (ImGui::IsItemDeactivatedAfterEdit()) {
                     dirty = true;


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
n/a

## Description of change

Add a checkbox to the buttons edit dialog that lets you set a device as "always on", accomplished by setting the device to `Naive`, vkey to `0xff` (invalid), and `Invert`.

No backend rawinput changes.

## Testing
