### PR TITLE
overlay: prevent overlay from queueing up keyboard input while overlay is not visible

### DIFF
--- a/src/spice2x/hooks/graphics/graphics.cpp
+++ b/src/spice2x/hooks/graphics/graphics.cpp
@@ -1401,7 +1401,7 @@ void update_monitor_on_boot(std::optional<graphics_orientation> target_orientati
 }
 
 void update_monitor_at_runtime() {
-    if (monitor_settings_changed) {
+    if (!GRAPHICS_WINDOWED && monitor_settings_changed) {
         log_misc("graphics", "applying monitor updates at runtime as window regained focus...");
         update_monitor(false, target_orientation_on_boot, target_refresh_rate_on_boot);   
     }

--- a/src/spice2x/overlay/imgui/impl_spice.cpp
+++ b/src/spice2x/overlay/imgui/impl_spice.cpp
@@ -352,6 +352,8 @@ void ImGui_ImplSpice_NewFrame() {
     // only process new input from devices if window is in focus
     // (when not in focus, all mouse/keyboard events are treated as released)
     const auto accept_new_input = superexit::has_focus() && !rawinput::OS_WINDOW_ACTIVE;
+    const auto accept_new_keyboard_input = accept_new_input &&
+        (overlay::OVERLAY && overlay::OVERLAY->has_focus());
 
     // remember old state
     std::array<BYTE, VKEY_MAX> KeysDownOld;
@@ -410,7 +412,7 @@ void ImGui_ImplSpice_NewFrame() {
                     break;
                 }
                 case rawinput::KEYBOARD: {
-                    if (accept_new_input) {
+                    if (accept_new_keyboard_input) {
                         // iterate all virtual key codes
                         for (size_t vKey = 0; vKey < VKEY_MAX; vKey++) {
                             // get state (combined from all pages)


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
Fixes #675

Yet another regression from #604 

## Description of change
When overlay was hidden (not visible) it was still accepting keyboard input, so when it became visible again the queued up keystrokes got processed all at once.

Also, fix a bug with monitor settings update kicking in when in windowed mode - this really should have been only for full screen.

## Testing
Tested DDR windowed / full screen, TDJ with subscreen overlay windowed / fullscreen.
