### PR TITLE
launcher: prevent early hook from launching in standalone configurator

### DIFF
--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -1532,16 +1532,18 @@ int main_implementation(int argc, char *argv[]) {
     }
 
     // early hooks
-    for (auto &hook : early_hooks) {
-        log_info("launcher", "loading early hook DLL {}", hook);
-        libutils::print_dll_info(hook);
-        HMODULE module;
-        if (!(module = libutils::try_library(hook))) {
-            log_warning("launcher", "failed to load early hook {}: {}", hook, get_last_error_string());
-            deferredlogs::defer_error_messages({
-                fmt::format("failed to load early hook {}:", hook),
-                fmt::format("    {}", get_last_error_string())
-                });
+    if (!cfg_run) {
+        for (auto &hook : early_hooks) {
+            log_info("launcher", "loading early hook DLL {}", hook);
+            libutils::print_dll_info(hook);
+            HMODULE module;
+            if (!(module = libutils::try_library(hook))) {
+                log_warning("launcher", "failed to load early hook {}: {}", hook, get_last_error_string());
+                deferredlogs::defer_error_messages({
+                    fmt::format("failed to load early hook {}:", hook),
+                    fmt::format("    {}", get_last_error_string())
+                    });
+            }
         }
     }
 


### PR DESCRIPTION
## Description of change
Seems to be an oversight when it was initially implemented; hooks should not load when launching `spicecfg` (or `spice -cfg` or `spice64 -cfg`).
