### PR TITLE
overlay: fix mouse events queued up while overlay is hidden

### DIFF
--- a/src/spice2x/games/ccj/trackball.cpp
+++ b/src/spice2x/games/ccj/trackball.cpp
@@ -113,7 +113,7 @@ namespace games::ccj {
                 static std::chrono::time_point<std::chrono::steady_clock> lastModified = std::chrono::steady_clock::now();
                 static std::chrono::milliseconds debounceDuration(100);
                 auto currentTime = std::chrono::steady_clock::now();
-                bool pressed = get_async_secondary_mouse() & 0x8000;
+                bool pressed = get_async_secondary_mouse();
                 bool focused = GetForegroundWindow() == hWnd;
 
                 if (focused && MOUSE_TRACKBALL_USE_TOGGLE && pressed && (currentTime - lastModified > debounceDuration)) {

--- a/src/spice2x/launcher/superexit.cpp
+++ b/src/spice2x/launcher/superexit.cpp
@@ -67,7 +67,9 @@ namespace superexit {
                     }
                 }
 
-                bool async_key_exit = GetAsyncKeyState(VK_MENU) && GetAsyncKeyState(VK_F4);
+                bool async_key_exit =
+                    (GetAsyncKeyState(VK_MENU) & 0x8000) != 0 &&
+                    (GetAsyncKeyState(VK_F4) & 0x8000) != 0;
 
                 bool overlay_exit = false;
                 auto buttons = games::get_buttons_overlay(eamuse_get_game());

--- a/src/spice2x/overlay/imgui/impl_spice.cpp
+++ b/src/spice2x/overlay/imgui/impl_spice.cpp
@@ -351,9 +351,8 @@ void ImGui_ImplSpice_NewFrame() {
 
     // only process new input from devices if window is in focus
     // (when not in focus, all mouse/keyboard events are treated as released)
-    const auto accept_new_input = superexit::has_focus() && !rawinput::OS_WINDOW_ACTIVE;
-    const auto accept_new_keyboard_input = accept_new_input &&
-        (overlay::OVERLAY && overlay::OVERLAY->has_focus());
+    const auto overlay_visible = overlay::OVERLAY && overlay::OVERLAY->get_active();
+    const auto accept_new_input = superexit::has_focus() && !rawinput::OS_WINDOW_ACTIVE && overlay_visible;
 
     // remember old state
     std::array<BYTE, VKEY_MAX> KeysDownOld;
@@ -368,9 +367,11 @@ void ImGui_ImplSpice_NewFrame() {
     g_KeysDown.fill(false);
 
     // apply windows mouse buttons
-    g_MouseDown[ImGuiMouseButton_Left] |= (get_async_primary_mouse()) != 0;
-    g_MouseDown[ImGuiMouseButton_Right] |= (get_async_secondary_mouse()) != 0;
-    g_MouseDown[ImGuiMouseButton_Middle] |= (GetAsyncKeyState(VK_MBUTTON)) != 0;
+    if (accept_new_input) {
+        g_MouseDown[ImGuiMouseButton_Left] |= get_async_primary_mouse();
+        g_MouseDown[ImGuiMouseButton_Right] |= get_async_secondary_mouse();
+        g_MouseDown[ImGuiMouseButton_Middle] |= (GetAsyncKeyState(VK_MBUTTON) & 0x8000) != 0;
+    }
 
     // read new keys state
     static long mouse_wheel_last = 0;
@@ -412,7 +413,7 @@ void ImGui_ImplSpice_NewFrame() {
                     break;
                 }
                 case rawinput::KEYBOARD: {
-                    if (accept_new_keyboard_input) {
+                    if (accept_new_input) {
                         // iterate all virtual key codes
                         for (size_t vKey = 0; vKey < VKEY_MAX; vKey++) {
                             // get state (combined from all pages)

--- a/src/spice2x/overlay/windows/config.cpp
+++ b/src/spice2x/overlay/windows/config.cpp
@@ -948,7 +948,7 @@ namespace overlay::windows {
 
             // grab current keyboard state
             for (unsigned short int i = 0x01; i < 0xFF; i++) {
-                buttons_keyboard_state[i] = GetAsyncKeyState(i) != 0;
+                buttons_keyboard_state[i] = (GetAsyncKeyState(i) & 0x8000) != 0;
             }
         }
         if (ImGui::IsItemHovered(ImGui::TOOLTIP_FLAGS)) {
@@ -1615,7 +1615,7 @@ namespace overlay::windows {
                 // use care when iterating over the result (could result in torn reads)
                 bool keyboard_state_new[sizeof(buttons_keyboard_state)];
                 for (size_t i = 0; i < sizeof(keyboard_state_new); i++) {
-                    keyboard_state_new[i] = GetAsyncKeyState(i) != 0;
+                    keyboard_state_new[i] = (GetAsyncKeyState(i) & 0x8000) != 0;
                 }
 
                 // detect key presses

--- a/src/spice2x/util/utils.h
+++ b/src/spice2x/util/utils.h
@@ -319,14 +319,14 @@ bool acquire_shutdown_privs();
 
 void generate_ea_card(char card[17]);
 
-static inline int get_async_primary_mouse() {
+static inline bool get_async_primary_mouse() {
     int vk = GetSystemMetrics(SM_SWAPBUTTON) ? VK_RBUTTON : VK_LBUTTON;
-    return GetAsyncKeyState(vk);
+    return (GetAsyncKeyState(vk) & 0x8000) != 0;
 }
 
-static inline int get_async_secondary_mouse() {
+static inline bool get_async_secondary_mouse() {
     int vk = GetSystemMetrics(SM_SWAPBUTTON) ? VK_LBUTTON : VK_RBUTTON;
-    return GetAsyncKeyState(vk);
+    return (GetAsyncKeyState(vk) & 0x8000) != 0;
 }
 
 static inline bool parse_width_height(const std::string wh, std::pair<uint32_t, uint32_t> &result) {


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
continuation of #677

## Description of change
When overlay was hidden, when mouse buttons were clicked, they were queued up and replayed when overlay became visible again.

This is due to improper usage of `GetAsyncKeyState`, per documentation.

## Testing

