### PR TITLE
jb: introduce new algorithm for touch

### DIFF
--- a/src/spice2x/games/jb/jb.cpp
+++ b/src/spice2x/games/jb/jb.cpp
@@ -19,7 +19,7 @@
 namespace games::jb {
 
     // touch stuff
-    bool TOUCH_LEGACY_BOX = false;
+    bool TOUCH_LEGACY_BOX = true;
     static bool TOUCH_ENABLE = false;
     static bool TOUCH_ATTACHED = false;
     static bool IS_PORTRAIT = true;
@@ -192,6 +192,12 @@ namespace games::jb {
 
         // enable touch
         TOUCH_ENABLE = true;
+
+        if (TOUCH_LEGACY_BOX) {
+            log_info("jubeat", "using 'legacy' touch targets");
+        } else {
+            log_info("jubeat", "using 'accurate' touch targets");
+        }
 
         // enable debug logging of gftools
         HMODULE gftools = libutils::try_module("gftools.dll");

--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -1147,9 +1147,13 @@ int main_implementation(int argc, char *argv[]) {
         sysutils::SECOND_MONITOR_OVERRIDE = options[launcher::Options::IIDXSubMonitorOverride].value_text();
     }
 
-    if (options[launcher::Options::spice2x_JubeatLegacyTouch].value_bool()) {
-        games::jb::TOUCH_LEGACY_BOX = true;
+    // note: spice2x_JubeatLegacyTouch is deprecated since legacy is now the default
+    if (options[launcher::Options::JubeatTouchAlgo].is_active()) {
+        if (options[launcher::Options::JubeatTouchAlgo].value_text() == "accurate") {
+            games::jb::TOUCH_LEGACY_BOX = false;
+        }
     }
+
     if (options[launcher::Options::spice2x_RBTouchScale].is_active()) {
         games::rb::TOUCH_SCALING = options[launcher::Options::spice2x_RBTouchScale].value_uint32();
     }

--- a/src/spice2x/launcher/options.cpp
+++ b/src/spice2x/launcher/options.cpp
@@ -2279,15 +2279,29 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
     },
     {
         // spice2x_JubeatLegacyTouch
-        .title = "JB Legacy Touch Targets",
+        .title = "JB Legacy Touch Targets (Deprecated - use -jubeattouchalgo instead)",
         .name = "sp2x-jubeatlegacytouch",
         .display_name = "jubeatlegacytouch",
         .aliases= "jubeatlegacytouch",
-        .desc = "For touch screen players - use the legacy & less accurate grid-based layout for touch recognition, "
-            "instead of the new & more accurate touch targets. Default: off.",
+        .desc = "Not needed as the default algorithm is already the legacy touch algorithm.",
         .type = OptionType::Bool,
+        .hidden = true,
         .game_name = "Jubeat",
         .category = "Game Options",
+    },
+    {
+        .title = "JB Touch Algorithm",
+        .name = "jubeattouchalgo",
+        .desc = "For touch screen players - choose the touch algorithm to use. "
+            "legacy (default) - evenly divide the grid into 16 squares; touching the gap will trigger the closest button (for most touch screens)\n"
+            "accurate - only the squares are valid touch targets; gaps between buttons will trigger nothing (for AC size touch screens)",
+        .type = OptionType::Enum,
+        .game_name = "Jubeat",
+        .category = "Game Options",
+        .elements = {
+            {"legacy", ""},
+            {"accurate", ""},
+        },
     },
     {
         // spice2x_RBTouchScale

--- a/src/spice2x/launcher/options.h
+++ b/src/spice2x/launcher/options.h
@@ -239,6 +239,7 @@ namespace launcher {
             IIDXWindowedSubscreenBorderless,
             IIDXWindowedSubscreenAlwaysOnTop,
             spice2x_JubeatLegacyTouch,
+            JubeatTouchAlgo,
             spice2x_RBTouchScale,
             spice2x_AsioForceUnload,
             spice2x_IIDXNoESpec,


### PR DESCRIPTION
## Description of change
There was enough feedback that the current algorithm is not ideal for most touch screens because most touch screens are not 24". In the current algorithm touching the gap is no-op, so people think the game is dropping touches.

This PR introduces a new algorithm that inspect touches on the gap and triggers the nearest square.



