### PR TITLE
graphics: hide subscreen window from task bar and alt+tab list when in full screen

### DIFF
--- a/src/spice2x/hooks/graphics/graphics.cpp
+++ b/src/spice2x/hooks/graphics/graphics.cpp
@@ -357,16 +357,24 @@ static HWND WINAPI CreateWindowExA_hook(DWORD dwExStyle, LPCSTR lpClassName, LPC
     bool is_popn_sub_window = avs::game::is_model("M39") && window_name.ends_with("Sub Screen");
     bool is_gfdm_sub_window = games::gitadora::is_arena_model() && window_name.ends_with("SMALL");
 
-    // hide maximize button (prevent misaligned touches)
-    if ((is_tdj_sub_window && GRAPHICS_IIDX_WSUB) || is_sdvx_sub_window || is_gfdm_sub_window || is_popn_sub_window) {
+    // update style / ex-style
+    if (is_tdj_sub_window || is_sdvx_sub_window || is_gfdm_sub_window || is_popn_sub_window) {
+        // hide maximize button (prevent misaligned touches)
         dwStyle &= ~(WS_MAXIMIZEBOX);
-    }
-    // mouse clicks become misaligned when resized
-    if (is_gfdm_sub_window) {
+
+        // mouse clicks become misaligned when resized
         dwStyle &= ~(WS_SIZEBOX);
-    }
-    if ((is_tdj_sub_window || is_sdvx_sub_window || is_popn_sub_window) && GRAPHICS_WSUB_BORDERLESS) {
-        dwStyle &= ~(WS_OVERLAPPEDWINDOW);
+
+        // borderless
+        if (GRAPHICS_WINDOWED && GRAPHICS_WSUB_BORDERLESS) {
+            dwStyle &= ~(WS_OVERLAPPEDWINDOW);
+        }
+
+        // don't show the sub window on task bar / alt-tab targets
+        if (!GRAPHICS_WINDOWED) {
+            dwExStyle &= ~(WS_EX_APPWINDOW);
+            dwExStyle |= WS_EX_TOOLWINDOW;
+        }
     }
 
     if (is_sdvx_sub_window) {


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
n/a

## Description of change
When booting in fullscreen, hide the subscreen from the alt+tab list and from the task bar. Alt-tabbing to it does nothing, so this is just to avoid confusion.

No change to windowed mode.

## Testing
Tested TDJ/SDVX/Popn. Didn't test Gitadora but it's probably fine..
