### PR TITLE
[+] Hide sides on gitadora 𝛿

### DIFF
--- a/src/spice2x/hooks/graphics/backends/d3d9/d3d9_device.cpp
+++ b/src/spice2x/hooks/graphics/backends/d3d9/d3d9_device.cpp
@@ -253,15 +253,16 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DDevice9::CreateAdditionalSwapChain(
 {
     WRAP_VERBOSE;
 
-    HRESULT hr = pReal->CreateAdditionalSwapChain(pPresentationParameters, ppSwapChain);
-
     int index = 0;
     bool create_swap_chain = false;
+    bool create_fake_swap_chain = false;
     if (avs::game::is_model({"LDJ", "KFC", "M39"})) {
         create_swap_chain = true;
 
     } else if (games::gitadora::is_arena_model() &&
-        (GRAPHICS_FORCE_SINGLE_ADAPTER || GRAPHICS_PREVENT_SECONDARY_WINDOW)) {
+        (GRAPHICS_FORCE_SINGLE_ADAPTER ||
+            GRAPHICS_PREVENT_SECONDARY_WINDOW ||
+            GRAPHICS_GITADORA_HIDE_SIDE_WINDOWS)) {
         if (pPresentationParameters->BackBufferWidth == 800) {
             // SMALL (subscreen)
             create_swap_chain = true;
@@ -273,10 +274,31 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DDevice9::CreateAdditionalSwapChain(
             if (sub_swapchain[index] || fake_sub_swapchain[index]) {
                 index = 2;
             }
+            create_fake_swap_chain = GRAPHICS_GITADORA_HIDE_SIDE_WINDOWS &&
+                !GRAPHICS_PREVENT_SECONDARY_WINDOW;
         } else {
             log_warning("graphics::d3d9", "unknown swap chain detected in CreateAdditionalSwapChain");
         }
     }
+
+    if (create_fake_swap_chain) {
+        if (!fake_sub_swapchain[index]) {
+            log_info(
+                "graphics::d3d9",
+                "CreateAdditionalSwapChain called for hidden GITADORA side swap chain {}, "
+                "using fake swap chain",
+                index);
+
+            fake_sub_swapchain[index] =
+                new FakeIDirect3DSwapChain9(this, pPresentationParameters, false);
+        }
+        fake_sub_swapchain[index]->AddRef();
+        *ppSwapChain = static_cast<IDirect3DSwapChain9 *>(fake_sub_swapchain[index]);
+
+        return D3D_OK;
+    }
+
+    HRESULT hr = pReal->CreateAdditionalSwapChain(pPresentationParameters, ppSwapChain);
 
     if (create_swap_chain) {
         log_misc(

--- a/src/spice2x/hooks/graphics/graphics.cpp
+++ b/src/spice2x/hooks/graphics/graphics.cpp
@@ -359,8 +359,8 @@ static HWND WINAPI CreateWindowExA_hook(DWORD dwExStyle, LPCSTR lpClassName, LPC
     bool is_sdvx_sub_window = avs::game::is_model("KFC") && window_name.ends_with(" Sub Screen");
     bool is_popn_sub_window = avs::game::is_model("M39") && window_name.ends_with("Sub Screen");
     bool is_gfdm_sub_window = games::gitadora::is_arena_model() && window_name.ends_with("SMALL");
-    bool is_gfdm_left_window = games::gitadora::is_arena_model() && window_name == "LEFT";
-    bool is_gfdm_right_window = games::gitadora::is_arena_model() && window_name == "RIGHT";
+    bool is_gfdm_left_window = games::gitadora::is_arena_model() && window_name.ends_with("LEFT");
+    bool is_gfdm_right_window = games::gitadora::is_arena_model() && window_name.ends_with("RIGHT");
 
     // update style / ex-style
     if (is_tdj_sub_window || is_sdvx_sub_window || is_gfdm_sub_window || is_popn_sub_window) {

--- a/src/spice2x/hooks/graphics/graphics.cpp
+++ b/src/spice2x/hooks/graphics/graphics.cpp
@@ -39,6 +39,8 @@ struct CaptureData {
 HWND TDJ_SUBSCREEN_WINDOW = nullptr;
 HWND SDVX_SUBSCREEN_WINDOW = nullptr;
 HWND GFDM_SUBSCREEN_WINDOW = nullptr;
+static HWND GFDM_LEFT_WINDOW = nullptr;
+static HWND GFDM_RIGHT_WINDOW = nullptr;
 HWND POPN_SUBSCREEN_WINDOW = nullptr;
 bool FAKE_SUBSCREEN_ADAPTER = false;
 
@@ -77,6 +79,7 @@ std::optional<uint32_t> GRAPHICS_FORCE_REFRESH_SUB;
 std::optional<int> GRAPHICS_FORCE_VSYNC_BUFFER;
 bool GRAPHICS_FORCE_SINGLE_ADAPTER = false;
 bool GRAPHICS_PREVENT_SECONDARY_WINDOW = false;
+bool GRAPHICS_GITADORA_HIDE_SIDE_WINDOWS = false;
 graphics_dx9on12_state GRAPHICS_9_ON_12_STATE = DX9ON12_AUTO;
 bool GRAPHICS_9_ON_12_REQUESTED_BY_GAME = false;
 bool SUBSCREEN_FORCE_REDRAW = false;
@@ -356,6 +359,8 @@ static HWND WINAPI CreateWindowExA_hook(DWORD dwExStyle, LPCSTR lpClassName, LPC
     bool is_sdvx_sub_window = avs::game::is_model("KFC") && window_name.ends_with(" Sub Screen");
     bool is_popn_sub_window = avs::game::is_model("M39") && window_name.ends_with("Sub Screen");
     bool is_gfdm_sub_window = games::gitadora::is_arena_model() && window_name.ends_with("SMALL");
+    bool is_gfdm_left_window = games::gitadora::is_arena_model() && window_name == "LEFT";
+    bool is_gfdm_right_window = games::gitadora::is_arena_model() && window_name == "RIGHT";
 
     // update style / ex-style
     if (is_tdj_sub_window || is_sdvx_sub_window || is_gfdm_sub_window || is_popn_sub_window) {
@@ -424,6 +429,12 @@ static HWND WINAPI CreateWindowExA_hook(DWORD dwExStyle, LPCSTR lpClassName, LPC
     if (is_gfdm_sub_window && GRAPHICS_WINDOWED && !GRAPHICS_PREVENT_SECONDARY_WINDOW) {
         GFDM_SUBSCREEN_WINDOW = result;
         graphics_hook_subscreen_window(GFDM_SUBSCREEN_WINDOW);
+    }
+    if (is_gfdm_left_window) {
+        GFDM_LEFT_WINDOW = result;
+    }
+    if (is_gfdm_right_window) {
+        GFDM_RIGHT_WINDOW = result;
     }
 
     if (is_popn_sub_window) {
@@ -705,6 +716,13 @@ static BOOL WINAPI ShowWindow_hook(HWND hWnd, int nCmdShow) {
         GRAPHICS_PREVENT_SECONDARY_WINDOW &&
         hWnd != GRAPHICS_HOOKED_WINDOW) {
         log_info("graphics", "ShowWindow_hook - hiding sub window {}", fmt::ptr(hWnd));
+        return true;
+    }
+
+    if (games::gitadora::is_arena_model() &&
+        GRAPHICS_GITADORA_HIDE_SIDE_WINDOWS &&
+        (hWnd == GFDM_LEFT_WINDOW || hWnd == GFDM_RIGHT_WINDOW)) {
+        log_info("graphics", "ShowWindow_hook - hiding GITADORA side window {}", fmt::ptr(hWnd));
         return true;
     }
 

--- a/src/spice2x/hooks/graphics/graphics.h
+++ b/src/spice2x/hooks/graphics/graphics.h
@@ -39,6 +39,7 @@ extern std::optional<uint32_t> GRAPHICS_FORCE_REFRESH_SUB;
 extern std::optional<int> GRAPHICS_FORCE_VSYNC_BUFFER;
 extern bool GRAPHICS_FORCE_SINGLE_ADAPTER;
 extern bool GRAPHICS_PREVENT_SECONDARY_WINDOW;
+extern bool GRAPHICS_GITADORA_HIDE_SIDE_WINDOWS;
 extern std::optional<std::pair<uint32_t, uint32_t>> GRAPHICS_FS_CUSTOM_RESOLUTION;
 extern std::optional<std::pair<uint32_t, uint32_t>> GRAPHICS_FS_CUSTOM_RESOLUTION_SUB;
 extern bool GRAPHICS_FS_ORIENTATION_SWAP;

--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -650,6 +650,9 @@ int main_implementation(int argc, char *argv[]) {
         // for windowed
         GRAPHICS_PREVENT_SECONDARY_WINDOW = true;
     }
+    if (options[launcher::Options::GitaDoraArenaHideSideWindows].value_bool()) {
+        GRAPHICS_GITADORA_HIDE_SIDE_WINDOWS = true;
+    }
     if (options[launcher::Options::GitaDoraWailHold].is_active()) {
         socd::TILT_HOLD_MS = options[launcher::Options::GitaDoraWailHold].value_uint32();
     }

--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -645,14 +645,26 @@ int main_implementation(int argc, char *argv[]) {
     if (options[launcher::Options::GitaDoraCabinetType].is_active()) {
         games::gitadora::CAB_TYPE = options[launcher::Options::GitaDoraCabinetType].value_uint32();
     }
-    if (options[launcher::Options::GitaDoraArenaSingleWindow].value_bool()) {
-        // for full screen
-        GRAPHICS_FORCE_SINGLE_ADAPTER = true;
-        // for windowed
-        GRAPHICS_PREVENT_SECONDARY_WINDOW = true;
+    if (options[launcher::Options::GitaDoraArenaWindowLayout].is_active()) {
+        if (GRAPHICS_WINDOWED) {
+            const auto window_count = options[launcher::Options::GitaDoraArenaWindowLayout].value_uint32();
+            if (window_count == 1) {
+                GRAPHICS_PREVENT_SECONDARY_WINDOW = true;
+            } else if (window_count == 2) {
+                GRAPHICS_GITADORA_HIDE_SIDE_WINDOWS = true;
+            }
+        } else {
+            log_warning("launcher", "-gdawindows only applies with -w; ignoring GitaDora Arena windowed layout");
+        }
     }
-    if (options[launcher::Options::GitaDoraArenaHideSideWindows].value_bool()) {
-        GRAPHICS_GITADORA_HIDE_SIDE_WINDOWS = true;
+    if (options[launcher::Options::GitaDoraArenaSingleWindow].value_bool()) {
+        if (GRAPHICS_WINDOWED) {
+            GRAPHICS_PREVENT_SECONDARY_WINDOW = true;
+            GRAPHICS_GITADORA_HIDE_SIDE_WINDOWS = false;
+        } else {
+            GRAPHICS_FORCE_SINGLE_ADAPTER = true;
+            GRAPHICS_PREVENT_SECONDARY_WINDOW = true;
+        }
     }
     if (options[launcher::Options::GitaDoraWailHold].is_active()) {
         socd::TILT_HOLD_MS = options[launcher::Options::GitaDoraWailHold].value_uint32();

--- a/src/spice2x/launcher/options.cpp
+++ b/src/spice2x/launcher/options.cpp
@@ -1090,6 +1090,18 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .category = "Game Options",
     },
     {
+        // GitaDoraArenaHideSideWindows
+        .title = "GitaDora Arena Hide Side Screens (EXPERIMENTAL)",
+        .name = "gdahideside",
+        .desc = "For Arena Model windowed mode: hide the LEFT and RIGHT side screens, "
+            "but keep the dedicated SMALL touch screen window.\n\n"
+            "This is independent from GitaDora Arena Disable Subscreens. If both are "
+            "enabled, Disable Subscreens takes priority and SMALL is also hidden.",
+        .type = OptionType::Bool,
+        .game_name = "GitaDora",
+        .category = "Game Options",
+    },
+    {
         // GitaDoraLefty
         .title = "GitaDora Lefty Guitar (for Digital Wailing)",
         .name = "gdlefty",

--- a/src/spice2x/launcher/options.cpp
+++ b/src/spice2x/launcher/options.cpp
@@ -1105,16 +1105,22 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .category = "Game Options",
     },
     {
-        // GitaDoraArenaHideSideWindows
-        .title = "GitaDora Arena Hide Side Screens (EXPERIMENTAL)",
-        .name = "gdahideside",
-        .desc = "For Arena Model windowed mode: hide the LEFT and RIGHT side screens, "
-            "but keep the dedicated SMALL touch screen window.\n\n"
-            "This is independent from GitaDora Arena Disable Subscreens. If both are "
-            "enabled, Disable Subscreens takes priority and SMALL is also hidden.",
-        .type = OptionType::Bool,
+        // GitaDoraArenaWindowLayout
+        .title = "GitaDora Arena Windowed Layout (EXPERIMENTAL)",
+        .name = "gdawindows",
+        .desc = "For Arena Model windowed mode (-w): select how many windows to create.\n\n"
+            "4 windows: main + LEFT + RIGHT + SMALL.\n\n"
+            "2 windows: main + SMALL.\n\n"
+            "1 window: main only; use the subscreen overlay for SMALL.\n\n"
+            "Ignored in fullscreen mode.",
+        .type = OptionType::Enum,
         .game_name = "GitaDora",
         .category = "Game Options",
+        .elements = {
+            {"4", "4 windows"},
+            {"2", "2 windows"},
+            {"1", "1 window"},
+        },
     },
     {
         // GitaDoraLefty

--- a/src/spice2x/launcher/options.h
+++ b/src/spice2x/launcher/options.h
@@ -110,7 +110,7 @@ namespace launcher {
             GitaDoraTwoChannelAudio,
             GitaDoraCabinetType,
             GitaDoraArenaSingleWindow,
-            GitaDoraArenaHideSideWindows,
+            GitaDoraArenaWindowLayout,
             GitaDoraLefty,
             GitaDoraWailHold,
             GitaDoraPickAlgo,

--- a/src/spice2x/launcher/options.h
+++ b/src/spice2x/launcher/options.h
@@ -109,6 +109,7 @@ namespace launcher {
             GitaDoraTwoChannelAudio,
             GitaDoraCabinetType,
             GitaDoraArenaSingleWindow,
+            GitaDoraArenaHideSideWindows,
             GitaDoraLefty,
             GitaDoraWailHold,
             GitaDoraPickAlgo,


### PR DESCRIPTION
## Description of change
Added an option to only disable the left/right screens of gitadora gw delta while exposing the touch panel screen.

## Testing
Tested by hand on CachyOS + hyprland + gamescope + wine + vnc + phone + cat 🐈‍⬛ 

<img width="2560" height="1707" alt="image" src="https://github.com/user-attachments/assets/a2ef0172-68e2-43c2-89c3-4863698f2f00" />
