### PR TITLE
overlay: prevent save button shifting patches text

### DIFF
--- a/src/spice2x/overlay/windows/patch_manager.cpp
+++ b/src/spice2x/overlay/windows/patch_manager.cpp
@@ -365,21 +365,24 @@ namespace overlay::windows {
             config_dirty = true;
         }
 
-        // check for dirty state
-        if (config_dirty) {
-            if (cfg::CONFIGURATOR_STANDALONE) {
-                // auto save for configurator version
+        // handle dirty state
+        if (cfg::CONFIGURATOR_STANDALONE) {
+            // auto save for configurator version
+            if (config_dirty) {
                 this->config_save();
-
-            } else {
-                // manual save for live version
-                ImGui::AlignTextToFramePadding();
-                ImGui::HelpMarker("Save current patch state to the configuration file.");
-                ImGui::SameLine();
-                if (ImGui::Button("Save")) {
-                    this->config_save();
-                }
             }
+        } else {
+            // manual save for live version: always render the row so the rest
+            // of the panel doesn't shift when config_dirty flips. Disable the
+            // button when there is nothing to save.
+            ImGui::AlignTextToFramePadding();
+            ImGui::HelpMarker("Save current patch state to the configuration file.");
+            ImGui::SameLine();
+            ImGui::BeginDisabled(!config_dirty);
+            if (ImGui::Button("Save")) {
+                this->config_save();
+            }
+            ImGui::EndDisabled();
         }
 
         bool disable_all_patches = false;


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
#0

## Description of change
When opening the patches tab by pressing F4 in game, the Save button doesn't appear until after initially selecting/deselecting a patch, then it shifts all of the patch text below. To solve this annoyance, this keeps the Save button in a fixed position (starts greyed out until a selection) and no longer shifts the text.

## Testing
Confirmed saving selected patches still works properly in the overlay and standalone cfg
