### PR TITLE
overlay: fix z-ordering of subscreen windows

### DIFF
--- a/src/spice2x/overlay/windows/generic_sub.cpp
+++ b/src/spice2x/overlay/windows/generic_sub.cpp
@@ -231,11 +231,15 @@ namespace overlay::windows {
         surface->Release();
         texture_surface->Release();
 
-        // draw the subscreen (this draws *under* ImGui windows, over the game surface)
+        // draw the subscreen into the current window's draw list so it participates in
+        // normal ImGui z-ordering (i.e. other ImGui windows can appear above it)
         auto bottom_right = overlay_content_size;
         bottom_right.x += overlay_content_top_left.x;
         bottom_right.y += overlay_content_top_left.y;
-        ImGui::GetBackgroundDrawList()->AddImage(
+        auto draw_list = this->draws_window
+            ? ImGui::GetWindowDrawList()
+            : ImGui::GetBackgroundDrawList();
+        draw_list->AddImage(
             reinterpret_cast<ImTextureID>(this->texture),
             overlay_content_top_left,
             bottom_right);


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
n/a

## Description of change
Subscreen overlay window used to draw above the main game surface, but below any other ImGui widgets. Fix this so that the subscreen image is drawn at the same z-level as the sub window itself.

This has been a long-standing issue - at least since 2023 when spice2x first forked...

## Testing
Tested TDJ in windowed mode.