### PR TITLE
misc: clean up eamuse_get_game

### DIFF
--- a/src/spice2x/misc/eamuse.cpp
+++ b/src/spice2x/misc/eamuse.cpp
@@ -631,7 +631,7 @@ void eamuse_update_keypad_bindings() {
     KEYPAD_BINDINGS = Config::getInstance().getKeypadBindings(EAMUSE_GAME_NAME);
 }
 
-std::string eamuse_get_game() {
+const std::string &eamuse_get_game() {
     return EAMUSE_GAME_NAME;
 }
 

--- a/src/spice2x/misc/eamuse.h
+++ b/src/spice2x/misc/eamuse.h
@@ -78,7 +78,7 @@ bool eamuse_keypad_state_naive();
 
 void eamuse_set_game(std::string game);
 
-std::string eamuse_get_game();
+const std::string &eamuse_get_game();
 int eamuse_get_game_keypads();
 int eamuse_get_game_keypads_name();
 


### PR DESCRIPTION
No need to allocate a new `std::string` every call...