### PR TITLE
cfg: optimize saving config

### DIFF
--- a/src/spice2x/cfg/config.cpp
+++ b/src/spice2x/cfg/config.cpp
@@ -98,7 +98,7 @@ bool Config::getStatus() {
     return this->status;
 }
 
-bool Config::addGame(Game &game) {
+bool Config::addGame(Game &game, bool save) {
     tinyxml2::XMLNode *rootNode = this->configFile.LastChild();
     tinyxml2::XMLElement *gameNodes = rootNode->FirstChildElement("game");
 
@@ -486,11 +486,18 @@ bool Config::addGame(Game &game) {
         rootNode->InsertEndChild(gameNode);
     }
 
-    // save config
-    this->saveConfigFile();
+    // save config (skipped when caller batches multiple addGame calls
+    // and flushes once at the end via Config::save())
+    if (save) {
+        this->saveConfigFile();
+    }
 
     // return success
     return true;
+}
+
+void Config::save() {
+    this->saveConfigFile();
 }
 
 bool Config::updateBinding(const Game &game, const Button &button, int alternative) {

--- a/src/spice2x/cfg/config.h
+++ b/src/spice2x/cfg/config.h
@@ -22,7 +22,12 @@ public:
     bool getStatus();
     bool createConfigFile();
 
-    bool addGame(Game &game);
+    bool addGame(Game &game, bool save = true);
+
+    // flush pending in-memory changes to disk; intended to be paired with
+    // addGame(game, false) in bulk-init paths so we write the XML once instead
+    // of once per game
+    void save();
 
     bool updateBinding(const Game &game, const Button &button, int alternative);
     bool updateBinding(const Game &game, const Analog &analog);

--- a/src/spice2x/overlay/windows/config.cpp
+++ b/src/spice2x/overlay/windows/config.cpp
@@ -154,12 +154,14 @@ namespace overlay::windows {
         // add games to the config and window
         auto &config = ::Config::getInstance();
         for (auto &game : games_list) {
-            config.addGame(game);
+            config.addGame(game, /* save */ false);
 
             if (!config.getStatus()) {
                 log_warning("config", "failure adding game: {}", game.getGameName());
             }
         }
+        // single flush in place of ~33 redundant writes during the loop above
+        config.save();
 
         // read card numbers
         read_card();


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
#0

## Description of change
Save config xml once instead of ~33 times

## Testing
xml is still saved properly
