### PR TITLE
rawinput: fix spicecfg close delay

### DIFF
--- a/src/spice2x/rawinput/rawinput.cpp
+++ b/src/spice2x/rawinput/rawinput.cpp
@@ -1112,7 +1112,16 @@ void rawinput::RawInputManager::flush_start() {
                  * to button based lighting.
                  */
                 this->devices_flush_output(false);
-                Sleep(495);
+
+                // wait up to ~500ms, but wake immediately if flush_stop()
+                // flips the running flag. Without the CV the in-flight
+                // Sleep() forced launcher::shutdown() to block for the full
+                // remaining sleep window on every close.
+                std::unique_lock<std::mutex> lock(this->flush_thread_m);
+                this->flush_thread_cv.wait_for(
+                    lock,
+                    std::chrono::milliseconds(495),
+                    [this] { return !this->flush_thread_running; });
             }
         });
     }
@@ -1120,8 +1129,13 @@ void rawinput::RawInputManager::flush_start() {
 
 void rawinput::RawInputManager::flush_stop() {
 
-    // set stop flag
-    this->flush_thread_running = false;
+    // set stop flag and wake the flush thread immediately so shutdown
+    // isn't blocked by the in-progress wait inside the loop above.
+    {
+        std::lock_guard<std::mutex> lock(this->flush_thread_m);
+        this->flush_thread_running = false;
+    }
+    this->flush_thread_cv.notify_all();
 
     // check if thread is set
     if (this->flush_thread) {

--- a/src/spice2x/rawinput/rawinput.h
+++ b/src/spice2x/rawinput/rawinput.h
@@ -69,6 +69,8 @@ namespace rawinput {
         std::thread *input_thread = nullptr;
         std::thread *flush_thread = nullptr;
         bool flush_thread_running = false;
+        std::mutex flush_thread_m;
+        std::condition_variable flush_thread_cv;
         std::thread *output_thread = nullptr;
         std::mutex output_thread_m;
         bool output_thread_ready = false;


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
#0

## Description of change
Closing spicecfg was blocked for up to ~495 ms. Runtime behavior is unchanged: same flush interval and same output path during normal operation. Only shutdown teardown is faster.

## Testing
Opened and closed spicecfg.exe repeatedly; the window closes immediately with no hang
