### PR TITLE
cfg: fix alt+f4 exit

### DIFF
--- a/src/spice2x/cfg/configurator_wnd.cpp
+++ b/src/spice2x/cfg/configurator_wnd.cpp
@@ -495,6 +495,9 @@ LRESULT CALLBACK cfg::ConfiguratorWindow::window_proc(HWND hWnd, UINT uMsg, WPAR
         case WM_SYSKEYDOWN:
         case WM_KEYUP:
         case WM_SYSKEYUP: {
+            if (wParam == VK_F4) {
+                return DefWindowProc(hWnd, uMsg, wParam, lParam);
+            }
             const bool down = (uMsg == WM_KEYDOWN) || (uMsg == WM_SYSKEYDOWN);
             auto &io = ImGui::GetIO();
             const ImGuiKey key = vk_to_imgui_key(wParam);


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
#720

## Description of change
Pass `VK_F4` sys-key messages through to `DefWindowProc` before ImGui ingestion, restoring the normal Alt+F4 -> `WM_CLOSE` -> `launcher::shutdown()` path.

## Testing
- [x] Launch `spicecfg` (D3D9 default path) and press Alt+F4; window closes and process exits
- [x] Launch `spicecfg` (software path) and press Alt+F4; window closes and process exits
- [x] Close via title-bar X; still works