### PR TITLE
gitadora: (arena model) complain loudly about bad prop files

### DIFF
--- a/src/spice2x/games/gitadora/gitadora.cpp
+++ b/src/spice2x/games/gitadora/gitadora.cpp
@@ -593,6 +593,12 @@ namespace games::gitadora {
 #ifdef SPICE64
         // gitadora arena model 
         auto aio = libutils::try_library("libaio.dll");
+
+        // before we start patching and hooking things, detect invalid configuration
+        if (aio != nullptr && !is_arena_model()) {
+            log_fatal("gitadora", "arena model i/o (libaio.dll) detected, but <spec> is not an arena model - bad prop XML files?");
+        }
+
         if (aio != nullptr) {
             SETUPAPI_SETTINGS settings{};
             settings.class_guid[0] = 0x86E0D1E0;


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
n/a

## Description of change
Refuse to load if `libaio.dll` exists but `<spec>` is set incorrectly (almost certainly because the user copied old prop files from downlevel version)

## Testing

