### PR TITLE
gitadora: (arena model) flip realtek option

### DIFF
--- a/src/spice2x/games/gitadora/gitadora.cpp
+++ b/src/spice2x/games/gitadora/gitadora.cpp
@@ -35,6 +35,7 @@ namespace games::gitadora {
     std::optional<socd::SocdAlgorithm> PICK_ALGO = socd::SocdAlgorithm::PreferRecent;
     std::optional<uint8_t> ARENA_WINDOW_COUNT = std::nullopt;
     std::optional<std::string> ASIO_DRIVER = std::nullopt;
+    bool ALLOW_REALTEK_AUDIO = false;
 
     /*
      * Prevent GitaDora from creating folders on F drive
@@ -630,7 +631,25 @@ namespace games::gitadora {
 
             // volume change prevention
             hooks::audio::mme::init(avs::game::DLL_INSTANCE);
-            
+
+            // fake Realtek audio injection
+            // if ASIO init succeeds, game tries to look for audio device with `Realtek` in friendly name
+            // if ASIO init fails, game opens default audio device
+            // therefore, it's safe to enable this hook by default regardless of ASIO preference
+            // (unless the user explicitly disables it, of course)
+            if (ALLOW_REALTEK_AUDIO) {
+                log_info(
+                    "gitadora",
+                    "fake Realtek audio injection disabled "
+                    "(user's real Realtek audio may be used after successful ASIO init)");
+            } else {
+                log_info(
+                    "gitadora",
+                    "fake Realtek audio injection enabled "
+                    "(create a fake Realtek audio device to prevent crashes after successful ASIO init)");
+                hooks::audio::INJECT_FAKE_REALTEK_AUDIO = true;
+            }
+
             // monitor/touch hooks (windowed or full screen)
             if (GRAPHICS_PREVENT_SECONDARY_WINDOWS) {
                 // enable touch hook for subscreen overlay

--- a/src/spice2x/games/gitadora/gitadora.h
+++ b/src/spice2x/games/gitadora/gitadora.h
@@ -20,6 +20,7 @@ namespace games::gitadora {
     extern std::optional<socd::SocdAlgorithm> PICK_ALGO;
     extern std::optional<uint8_t> ARENA_WINDOW_COUNT;
     extern std::optional<std::string> ASIO_DRIVER;
+    extern bool ALLOW_REALTEK_AUDIO;
 
     class GitaDoraGame : public games::Game {
     public:

--- a/src/spice2x/hooks/audio/audio.cpp
+++ b/src/spice2x/hooks/audio/audio.cpp
@@ -47,7 +47,7 @@ namespace hooks::audio {
     bool USE_DUMMY = false;
     WAVEFORMATEXTENSIBLE FORMAT {};
     std::optional<Backend> BACKEND = std::nullopt;
-    bool FAKE_REALTEK_RENDER_DEVICE = false;
+    bool INJECT_FAKE_REALTEK_AUDIO = false;
     std::optional<size_t> ASIO_DRIVER_ID = std::nullopt;
     std::string ASIO_DRIVER_NAME = "";
     bool ASIO_FORCE_UNLOAD_ON_STOP = false;

--- a/src/spice2x/hooks/audio/audio.h
+++ b/src/spice2x/hooks/audio/audio.h
@@ -44,7 +44,7 @@ namespace hooks::audio {
     // when true, a synthetic "Realtek" render endpoint is injected into device enumeration that
     // discards all audio. used by gitadora arena, whose device search crashes when no render
     // endpoint reports a "Realtek" friendly name.
-    extern bool FAKE_REALTEK_RENDER_DEVICE;
+    extern bool INJECT_FAKE_REALTEK_AUDIO;
     extern std::optional<size_t> ASIO_DRIVER_ID;
     extern std::string ASIO_DRIVER_NAME;
     extern bool ASIO_FORCE_UNLOAD_ON_STOP;

--- a/src/spice2x/hooks/audio/backends/mmdevice/null_device.cpp
+++ b/src/spice2x/hooks/audio/backends/mmdevice/null_device.cpp
@@ -27,7 +27,7 @@ static const PROPERTYKEY PKEY_DEVICE_FRIENDLY_NAME_LOCAL = {
 };
 
 bool null_render_device_enabled() {
-    return hooks::audio::FAKE_REALTEK_RENDER_DEVICE;
+    return hooks::audio::INJECT_FAKE_REALTEK_AUDIO;
 }
 
 // duplicate a wide string into CoTaskMem so the caller can free it with

--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -687,8 +687,8 @@ int main_implementation(int argc, char *argv[]) {
     if (options[launcher::Options::GitaDoraArenaAsioDriver].is_active()) {
         games::gitadora::ASIO_DRIVER = options[launcher::Options::GitaDoraArenaAsioDriver].value_text();
     }
-    if (options[launcher::Options::GitaDoraArenaFakeRealtekDevice].value_bool()) {
-        hooks::audio::FAKE_REALTEK_RENDER_DEVICE = true;
+    if (options[launcher::Options::GitaDoraArenaRealtekAccess].value_bool()) {
+        games::gitadora::ALLOW_REALTEK_AUDIO = true;
     }
     if (options[launcher::Options::LoadNostalgiaModule].value_bool()) {
         attach_nostalgia = true;

--- a/src/spice2x/launcher/options.cpp
+++ b/src/spice2x/launcher/options.cpp
@@ -1215,12 +1215,13 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .picker = OptionPickerType::AsioDriver,
     },
     {
-        // GitaDoraArenaFakeRealtekDevice
-        .title = "GitaDora Arena Fake Realtek Device",
-        .name = "gdafakerealtek",
-        .desc = "For Arena Model: inject a fake \"Realtek\" audio render device that discards all "
-            "audio sent to it. This is needed as the game crashes when ASIO is in use but Realtek "
-            "audio is not available. On an arcade cabinet, Realtek is used for headphone output.",
+        // GitaDoraArenaRealtekAccess
+        .title = "GitaDora Arena ASIO Allow Headphones",
+        .name = "gdarealtek",
+        .desc = "For Arena Model: allow the game to access the Realtek audio for headphone output.\n\n"
+            "After opening ASIO device, the game then tries to look for audio devices named Realtek to open "
+            "a second audio stream. For compatibility, spice prevents the game from doing this, but enabling "
+            "this option will allow the game to access the Realtek audio device again.",
         .type = OptionType::Bool,
         .game_name = "GitaDora",
         .category = "Game Options",

--- a/src/spice2x/launcher/options.h
+++ b/src/spice2x/launcher/options.h
@@ -117,7 +117,7 @@ namespace launcher {
             GitaDoraArenaSingleWindow,
             GitaDoraArenaWindowLayout,
             GitaDoraArenaAsioDriver,
-            GitaDoraArenaFakeRealtekDevice,
+            GitaDoraArenaRealtekAccess,
             LoadJubeatModule,
             LoadReflecBeatModule,
             LoadShogikaiModule,


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
#730 

## Description of change
Flip the option - enable the Realtek hack by default, unless the user chooses not to.

## Testing
Tested ASIO path and WASAPI path. WASAPI path should be unaffected as the game just picks the default audio device.