### PR TITLE
overlay: make overlay toggle behavior more consistent

### DIFF
--- a/src/spice2x/overlay/overlay.cpp
+++ b/src/spice2x/overlay/overlay.cpp
@@ -827,14 +827,8 @@ bool overlay::SpiceOverlay::update_cursor() {
 }
 
 void overlay::SpiceOverlay::toggle_active() {
-
     // invert active state
     this->active = !this->active;
-
-    // get rid of main menu if it was visible
-    if (this->window_main_menu) {
-        this->window_main_menu->set_active(false);
-    }
 }
 
 void overlay::SpiceOverlay::show_main_menu() {
@@ -844,12 +838,17 @@ void overlay::SpiceOverlay::show_main_menu() {
     if (this->window_main_menu->get_active()) {
         // window already visible - close the window
         this->window_main_menu->set_active(false);
+        // if the overlay was not visible when this came into view, turn off overlay as well
+        if (!this->overlay_active_when_main_menu_shown) {
+            this->set_active(false);
+        }
         return;
     }
     if (ImGui::IsPopupOpen(0, ImGuiPopupFlags_AnyPopup)) {
         return;
     }
 
+    this->overlay_active_when_main_menu_shown = this->get_active();
     if (this->get_active()) {
         if (!ImGui::IsAnyItemActive() && !ImGui::IsAnyItemFocused()) {
             this->window_main_menu->set_active(true);

--- a/src/spice2x/overlay/overlay.h
+++ b/src/spice2x/overlay/overlay.h
@@ -202,6 +202,7 @@ namespace overlay {
         bool active = false;
         bool toggle_down = false;
         bool main_menu_down = false;
+        bool overlay_active_when_main_menu_shown = false;
         bool fps_down = false;
         bool hotkey_toggle = false;
         bool hotkey_toggle_last = false;

--- a/src/spice2x/overlay/window.cpp
+++ b/src/spice2x/overlay/window.cpp
@@ -31,6 +31,12 @@ void overlay::Window::update() {
 
             // if the overlay is hidden just reactivate it
             if (!this->overlay->get_active()) {
+
+                // but don't let the main menu occlude it if it was previously visible
+                if (this->overlay->window_main_menu) {
+                    this->overlay->window_main_menu->set_active(false);
+                }
+
                 this->active = true;
                 this->overlay->set_active(true);
             } else {

--- a/src/spice2x/overlay/windows/exitprompt.cpp
+++ b/src/spice2x/overlay/windows/exitprompt.cpp
@@ -31,8 +31,10 @@ namespace overlay::windows {
     void ExitPrompt::update() {
         Window::update();
 
-        // allow the popup to be reopened the next time the menu is shown
-        if (!this->active) {
+        // allow the popup to be reopened the next time the menu is shown.
+        // also reset while the overlay is hidden: new_frame() doesn't submit the
+        // popup then, so ImGui closes it and it must be re-opened when shown again
+        if (!this->active || !this->overlay->get_active()) {
             this->popup_opened = false;
         }
     }


### PR DESCRIPTION
Clean up how various overlay toggle shortcuts work with the main menu visible.