### PR TITLE
overlay: redesign Options tab(s)

### DIFF
--- a/src/spice2x/cfg/option.h
+++ b/src/spice2x/cfg/option.h
@@ -46,6 +46,8 @@ struct OptionDefinition {
 
     // for OptionPickerType::FilePath
     std::string file_extension = "";
+
+    std::string quick_setting_category = "";
 };
 
 class Option {

--- a/src/spice2x/launcher/options.cpp
+++ b/src/spice2x/launcher/options.cpp
@@ -5,6 +5,8 @@
 #include "util/fileutils.h"
 
 #include <fstream>
+#include <mutex>
+#include <set>
 
 #ifdef NO_SCARD
 #define WITH_SCARD 0
@@ -14,8 +16,8 @@
 
 static const std::vector<std::string> CATEGORY_ORDER_API = {
     "Companion & API",
-    "API (Serial)",
-    "API (Dev)",
+    "API over Serial",
+    "API Dev",
     "BT5 API",
 };
 
@@ -31,23 +33,25 @@ static const std::vector<std::string> CATEGORY_ORDER_DISPLAY = {
     "Graphics",
     "Full Screen Settings",
     "Windowed Settings",
+    "Game Windowed Settings",
 };
 
 static const std::vector<std::string> CATEGORY_ORDER_AUDIO = {
     "Audio",
-    "Audio (Conversion)",
-    "Audio (Hacks)",
+    "Audio Conversion",
+    "Audio Hacks",
 };
 
 static const std::vector<std::string> CATEGORY_ORDER_NETWORK = {
     "Network",
     "Auto PIN",
-    "Network (Advanced)",
-    "Network (Development)",
+    "Advanced Network",
+    "Network Dev",
 };
 
 static const std::vector<std::string> CATEGORY_ORDER_OVERLAY = {
-    "Overlay",
+    "General Overlay",
+    "Game Overlay",
 };
 
 static const std::vector<std::string> CATEGORY_ORDER_ADVANCED = {
@@ -406,7 +410,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .name = "smartea",
         .desc = "Automatically enables -ea when server is offline.",
         .type = OptionType::Bool,
-        .category = "Network (Advanced)",
+        .category = "Advanced Network",
     },
     {
         // EAmusementMaintenance
@@ -415,7 +419,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Enables EA Maintenance, 1 for on, 0 for off.",
         .type = OptionType::Enum,
         .hidden = true,
-        .category = "Network (Advanced)",
+        .category = "Advanced Network",
         .elements = {{"0", "Off"}, {"1", "On"}},
     },
     {
@@ -426,7 +430,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .aliases= "forceeamaint",
         .desc = "Causes local EA to start in maintenance mode. Must be used with -ea or -smartea.",
         .type = OptionType::Bool,
-        .category = "Network (Advanced)",
+        .category = "Advanced Network",
     },
     {
         .title = "Preferred NetAdapter IP",
@@ -434,7 +438,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "This is NOT the EA service URL; use -url for that. "
             "Force the use of an adapter with the specified network. Must also provide -subnet.",
         .type = OptionType::Text,
-        .category = "Network (Advanced)",
+        .category = "Advanced Network",
         .sensitive = true,
     },
     {
@@ -442,21 +446,21 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .name = "subnet",
         .desc = "Force the use of an adapter with the specified subnet. Must also provide -network.",
         .type = OptionType::Text,
-        .category = "Network (Advanced)",
+        .category = "Advanced Network",
     },
     {
         .title = "Disable Network Fixes",
         .name = "netfixdisable",
         .desc = "Force disables network fixes.",
         .type = OptionType::Bool,
-        .category = "Network (Development)",
+        .category = "Network Dev",
     },
     {
         .title = "HTTP/1.1",
         .name = "http11",
         .desc = "Sets EA3 http11 value.",
         .type = OptionType::Enum,
-        .category = "Network (Development)",
+        .category = "Network Dev",
         .elements = {{"0", "Off"}, {"1", "On"}},
     },
     {
@@ -464,14 +468,14 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .name = "ssldisable",
         .desc = "Prevents the SSL protocol from being registered.",
         .type = OptionType::Bool,
-        .category = "Network (Development)",
+        .category = "Network Dev",
     },
     {
         .title = "URL Slash",
         .name = "urlslash",
         .desc = "Sets EA3 urlslash value.",
         .type = OptionType::Enum,
-        .category = "Network (Advanced)",
+        .category = "Advanced Network",
         .elements = {{"0", "Off"}, {"1", "On"}},
     },
     {
@@ -498,7 +502,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .name = "overlaydisable",
         .desc = "Disables the in-game overlay.",
         .type = OptionType::Bool,
-        .category = "Overlay",
+        .category = "General Overlay",
     },
     {
         // OverlayScaling
@@ -509,7 +513,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "Enter value in percentage, between 10-400, inclusive.",
         .type = OptionType::Integer,
         .setting_name = "200",
-        .category = "Overlay",
+        .category = "General Overlay",
     },
     {
         // NotificationPosition
@@ -517,7 +521,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .name = "toast",
         .desc = "Select where notifications will appear on the screen.",
         .type = OptionType::Enum,
-        .category = "Overlay",
+        .category = "General Overlay",
         .elements = {
             {"off", ""},
             {"topleft", ""},
@@ -534,7 +538,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .aliases= "autofps",
         .desc = "Automatically show FPS / clock / timer overlay window when the game starts.",
         .type = OptionType::Bool,
-        .category = "Overlay",
+        .category = "General Overlay",
     },
     {
         // spice2x_FpsOpposite
@@ -544,7 +548,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "Deprecated - use -fpslocation instead.",
         .type = OptionType::Bool,
         .hidden = true,
-        .category = "Overlay",
+        .category = "General Overlay",
     },
     {
         // FpsLocation
@@ -552,7 +556,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .name = "fpslocation",
         .desc = "Select which corner of the screen the FPS / clock / timer overlay appears in.",
         .type = OptionType::Enum,
-        .category = "Overlay",
+        .category = "General Overlay",
         .elements = {
             {"topright", ""},
             {"topleft", ""},
@@ -568,7 +572,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .aliases= "autosubscreen",
         .desc = "Automatically show the subscreen overlay when the game starts, if the game has one.",
         .type = OptionType::Bool,
-        .category = "Overlay",
+        .category = "General Overlay",
     },
     {
         // spice2x_IOPanelAutoShow
@@ -578,7 +582,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .aliases= "autoiopanel",
         .desc = "Automatically show I/O panel window when the game starts.",
         .type = OptionType::Bool,
-        .category = "Overlay",
+        .category = "General Overlay",
     },
     {
         // spice2x_KeypadAutoShow
@@ -588,7 +592,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .aliases= "autokeypad",
         .desc = "Automatically show virtual keypad window when the game starts.",
         .type = OptionType::Enum,
-        .category = "Overlay",
+        .category = "General Overlay",
         .elements = {
             {"0", "Off"},
             {"1", "P1"},
@@ -803,7 +807,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Default size of the subscreen overlay.\n\nNote: in windowed mode, subscreen will always be full size.\n\nDefault: medium.",
         .type = OptionType::Enum,
         .game_name = "Beatmania IIDX",
-        .category = "Overlay",
+        .category = "Game Overlay",
         .elements = {
             {"small", ""},
             {"medium", ""},
@@ -820,7 +824,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Configure the font size of the segment display, in pixels. Default: 64 (px).",
         .type = OptionType::Integer,
         .game_name = "Beatmania IIDX",
-        .category = "Overlay",
+        .category = "Game Overlay",
     },
     {
         // spice2x_IIDXLEDColor
@@ -832,7 +836,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
                 "Default: 0xff0000 (red).",
         .type = OptionType::Hex,
         .game_name = "Beatmania IIDX",
-        .category = "Overlay",
+        .category = "Game Overlay",
     },
     {
         // spice2x_IIDXLEDPos
@@ -843,7 +847,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Initial position of the segment display. Default: bottom.",
         .type = OptionType::Enum,
         .game_name = "Beatmania IIDX",
-        .category = "Overlay",
+        .category = "Game Overlay",
         .elements = {
             {"topleft", ""},
             {"top", ""},
@@ -861,7 +865,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Make LED ticker overlay window borderless (remove window decoration).",
         .type = OptionType::Bool,
         .game_name = "Beatmania IIDX",
-        .category = "Overlay",
+        .category = "Game Overlay",
     },
     {
         .title = "Force Load Sound Voltex Module",
@@ -1030,7 +1034,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Location for the subscreen overlay. Default: bottom.",
         .type = OptionType::Enum,
         .game_name = "Sound Voltex",
-        .category = "Overlay",
+        .category = "Game Overlay",
         .elements = {
             {"top", ""},
             {"center", ""},
@@ -1228,7 +1232,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Default size of the subscreen overlay. Default: medium.",
         .type = OptionType::Enum,
         .game_name = "GitaDora",
-        .category = "Overlay",
+        .category = "Game Overlay",
         .elements = {
             {"small", ""},
             {"medium", ""},
@@ -1629,35 +1633,35 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .name = "apilogging",
         .desc = "Verbose logging of API activity.",
         .type = OptionType::Bool,
-        .category = "API (Dev)",
+        .category = "API Dev",
     },
     {
         .title = "API Serial Port",
         .name = "apiserial",
         .desc = "Serial port the API should be listening on.",
         .type = OptionType::Text,
-        .category = "API (Serial)",
+        .category = "API over Serial",
     },
     {
         .title = "API Serial Baud",
         .name = "apiserialbaud",
         .desc = "Baud rate for the serial port.",
         .type = OptionType::Integer,
-        .category = "API (Serial)",
+        .category = "API over Serial",
     },
     {
         .title = "API Pretty",
         .name = "apipretty",
         .desc = "Slower, but pretty API output.",
         .type = OptionType::Bool,
-        .category = "API (Dev)",
+        .category = "API Dev",
     },
     {
         .title = "API Debug Mode",
         .name = "apidebug",
         .desc = "Enables API debugging mode.",
         .type = OptionType::Bool,
-        .category = "API (Dev)",
+        .category = "API Dev",
     },
     {
         // APIScreenMirrorQuality
@@ -1975,7 +1979,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
                 "you use a different backend instead of exclusive WASAPI).\n\n"
             "Check this to allow games to natively access your audio device.",
         .type = OptionType::Bool,
-        .category = "Audio (Hacks)",
+        .category = "Audio Hacks",
     },
     {
         // spice2x_DisableVolumeHook
@@ -1987,7 +1991,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "Default: off (prevent games from changing audio volume by hooking IAudioEndpointVolume).\n\n"
             "Check this to allow games to freely change your volume.",
         .type = OptionType::Bool,
-        .category = "Audio (Hacks)",
+        .category = "Audio Hacks",
     },
     {
         // AudioShared
@@ -2023,7 +2027,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "Does nothing for games that do not output to exclusive WASAPI.",
         .type = OptionType::Enum,
         .hidden = true,
-        .category = "Audio (Conversion)",
+        .category = "Audio Conversion",
         .elements = {
             {"asio", "ASIO"},
             {"waveout", "broken, do not use"}
@@ -2036,7 +2040,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Selects the ASIO driver id to use when Spice Audio Backend is set to ASIO.",
         .type = OptionType::Integer,
         .hidden = true,
-        .category = "Audio (Conversion)",
+        .category = "Audio Conversion",
     },
     {
         // AsioDriverName
@@ -2047,7 +2051,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "This should only be used as last resort if your audio device does not support WASAPI Exclusive.\n\n"
             "Does nothing for games that do not output to exclusive WASAPI.",
         .type = OptionType::Text,
-        .category = "Audio (Conversion)",
+        .category = "Audio Conversion",
         .picker = OptionPickerType::AsioDriver,
     },
     {
@@ -2057,7 +2061,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "This is automatically enabled when required and not normally needed.",
         .type = OptionType::Bool,
         .hidden = true,
-        .category = "Audio (Hacks)",
+        .category = "Audio Hacks",
     },
     {
         // DownmixAudioToStereo
@@ -2072,7 +2076,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "rear: rear channels only.\n\n"
             "side: side channels only.",
         .type = OptionType::Enum,
-        .category = "Audio (Conversion)",
+        .category = "Audio Conversion",
         .elements = {
             {"ac4", "AC-4 downmix"},
             {"normalize", "All channels"},
@@ -2113,7 +2117,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "Select the TARGET sample rate (one that your audio card supports).\n\n"
             "Will result in couple milliseconds of latency and increased CPU usage when active.",
         .type = OptionType::Enum,
-        .category = "Audio (Conversion)",
+        .category = "Audio Conversion",
         .elements = {
             {"44100", "44.1 kHz"},
             {"48000", "48 kHz"},
@@ -2132,7 +2136,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "(at the cost of slightly increased latency).",
         .type = OptionType::Integer,
         .setting_name = "16",
-        .category = "Audio (Conversion)",
+        .category = "Audio Conversion",
     },
     {
         // AsioDownmixToStereo
@@ -2146,7 +2150,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "rear: channels 4/5 (rear left/right).\n\n"
             "side: channels 6/7 (side left/right).",
         .type = OptionType::Enum,
-        .category = "Audio (Conversion)",
+        .category = "Audio Conversion",
         .elements = {
             {"front", "Front (ch 0/1)"},
             {"center", "Center (ch 2)"},
@@ -2230,15 +2234,15 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .name = "automap",
         .desc = "Enable automap in patch configuration.",
         .type = OptionType::Bool,
-        .category = "Network (Development)",
+        .category = "Network Dev",
     },
     {
         .title = "EA Netdump",
         .name = "netdump",
         .desc = "Enable automap in network dumping configuration.",
         .type = OptionType::Bool,
-        .category = "Network (Development)",
-    },    
+        .category = "Network Dev",
+    },
     {
         .title = "Blocking Logger",
         .name = "logblock",
@@ -2539,7 +2543,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "\\\\.\\DISPLAY1",
         .game_name = "GitaDora",
-        .category = "Windowed Settings",
+        .category = "Game Windowed Settings",
         .picker = OptionPickerType::Monitor,
     },
     {
@@ -2551,7 +2555,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "\\\\.\\DISPLAY2",
         .game_name = "GitaDora",
-        .category = "Windowed Settings",
+        .category = "Game Windowed Settings",
         .picker = OptionPickerType::Monitor,
     },
     {
@@ -2563,7 +2567,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "\\\\.\\DISPLAY3",
         .game_name = "GitaDora",
-        .category = "Windowed Settings",
+        .category = "Game Windowed Settings",
         .picker = OptionPickerType::Monitor,
     },
     {
@@ -2575,7 +2579,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "\\\\.\\DISPLAY4",
         .game_name = "GitaDora",
-        .category = "Windowed Settings",
+        .category = "Game Windowed Settings",
         .picker = OptionPickerType::Monitor,
     },
     {
@@ -2586,7 +2590,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "1280,720",
         .game_name = "Beatmania IIDX",
-        .category = "Windowed Settings",
+        .category = "Game Windowed Settings",
     },
     {
         // spice2x_IIDXWindowedSubscreenPosition
@@ -2596,7 +2600,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "0,0",
         .game_name = "Beatmania IIDX",
-        .category = "Windowed Settings",
+        .category = "Game Windowed Settings",
     },
     {
         // IIDXWindowedSubscreenBorderless
@@ -2605,7 +2609,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Remove window decoration from windowed subscreen.",
         .type = OptionType::Bool,
         .game_name = "Beatmania IIDX",
-        .category = "Windowed Settings",
+        .category = "Game Windowed Settings",
     },
     {
         // IIDXWindowedSubscreenAlwaysOnTop
@@ -2614,7 +2618,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Keep windowed subscreen on top.",
         .type = OptionType::Bool,
         .game_name = "Beatmania IIDX",
-        .category = "Windowed Settings",
+        .category = "Game Windowed Settings",
     },
     {
         // spice2x_JubeatLegacyTouch
@@ -2691,7 +2695,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "For certain buggy ASIO drivers, force unload of ASIO driver when audio stream stops. "
             "Used for working around ASIO drivers that lock up after force quitting games.",
         .type = OptionType::Bool,
-        .category = "Audio (Hacks)",
+        .category = "Audio Hacks",
     },
     {
         // spice2x_IIDXNoESpec
@@ -3036,7 +3040,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "1920,1080",
         .game_name = "Sound Voltex",
-        .category = "Windowed Settings",
+        .category = "Game Windowed Settings",
     },
     {
         // SDVXWindowedSubscreenPosition
@@ -3046,7 +3050,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "0,0",
         .game_name = "Sound Voltex",
-        .category = "Windowed Settings",
+        .category = "Game Windowed Settings",
     },
     {
         // SDVXWindowedSubscreenBorderless
@@ -3055,7 +3059,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Remove window decoration from windowed subscreen.",
         .type = OptionType::Bool,
         .game_name = "Sound Voltex",
-        .category = "Windowed Settings",
+        .category = "Game Windowed Settings",
     },
     {
         // SDVXWindowedSubscreenAlwaysOnTop
@@ -3064,7 +3068,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Keep windowed subscreen on top.",
         .type = OptionType::Bool,
         .game_name = "Sound Voltex",
-        .category = "Windowed Settings",
+        .category = "Game Windowed Settings",
     },
     {
         // LovePlusCamEnable
@@ -3159,7 +3163,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Emulate keepalive ping replies in user mode, so the game does not need to "
             "open privileged raw ICMP sockets.",
         .type = OptionType::Bool,
-        .category = "Network (Development)",
+        .category = "Network Dev",
     },
     {
         // AutoElevate
@@ -3220,7 +3224,45 @@ const std::vector<OptionDefinition> &launcher::get_option_definitions() {
     return OPTION_DEFINITIONS;
 }
 
+void launcher::validate_option_categories() {
+    // every category the grouped Options nav can display, gathered straight from
+    // get_categories() so this stays in sync with the actual nav. the Everything
+    // group maps to CATEGORY_ORDER_NONE ("") and is intentionally excluded.
+    static const Options::OptionsCategory groups[] = {
+        Options::OptionsCategory::GameOptions,
+        Options::OptionsCategory::Display,
+        Options::OptionsCategory::Audio,
+        Options::OptionsCategory::Network,
+        Options::OptionsCategory::Overlay,
+        Options::OptionsCategory::Advanced,
+        Options::OptionsCategory::Dev,
+        Options::OptionsCategory::API,
+    };
+    std::set<std::string> valid;
+    for (auto group : groups) {
+        for (const auto &category : get_categories(group)) {
+            if (!category.empty()) {
+                valid.insert(category);
+            }
+        }
+    }
+
+    // any definition whose category is not in a group list is orphaned: it only
+    // shows up under Search, never in the grouped Options nav/content. treat this
+    // as fatal so it is caught immediately during development.
+    for (const auto &definition : get_option_definitions()) {
+        if (!valid.contains(definition.category)) {
+            log_fatal("options", "option -{} has orphaned category \"{}\"",
+                definition.name, definition.category);
+        }
+    }
+}
+
 std::unique_ptr<std::vector<Option>> launcher::parse_options(int argc, char *argv[]) {
+
+    // one-time sanity check that every option lands in a known nav category
+    static std::once_flag validate_once;
+    std::call_once(validate_once, validate_option_categories);
 
     // generate options
     auto &definitions = get_option_definitions();

--- a/src/spice2x/launcher/options.cpp
+++ b/src/spice2x/launcher/options.cpp
@@ -19,15 +19,8 @@ static const std::vector<std::string> CATEGORY_ORDER_API = {
     "BT5 API",
 };
 
-static const std::vector<std::string> CATEGORY_ORDER_BASIC = {
-    "Game Options",
-    "Common",
-    "Network",
-    "Graphics",
-    "Audio",
-};
-
 static const std::vector<std::string> CATEGORY_ORDER_GAME_OPTIONS = {
+    "DLL Hooks",
     "Game Options",
     "Advanced Game Options",
     "Cab Peripherals",
@@ -36,8 +29,8 @@ static const std::vector<std::string> CATEGORY_ORDER_GAME_OPTIONS = {
 static const std::vector<std::string> CATEGORY_ORDER_DISPLAY = {
     "Monitor",
     "Graphics",
-    "Full Screen",
-    "Windowed",
+    "Full Screen Settings",
+    "Windowed Settings",
 };
 
 static const std::vector<std::string> CATEGORY_ORDER_AUDIO = {
@@ -60,6 +53,7 @@ static const std::vector<std::string> CATEGORY_ORDER_OVERLAY = {
 static const std::vector<std::string> CATEGORY_ORDER_ADVANCED = {
     "Performance",
     "Miscellaneous",
+    "Mouse",
     "Touch Parameters",
     "I/O Options",
     "NFC Card Readers",
@@ -72,6 +66,16 @@ static const std::vector<std::string> CATEGORY_ORDER_DEV = {
 };
 static const std::vector<std::string> CATEGORY_ORDER_NONE = {
     ""
+};
+
+// display order for the quick_setting_category names used by the Options tab's
+// "Quick Settings" view (these are independent of the regular option categories)
+static const std::vector<std::string> CATEGORY_ORDER_QUICK = {
+    "Game",
+    "Common",
+    "Network",
+    "Display",
+    "Audio",
 };
 
 static auto format_as(OptionType f) {
@@ -119,6 +123,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Enables the integrated local EA server, just enough to boot the game; no card in, no data saving.",
         .type = OptionType::Bool,
         .category = "Network",
+        .quick_setting_category = "Network",
     },
     {
         // ServiceURL
@@ -128,6 +133,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "http://example.com:8083",
         .category = "Network",
+        .quick_setting_category = "Network",
     },
     {
         .title = "PCBID",
@@ -137,6 +143,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .setting_name = "01201000000000010101",
         .category = "Network",
         .sensitive = true,
+        .quick_setting_category = "Network",
     },
     {
         .title = "Player 1 Card",
@@ -147,6 +154,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .category = "Network",
         .sensitive = true,
         .picker = OptionPickerType::EACard,
+        .quick_setting_category = "Network",
     },
     {
         .title = "Player 2 Card",
@@ -157,6 +165,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .category = "Network",
         .sensitive = true,
         .picker = OptionPickerType::EACard,
+        .quick_setting_category = "Network",
     },
     {
         // Player1PinMacro
@@ -205,7 +214,8 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .name = "w",
         .desc = "Enables windowed mode.",
         .type = OptionType::Bool,
-        .category = "Graphics",
+        .category = "Windowed Settings",
+        .quick_setting_category = "Display",
     },
     {
         // InjectHook
@@ -216,7 +226,8 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
                 "specified file before running the main game code.",
         .type = OptionType::Text,
         .setting_name = "a.dll b.dll c.dll",
-        .category = "Common",
+        .category = "DLL Hooks",
+        .quick_setting_category = "Common",
     },
     {
         // EarlyInjectHook
@@ -226,7 +237,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
                 "the game module has been loaded into the process.",
         .type = OptionType::Text,
         .setting_name = "a.dll b.dll c.dll",
-        .category = "Common",
+        .category = "DLL Hooks",
     },
     {
         .title = "(REMOVED) Execute Lua Script",
@@ -242,14 +253,15 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .name = "c",
         .desc = "Confines the cursor to be within the game window.",
         .type = OptionType::Bool,
-        .category = "Common",
+        .category = "Mouse",
     },
     {
         .title = "Show Cursor & Touch Emulation Enable",
         .name = "s",
         .desc = "Shows the cursor in the game window; also turns on touch emulation. Do not enable this if you have a real touch screen.",
         .type = OptionType::Bool,
-        .category = "Common",
+        .category = "Mouse",
+        .quick_setting_category = "Common",
     },
     {
         // PrimaryMonitor
@@ -274,7 +286,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "Not all games will respect this. Not recommended for multi-monitor games like Lightning Model / Valkyrie Model modes. "
             "Disable Full Screen Optimizations for best results.",
         .type = OptionType::Integer,
-        .category = "Full Screen",
+        .category = "Full Screen Settings",
     },
     {
         .title = "Only Use Main Monitor For Full Screen",
@@ -282,7 +294,8 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Force the graphics device to be opened utilizing only one adapter in multi-monitor systems.\n\n"
             "May cause unstable framerate and desyncs, especially if monitors have different refresh rates!",
         .type = OptionType::Bool,
-        .category = "Full Screen",
+        .category = "Full Screen Settings",
+        .quick_setting_category = "Display",
     },
     {
         .title = "Monitor Refresh Rate",
@@ -290,6 +303,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Change the refresh rate for the primary monitor before launching the game. It will be restored on exit.",
         .type = OptionType::Integer,
         .category = "Monitor",
+        .quick_setting_category = "Display",
     },
     {
         // FullscreenResolution
@@ -302,7 +316,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "This should only be used as last resort if your GPU/monitor can't display the resolution required by the game.",
         .type = OptionType::Text,
         .setting_name = "1280,720",
-        .category = "Full Screen"
+        .category = "Full Screen Settings"
     },
     {
         // FullscreenOrientationFlip
@@ -316,7 +330,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "with Live2D!",
         .type = OptionType::Bool,
         .hidden = true,
-        .category = "Full Screen"
+        .category = "Full Screen Settings"
     },
     {
         // FullscreenSubResolution
@@ -328,7 +342,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "WARNING: experimental as we have not done extensive testing to see if this causes desyncs.",
         .type = OptionType::Text,
         .setting_name = "1280,720",
-        .category = "Full Screen"
+        .category = "Full Screen Settings"
     },
     {
         // FullscreenSubRefreshRate
@@ -339,7 +353,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "useful if you have a sub monitor that is not quite exactly 60Hz.\n\n"
             "WARNING: experimental as we have not done extensive testing to see if this causes desyncs.",
         .type = OptionType::Integer,
-        .category = "Full Screen"
+        .category = "Full Screen Settings"
     },
     {
         // Graphics9On12
@@ -708,6 +722,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             {"wasapi", "Windows Audio"},
             {"asio", "ASIO"},
         },
+        .quick_setting_category = "Game",
     },
     {
         .title = "IIDX ASIO Driver",
@@ -719,6 +734,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .game_name = "Beatmania IIDX",
         .category = "Game Options",
         .picker = OptionPickerType::AsioDriver,
+        .quick_setting_category = "Game",
     },
     {
         .title = "IIDX BIO2 Firmware Update",
@@ -736,6 +752,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Bool,
         .game_name = "Beatmania IIDX",
         .category = "Game Options",
+        .quick_setting_category = "Game",
     },
     {
         // spice2x_IIDXDigitalTTSensitivity
@@ -992,6 +1009,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .game_name = "Sound Voltex",
         .category = "Game Options",
         .picker = OptionPickerType::AsioDriver,
+        .quick_setting_category = "Game",
     },
     {
         // SDVXAsioTwoChannel
@@ -1001,6 +1019,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Bool,
         .game_name = "Sound Voltex",
         .category = "Game Options",
+        .quick_setting_category = "Game",
     },
     {
         // spice2x_SDVXSubPos
@@ -1028,7 +1047,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "\\\\.\\DISPLAY3",
         .game_name = "Sound Voltex",
-        .category = "Full Screen",
+        .category = "Full Screen Settings",
         .picker = OptionPickerType::Monitor,
     },
     {
@@ -1071,6 +1090,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Bool,
         .game_name = "Pop'n Music",
         .category = "Game Options",
+        .quick_setting_category = "Game",
     },
     {
         .title = "Pop'n Music Force SD Mode",
@@ -1079,6 +1099,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Bool,
         .game_name = "Pop'n Music",
         .category = "Game Options",
+        .quick_setting_category = "Game",
     },
     {
         // PopnNoSub
@@ -1088,6 +1109,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Bool,
         .game_name = "Pop'n Music",
         .category = "Game Options",
+        .quick_setting_category = "Game",
     },
     {
         // PopnSubMonitorOverride
@@ -1097,7 +1119,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "\\\\.\\DISPLAY3",
         .game_name = "Pop'n Music",
-        .category = "Full Screen",
+        .category = "Full Screen Settings",
         .picker = OptionPickerType::Monitor,
     },
     {
@@ -1135,6 +1157,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Bool,
         .game_name = "GitaDora",
         .category = "Game Options",
+        .quick_setting_category = "Game",
     },
     {
         .title = "GitaDora Cabinet Type",
@@ -1144,6 +1167,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .game_name = "GitaDora",
         .category = "Game Options",
         .elements = {{"1", "DX"}, {"2", "SD"}, {"3", "SD2 - white cab"}},
+        .quick_setting_category = "Game",
     },
     {
         // GitaDoraLefty
@@ -1163,6 +1187,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             {"p2", "p2 is lefty"},
             {"both", "both lefty"},
         },
+        .quick_setting_category = "Game",
     },
     {
         // GitaDoraWailHold
@@ -1241,6 +1266,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             {"2", "2 windows"},
             {"4", "4 windows"}
         },
+        .quick_setting_category = "Game",
     },
     {
         // GitaDoraArenaAsioDriver
@@ -1255,6 +1281,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .game_name = "GitaDora",
         .category = "Game Options",
         .picker = OptionPickerType::AsioDriver,
+        .quick_setting_category = "Game",
     },
     {
         // GitaDoraArenaRealtekAccess
@@ -1937,6 +1964,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
                 "May not work as expected for some games; namely G-SYNC and SDVX.",
         .type = OptionType::Bool,
         .category = "Graphics",
+        .quick_setting_category = "Display",
     },
     {
         // DisableAudioHooks
@@ -1971,6 +1999,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "you do not need to manually set the sample rate of your audio device before launching the game.",
         .type = OptionType::Bool,
         .category = "Audio",
+        .quick_setting_category = "Audio",
     },
     {
         // spice2x_LowLatencySharedAudio
@@ -1984,6 +2013,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "Requires Windows 10 and above.",
         .type = OptionType::Bool,
         .category = "Audio",
+        .quick_setting_category = "Audio",
     },
     {
         // AudioBackend
@@ -2071,6 +2101,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             {"25", "+25 dB"},
             {"30", "+30 dB"},
         },
+        .quick_setting_category = "Audio",
     },
     {
         // AudioResample
@@ -2175,6 +2206,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             {"2", "Landscape"},
             {"3", "Landscape, Flipped"}
         },
+        .quick_setting_category = "Display",
     },
     {
         // ChangeResolution
@@ -2335,6 +2367,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Bool,
         .game_name = "Chase Chase Jokers",
         .category = "Game Options",
+        .quick_setting_category = "Game",
     },
     {
         .title = "CCJ Mouse Trackball Toggle",
@@ -2437,7 +2470,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "Does not work for all games; can possibly make the game crash! "
             "Can also be changed in Screen Resize window (default F11).",
         .type = OptionType::Enum,
-        .category = "Windowed",
+        .category = "Windowed Settings",
         // match cfg::WindowDecorationMode
         .elements = {
             {"0", "default"},
@@ -2455,7 +2488,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "Can also be changed in Screen Resize window (default F11).",
         .type = OptionType::Text,
         .setting_name = "1280,720",
-        .category = "Windowed",
+        .category = "Windowed Settings",
     },
     {
         // spice2x_WindowPosition
@@ -2467,7 +2500,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "Can also be changed in Screen Resize window (default F11).",
         .type = OptionType::Text,
         .setting_name = "120,240",
-        .category = "Windowed",
+        .category = "Windowed Settings",
     },
     {
         // spice2x_WindowAlwaysOnTop
@@ -2478,7 +2511,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "For windowed mode: make window to be always on top of other windows. "
             "Can also be changed in Screen Resize window (default F11).",
         .type = OptionType::Bool,
-        .category = "Windowed",
+        .category = "Windowed Settings",
     },
     {
         // WindowForceScaling
@@ -2487,7 +2520,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "For windowed mode: forcibly set DX9 back buffer dimensions to match window size. "
             "Reduces pixelated scaling artifacts. Works great for some games, but can COMPLETELY BREAK other games - YMMV!",
         .type = OptionType::Bool,
-        .category = "Windowed",
+        .category = "Windowed Settings",
     },
     {
         // WindowDisableRoundedCorners
@@ -2495,7 +2528,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .name = "windownoroundcorners",
         .desc = "Windows 11 and above only: Disables rounded corners on the game window(s).",
         .type = OptionType::Bool,
-        .category = "Windowed",
+        .category = "Windowed Settings",
     },
     {
         // GitaDoraWindowedMainMonitor
@@ -2506,7 +2539,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "\\\\.\\DISPLAY1",
         .game_name = "GitaDora",
-        .category = "Windowed",
+        .category = "Windowed Settings",
         .picker = OptionPickerType::Monitor,
     },
     {
@@ -2518,7 +2551,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "\\\\.\\DISPLAY2",
         .game_name = "GitaDora",
-        .category = "Windowed",
+        .category = "Windowed Settings",
         .picker = OptionPickerType::Monitor,
     },
     {
@@ -2530,7 +2563,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "\\\\.\\DISPLAY3",
         .game_name = "GitaDora",
-        .category = "Windowed",
+        .category = "Windowed Settings",
         .picker = OptionPickerType::Monitor,
     },
     {
@@ -2542,7 +2575,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "\\\\.\\DISPLAY4",
         .game_name = "GitaDora",
-        .category = "Windowed",
+        .category = "Windowed Settings",
         .picker = OptionPickerType::Monitor,
     },
     {
@@ -2553,7 +2586,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "1280,720",
         .game_name = "Beatmania IIDX",
-        .category = "Windowed",
+        .category = "Windowed Settings",
     },
     {
         // spice2x_IIDXWindowedSubscreenPosition
@@ -2563,7 +2596,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "0,0",
         .game_name = "Beatmania IIDX",
-        .category = "Windowed",
+        .category = "Windowed Settings",
     },
     {
         // IIDXWindowedSubscreenBorderless
@@ -2572,7 +2605,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Remove window decoration from windowed subscreen.",
         .type = OptionType::Bool,
         .game_name = "Beatmania IIDX",
-        .category = "Windowed",
+        .category = "Windowed Settings",
     },
     {
         // IIDXWindowedSubscreenAlwaysOnTop
@@ -2581,7 +2614,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Keep windowed subscreen on top.",
         .type = OptionType::Bool,
         .game_name = "Beatmania IIDX",
-        .category = "Windowed",
+        .category = "Windowed Settings",
     },
     {
         // spice2x_JubeatLegacyTouch
@@ -2610,6 +2643,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             {"improved", ""},
             {"accurate", ""},
         },
+        .quick_setting_category = "Game",
     },
     {
         // spice2x_RBTouchScale
@@ -2741,6 +2775,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Bool,
         .game_name = "Beatmania IIDX",
         .category = "Game Options",
+        .quick_setting_category = "Game",
     },
     {
         // IIDXSubMonitorOverride
@@ -2750,7 +2785,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "\\\\.\\DISPLAY3",
         .game_name = "Beatmania IIDX",
-        .category = "Full Screen",
+        .category = "Full Screen Settings",
         .picker = OptionPickerType::Monitor,
     },
     {
@@ -2784,6 +2819,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             {"p2", ""},
             {"both", ""},
         },
+        .quick_setting_category = "Network",
     },
     {
         // spice2x_TapeLedAlgorithm
@@ -2838,6 +2874,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Bool,
         .game_name = "Sound Voltex",
         .category = "Game Options",
+        .quick_setting_category = "Game",
     },
     {
         // SDVXFullscreenLandscape
@@ -2999,7 +3036,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "1920,1080",
         .game_name = "Sound Voltex",
-        .category = "Windowed",
+        .category = "Windowed Settings",
     },
     {
         // SDVXWindowedSubscreenPosition
@@ -3009,7 +3046,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "0,0",
         .game_name = "Sound Voltex",
-        .category = "Windowed",
+        .category = "Windowed Settings",
     },
     {
         // SDVXWindowedSubscreenBorderless
@@ -3018,7 +3055,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Remove window decoration from windowed subscreen.",
         .type = OptionType::Bool,
         .game_name = "Sound Voltex",
-        .category = "Windowed",
+        .category = "Windowed Settings",
     },
     {
         // SDVXWindowedSubscreenAlwaysOnTop
@@ -3027,7 +3064,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Keep windowed subscreen on top.",
         .type = OptionType::Bool,
         .game_name = "Sound Voltex",
-        .category = "Windowed",
+        .category = "Windowed Settings",
     },
     {
         // LovePlusCamEnable
@@ -3103,6 +3140,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Bool,
         .game_name = "Otoca D'or",
         .category = "Cab Peripherals",
+        .quick_setting_category = "Game",
     },
     {
         // DisableHighResTimer
@@ -3154,8 +3192,6 @@ const std::vector<std::string> &launcher::get_categories(Options::OptionsCategor
     switch (category) {
         case Options::OptionsCategory::API:
             return CATEGORY_ORDER_API;
-        case Options::OptionsCategory::Basic:
-            return CATEGORY_ORDER_BASIC;
         case Options::OptionsCategory::GameOptions:
             return CATEGORY_ORDER_GAME_OPTIONS;
         case Options::OptionsCategory::Display:
@@ -3174,6 +3210,10 @@ const std::vector<std::string> &launcher::get_categories(Options::OptionsCategor
         default:
             return CATEGORY_ORDER_NONE;
     }
+}
+
+const std::vector<std::string> &launcher::get_quick_setting_categories() {
+    return CATEGORY_ORDER_QUICK;
 }
 
 const std::vector<OptionDefinition> &launcher::get_option_definitions() {

--- a/src/spice2x/launcher/options.cpp
+++ b/src/spice2x/launcher/options.cpp
@@ -13,7 +13,7 @@
 #endif
 
 static const std::vector<std::string> CATEGORY_ORDER_API = {
-    "SpiceCompanion and API",
+    "Companion & API",
     "API (Serial)",
     "API (Dev)",
     "BT5 API",
@@ -23,19 +23,38 @@ static const std::vector<std::string> CATEGORY_ORDER_BASIC = {
     "Game Options",
     "Common",
     "Network",
+    "Graphics",
+    "Audio",
+};
+
+static const std::vector<std::string> CATEGORY_ORDER_GAME_OPTIONS = {
+    "Game Options",
+    "Advanced Game Options",
+    "Cab Peripherals",
+};
+
+static const std::vector<std::string> CATEGORY_ORDER_DISPLAY = {
     "Monitor",
-    "Graphics (Common)",
-    "Graphics (Full Screen)",
-    "Graphics (Windowed)",
+    "Graphics",
+    "Full Screen",
+    "Windowed",
+};
+
+static const std::vector<std::string> CATEGORY_ORDER_AUDIO = {
     "Audio",
     "Audio (Conversion)",
+    "Audio (Hacks)",
+};
+
+static const std::vector<std::string> CATEGORY_ORDER_NETWORK = {
+    "Network",
+    "Auto PIN",
+    "Network (Advanced)",
+    "Network (Development)",
 };
 
 static const std::vector<std::string> CATEGORY_ORDER_ADVANCED = {
-    "Game Options (Advanced)",
-    "Game Options (Peripherals)",
     "Overlay",
-    "Network (Advanced)",
     "Performance",
     "Miscellaneous",
     "Touch Parameters",
@@ -44,8 +63,6 @@ static const std::vector<std::string> CATEGORY_ORDER_ADVANCED = {
 };
 static const std::vector<std::string> CATEGORY_ORDER_DEV = {
     "Path Overrides",
-    "Network (Development)",
-    "Audio (Hacks)",
     "I/O Modules",
     "Development",
     "Debug Log",
@@ -145,7 +162,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Set a PIN for Player 1 that will cause the PIN to be automatically typed when Player 1 PIN Macro overlay key is pressed.",
         .type = OptionType::Text,
         .setting_name = "1234",
-        .category = "Network (Advanced)",
+        .category = "Auto PIN",
         .sensitive = true,
     },
     {
@@ -155,7 +172,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Set a PIN for Player 2 that will cause the PIN to be automatically typed when Player 2 PIN Macro overlay key is pressed.",
         .type = OptionType::Text,
         .setting_name = "5678",
-        .category = "Network (Advanced)",
+        .category = "Auto PIN",
         .sensitive = true,
     },
     {
@@ -167,7 +184,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "screen is ready. When the substring appears in any log line, the PIN macro is "
             "typed for Player 1 only. Leave blank to disable auto-trigger for P1.",
         .type = OptionType::Text,
-        .category = "Network (Advanced)",
+        .category = "Auto PIN",
     },
     {
         // AutoPinMacroTrigger1
@@ -178,14 +195,14 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "screen is ready. When the substring appears in any log line, the PIN macro is "
             "typed for Player 2 only. Leave blank to disable auto-trigger for P2.",
         .type = OptionType::Text,
-        .category = "Network (Advanced)",
+        .category = "Auto PIN",
     },
     {
         .title = "Windowed Mode",
         .name = "w",
         .desc = "Enables windowed mode.",
         .type = OptionType::Bool,
-        .category = "Graphics (Windowed)",
+        .category = "Graphics",
     },
     {
         // InjectHook
@@ -254,7 +271,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "Not all games will respect this. Not recommended for multi-monitor games like Lightning Model / Valkyrie Model modes. "
             "Disable Full Screen Optimizations for best results.",
         .type = OptionType::Integer,
-        .category = "Graphics (Full Screen)",
+        .category = "Full Screen",
     },
     {
         .title = "Only Use Main Monitor For Full Screen",
@@ -262,7 +279,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Force the graphics device to be opened utilizing only one adapter in multi-monitor systems.\n\n"
             "May cause unstable framerate and desyncs, especially if monitors have different refresh rates!",
         .type = OptionType::Bool,
-        .category = "Graphics (Full Screen)",
+        .category = "Full Screen",
     },
     {
         .title = "Monitor Refresh Rate",
@@ -282,7 +299,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "This should only be used as last resort if your GPU/monitor can't display the resolution required by the game.",
         .type = OptionType::Text,
         .setting_name = "1280,720",
-        .category = "Graphics (Full Screen)"
+        .category = "Full Screen"
     },
     {
         // FullscreenOrientationFlip
@@ -296,7 +313,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "with Live2D!",
         .type = OptionType::Bool,
         .hidden = true,
-        .category = "Graphics (Full Screen)"
+        .category = "Full Screen"
     },
     {
         // FullscreenSubResolution
@@ -308,7 +325,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "WARNING: experimental as we have not done extensive testing to see if this causes desyncs.",
         .type = OptionType::Text,
         .setting_name = "1280,720",
-        .category = "Graphics (Full Screen)"
+        .category = "Full Screen"
     },
     {
         // FullscreenSubRefreshRate
@@ -319,7 +336,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "useful if you have a sub monitor that is not quite exactly 60Hz.\n\n"
             "WARNING: experimental as we have not done extensive testing to see if this causes desyncs.",
         .type = OptionType::Integer,
-        .category = "Graphics (Full Screen)"
+        .category = "Full Screen"
     },
     {
         // Graphics9On12
@@ -328,7 +345,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Use D3D9On12 wrapper library, requires Windows 10. Deprecated - use -dx9on12 instead.",
         .type = OptionType::Bool,
         .hidden = true,
-        .category = "Graphics (Common)",
+        .category = "Graphics",
     },
     {
         // spice2x_Dx9On12
@@ -339,7 +356,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Use D3D9On12 wrapper library, requires Windows 10. Has no effect on games that don't use DX9. Can cause some games to crash.\n\n"
             "Default: auto (use DX9 for most games, but turn on 9on12 for games that require it on non-NVIDIA GPUs).",
         .type = OptionType::Enum,
-        .category = "Graphics (Common)",
+        .category = "Graphics",
         .elements = {
             {"auto", "Automatic"},
             {"0", "Use DX9"},
@@ -358,6 +375,13 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .name = "richpresence",
         .desc = "Enables Discord Rich Presence support.",
         .type = OptionType::Bool,
+        .category = "Miscellaneous",
+    },
+    {
+        .title = "Discord RPC AppID Override",
+        .name = "discordappid",
+        .desc = "Set the discord RPC AppID override.",
+        .type = OptionType::Text,
         .category = "Miscellaneous",
     },
     {
@@ -393,7 +417,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "This is NOT the EA service URL; use -url for that. "
             "Force the use of an adapter with the specified network. Must also provide -subnet.",
         .type = OptionType::Text,
-        .category = "Network (Development)",
+        .category = "Network (Advanced)",
         .sensitive = true,
     },
     {
@@ -401,7 +425,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .name = "subnet",
         .desc = "Force the use of an adapter with the specified subnet. Must also provide -network.",
         .type = OptionType::Text,
-        .category = "Network (Development)",
+        .category = "Network (Advanced)",
     },
     {
         .title = "Disable Network Fixes",
@@ -561,7 +585,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Manually enable Beatmania IIDX module.",
         .type = OptionType::Bool,
         .game_name = "Beatmania IIDX",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "IIDX Camera Order Flip",
@@ -569,7 +593,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Flip the camera order.",
         .type = OptionType::Bool,
         .game_name = "Beatmania IIDX",
-        .category = "Game Options (Peripherals)",
+        .category = "Cab Peripherals",
     },
     {
         // IIDXDisableCameras
@@ -579,7 +603,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Bool,
         .hidden = true,
         .game_name = "Beatmania IIDX",
-        .category = "Game Options (Peripherals)",
+        .category = "Cab Peripherals",
     },
     {
         // IIDXCabCamAccess
@@ -589,7 +613,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "Only turn this on if you have OFFICIAL arcade cameras connected to the correct USB ports. Default: auto.",
         .type = OptionType::Enum,
         .game_name = "Beatmania IIDX",
-        .category = "Game Options (Peripherals)",
+        .category = "Cab Peripherals",
         .elements = {
             {"auto", ""},
             {"off", ""},
@@ -605,7 +629,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Experimental camera support for IIDX 27+ via texture hooking. Requires camera(s) that support YUY2 or NV12 encoding.",
         .type = OptionType::Bool,
         .game_name = "Beatmania IIDX",
-        .category = "Game Options (Peripherals)",
+        .category = "Cab Peripherals",
     },
     {
         // IIDXCamHookRatio
@@ -617,7 +641,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Enum,
         .hidden = true,
         .game_name = "Beatmania IIDX",
-        .category = "Game Options (Peripherals)",
+        .category = "Cab Peripherals",
         .elements = {
             {"43", "4:3"},
             {"169", "16:9"},
@@ -635,7 +659,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "0x5817a0,0x6fffbd8,0xbbae40,0xe0,0x30",
         .game_name = "Beatmania IIDX",
-        .category = "Game Options (Peripherals)",
+        .category = "Cab Peripherals",
     },
     {
         // IIDXCamHookTopId
@@ -650,7 +674,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "vid_1234&pid_5678",
         .game_name = "Beatmania IIDX",
-        .category = "Game Options (Peripherals)",
+        .category = "Cab Peripherals",
     },
     {
         // IIDXCamHookFrontId
@@ -665,7 +689,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "vid_90ab&pid_cdef",
         .game_name = "Beatmania IIDX",
-        .category = "Game Options (Peripherals)",
+        .category = "Cab Peripherals",
     },
     {
         .title = "IIDX Sound Output Device",
@@ -700,7 +724,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Bool,
         .hidden = true,
         .game_name = "Beatmania IIDX",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "IIDX TDJ Mode (Lightning Model)",
@@ -720,7 +744,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Integer,
         .setting_name = "(0-255)",
         .game_name = "Beatmania IIDX",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         // IIDXDigitalTTSocd
@@ -732,7 +756,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "neutral (default): TT does not move when both directions are pressed, recommended to avoid excessive POORs.",
         .type = OptionType::Enum,
         .game_name = "Beatmania IIDX",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
         .elements = {
             {"last", ""},
             {"first", ""},
@@ -748,7 +772,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Force Definition Type HD (720p) mode instead of FHD (1080p) for IIDX30+. Only for LDJ! TDJ is always FHD in IIDX30+.",
         .type = OptionType::Bool,
         .game_name = "Beatmania IIDX",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         // spice2x_IIDXTDJSubSize
@@ -825,7 +849,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Manually enable Sound Voltex Module.",
         .type = OptionType::Bool,
         .game_name = "Sound Voltex",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "SDVX Vivid Wave Force 720p Window (DEPRECATED - use -windowsize instead)",
@@ -834,7 +858,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Bool,
         .hidden = true,
         .game_name = "Sound Voltex",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "SDVX Printer Emulation",
@@ -842,7 +866,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Enable Sound Voltex printer emulation.",
         .type = OptionType::Bool,
         .game_name = "Sound Voltex",
-        .category = "Game Options (Peripherals)",
+        .category = "Cab Peripherals",
     },
     {
         // SDVXPrinterOutputPath
@@ -851,7 +875,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Path to folder where images will be stored.",
         .type = OptionType::Text,
         .game_name = "Sound Voltex",
-        .category = "Game Options (Peripherals)",
+        .category = "Cab Peripherals",
         .picker = OptionPickerType::DirectoryPath,
     },
     {
@@ -860,7 +884,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Clean up saved images in the output directory on startup.",
         .type = OptionType::Bool,
         .game_name = "Sound Voltex",
-        .category = "Game Options (Peripherals)",
+        .category = "Cab Peripherals",
     },
     {
         .title = "SDVX Printer Output Overwrite",
@@ -868,7 +892,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Always overwrite the same file in output directory.",
         .type = OptionType::Bool,
         .game_name = "Sound Voltex",
-        .category = "Game Options (Peripherals)",
+        .category = "Cab Peripherals",
     },
     {
         // SDVXPrinterOutputFormat
@@ -878,7 +902,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "(png/bmp/tga/jpg)",
         .game_name = "Sound Voltex",
-        .category = "Game Options (Peripherals)",
+        .category = "Cab Peripherals",
     },
     {
         .title = "SDVX Printer JPG Quality",
@@ -887,7 +911,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Integer,
         .setting_name = "(0-100)",
         .game_name = "Sound Voltex",
-        .category = "Game Options (Peripherals)",
+        .category = "Cab Peripherals",
     },
     {
         .title = "SDVX Disable Cameras (DEPRECATED - no longer needed)",
@@ -898,7 +922,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Bool,
         .hidden = true,
         .game_name = "Sound Voltex",
-        .category = "Game Options (Peripherals)",
+        .category = "Cab Peripherals",
     },
     {
         .title = "SDVX FS Subscreen Native Touch Handling",
@@ -909,7 +933,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
                 "Enable this when you get duplicate touch inputs from an actual touch screen.",
         .type = OptionType::Bool,
         .game_name = "Sound Voltex",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         // spice2x_SDVXSubRedraw
@@ -921,7 +945,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "this option forces subscreen to redraw every frame.",
         .type = OptionType::Bool,
         .game_name = "Sound Voltex",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         // spice2x_SDVXDigitalKnobSensitivity
@@ -933,7 +957,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Integer,
         .setting_name = "(0-255)",
         .game_name = "Sound Voltex",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         // SDVXDigitalKnobSocd
@@ -945,7 +969,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "neutral: knob does not move when both directions are pressed.",
         .type = OptionType::Enum,
         .game_name = "Sound Voltex",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
         .elements = {
             {"last", ""},
             {"first", ""},
@@ -1001,7 +1025,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "\\\\.\\DISPLAY3",
         .game_name = "Sound Voltex",
-        .category = "Graphics (Full Screen)",
+        .category = "Full Screen",
         .picker = OptionPickerType::Monitor,
     },
     {
@@ -1010,7 +1034,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Manually enable Dance Dance Revolution module.",
         .type = OptionType::Bool,
         .game_name = "Dance Dance Revolution",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "DDR 4:3 Mode",
@@ -1027,7 +1051,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Prevent automatic registration of codecs in the com folder.",
         .type = OptionType::Bool,
         .game_name = "Dance Dance Revolution",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "Force Load Pop'n Music Module",
@@ -1035,7 +1059,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Manually enable Pop'n Music module.",
         .type = OptionType::Bool,
         .game_name = "Pop'n Music",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "Pop'n Music Force HD Mode",
@@ -1070,7 +1094,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "\\\\.\\DISPLAY3",
         .game_name = "Pop'n Music",
-        .category = "Graphics (Full Screen)",
+        .category = "Full Screen",
         .picker = OptionPickerType::Monitor,
     },
     {
@@ -1083,7 +1107,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
                 "Enable this when you get duplicate touch inputs from an actual touch screen.",
         .type = OptionType::Bool,
         .game_name = "Pop'n Music",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "Force Load HELLO! Pop'n Music Module",
@@ -1091,7 +1115,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Manually enable HELLO! Pop'n Music module.",
         .type = OptionType::Bool,
         .game_name = "HELLO! Pop'n Music",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "Force Load GitaDora Module",
@@ -1099,7 +1123,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Manually enable GitaDora module.",
         .type = OptionType::Bool,
         .game_name = "GitaDora",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "GitaDora Two Channel Audio",
@@ -1247,7 +1271,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Manually enable Jubeat module.",
         .type = OptionType::Bool,
         .game_name = "Jubeat",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "Force Load Reflec Beat Module",
@@ -1255,7 +1279,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Manually enable Reflec Beat module.",
         .type = OptionType::Bool,
         .game_name = "Reflec Beat",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "Force Load Tenkaichi Shogikai Module",
@@ -1263,7 +1287,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Manually enable Tenkaichi Shogikai module.",
         .type = OptionType::Bool,
         .game_name = "Tenkaichi Shogikai",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "Force Load Beatstream Module",
@@ -1271,7 +1295,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Manually enable Beatstream module.",
         .type = OptionType::Bool,
         .game_name = "Beatstream",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "Force Load Nostalgia Module",
@@ -1279,7 +1303,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Manually enable Nostalgia module.",
         .type = OptionType::Bool,
         .game_name = "Nostalgia",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "Force Load Dance Evolution Module",
@@ -1287,7 +1311,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Manually enable Dance Evolution module.",
         .type = OptionType::Bool,
         .game_name = "Dance Evolution",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "Force Load FutureTomTom Module",
@@ -1295,7 +1319,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Manually enable FutureTomTom module.",
         .type = OptionType::Bool,
         .game_name = "FutureTomTom",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "Force Load BBC Module",
@@ -1303,7 +1327,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Manually enable Bishi Bashi Channel module.",
         .type = OptionType::Bool,
         .game_name = "Bishi Bashi Channel",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "Force Load Metal Gear Arcade Module",
@@ -1311,7 +1335,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Manually enable Metal Gear Arcade module.",
         .type = OptionType::Bool,
         .game_name = "Metal Gear",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "Force Load Quiz Magic Academy Module",
@@ -1319,7 +1343,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Manually enable Quiz Magic Academy module.",
         .type = OptionType::Bool,
         .game_name = "Quiz Magic Academy",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "Force Load Road Fighters 3D Module",
@@ -1327,7 +1351,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Manually enable Road Fighters 3D module.",
         .type = OptionType::Bool,
         .game_name = "Road Fighters 3D",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "Force Load Steel Chronicle Module",
@@ -1335,7 +1359,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Manually enable Steel Chronicle module.",
         .type = OptionType::Bool,
         .game_name = "Steel Chronicle",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "Force Load Mahjong Fight Club Module",
@@ -1343,7 +1367,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Manually enable Mahjong Fight Club module.",
         .type = OptionType::Bool,
         .game_name = "Mahjong Fight Club",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "Force Load Scotto Module",
@@ -1351,7 +1375,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Manually enable Scotto module.",
         .type = OptionType::Bool,
         .game_name = "Scotto",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "Force Load Dance Rush Module",
@@ -1359,7 +1383,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Manually enable Dance Rush module.",
         .type = OptionType::Bool,
         .game_name = "DANCERUSH",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "Force Load Winning Eleven Module",
@@ -1367,7 +1391,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Manually enable Winning Eleven module.",
         .type = OptionType::Bool,
         .game_name = "Winning Eleven",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "Force Load Otoca D'or Module",
@@ -1375,7 +1399,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Manually enable Otoca D'or module.",
         .type = OptionType::Bool,
         .game_name = "Otoca D'or",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "Force Load LovePlus Module",
@@ -1383,7 +1407,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Manually enable LovePlus module.",
         .type = OptionType::Bool,
         .game_name = "LovePlus",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "Force Load Charge Machine Module",
@@ -1391,7 +1415,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Manually enable Charge Machine module.",
         .type = OptionType::Bool,
         .game_name = "Charge Machine",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "Force Load Ongaku Paradise Module",
@@ -1399,7 +1423,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Manually enable Ongaku Paradise module.",
         .type = OptionType::Bool,
         .game_name = "Ongaku Paradise",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "Force Load Busou Shinki Module",
@@ -1407,7 +1431,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Manually enable Busou Shinki module.",
         .type = OptionType::Bool,
         .game_name = "Busou Shinki: Armored Princess Battle Conductor",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         // LoadCCJModule
@@ -1416,7 +1440,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Manually enable Chase Chase Jokers module.",
         .type = OptionType::Bool,
         .game_name = "Chase Chase Jokers",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         // LoadQKSModule
@@ -1425,7 +1449,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Manually enable QuizKnock STADIUM module.",
         .type = OptionType::Bool,
         .game_name = "QuizKnock STADIUM",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         // LoadMFGModule
@@ -1434,7 +1458,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Manually enable Mahjong Fight Girl module.",
         .type = OptionType::Bool,
         .game_name = "Mahjong Fight Girl",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         // LoadPCModule
@@ -1443,7 +1467,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Manually enable Polaris Chord module.",
         .type = OptionType::Bool,
         .game_name = "Polaris Chord",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         // LoadMusecaModule
@@ -1452,7 +1476,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Manually enable Museca module.",
         .type = OptionType::Bool,
         .game_name = "Museca",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "Modules Folder Override",
@@ -1560,14 +1584,14 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .name = "api",
         .desc = "Port the API should be listening on.",
         .type = OptionType::Integer,
-        .category = "SpiceCompanion and API",
+        .category = "Companion & API",
     },
     {
         .title = "API Password",
         .name = "apipass",
         .desc = "Set the custom user password needed to use the API.",
         .type = OptionType::Text,
-        .category = "SpiceCompanion and API",
+        .category = "Companion & API",
         .sensitive = true,
     },
     {
@@ -1613,7 +1637,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "Value must be between 0 (poor quality) and 100 (best quality), inclusive. Default: 70.",
         .type = OptionType::Integer,
         .setting_name = "(0-100)",
-        .category = "SpiceCompanion and API",
+        .category = "Companion & API",
     },
     {
         // APIScreenMirrorDivide
@@ -1625,7 +1649,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "Value must be 1 or greater. Default: 1.",
         .type = OptionType::Integer,
         .setting_name = "1",
-        .category = "SpiceCompanion and API",
+        .category = "Companion & API",
     },
     {
         .title = "Enable All IO Modules",
@@ -1894,7 +1918,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Broken feature that was not implemented correctly.",
         .type = OptionType::Bool,
         .hidden = true,
-        .category = "Graphics (Common)",
+        .category = "Graphics",
     },
     {
         // spice2x_NvapiProfile
@@ -1909,7 +1933,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
                 "G-SYNC may fail to disable properly; try enabling full-screen optimizations (FSO) for spice(64).exe.\n\n"
                 "May not work as expected for some games; namely G-SYNC and SDVX.",
         .type = OptionType::Bool,
-        .category = "Graphics (Common)",
+        .category = "Graphics",
     },
     {
         // DisableAudioHooks
@@ -2130,7 +2154,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
                 "-graphics-force-refresh flag to fix.",
         .type = OptionType::Bool,
         .hidden = true, // superseded by sp2x-autoorientation
-        .category = "Graphics (Common)",
+        .category = "Graphics",
     },
     {
         // spice2x_AutoOrientation
@@ -2179,14 +2203,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Enable automap in network dumping configuration.",
         .type = OptionType::Bool,
         .category = "Network (Development)",
-    },
-    {
-        .title = "Discord RPC AppID Override",
-        .name = "discordappid",
-        .desc = "Set the discord RPC AppID override.",
-        .type = OptionType::Text,
-        .category = "Development",
-    },
+    },    
     {
         .title = "Blocking Logger",
         .name = "logblock",
@@ -2295,7 +2312,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "",
         .game_name = "QuizKnock STADIUM",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "CCJ Arguments Override",
@@ -2305,7 +2322,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "",
         .game_name = "Chase Chase Jokers",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "CCJ Mouse Trackball",
@@ -2340,7 +2357,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "",
         .game_name = "Mahjong Fight Girl",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         .title = "MFG Cabinet Type",
@@ -2364,7 +2381,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Bool,
         .setting_name = "",
         .game_name = "Mahjong Fight Girl",
-        .category = "Game Options (Advanced)"
+        .category = "Advanced Game Options"
     },
     {
         // PCArgs
@@ -2374,7 +2391,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "",
         .game_name = "Polaris Chord",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         // PCNoIO
@@ -2384,7 +2401,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Bool,
         .setting_name = "",
         .game_name = "Polaris Chord",
-        .category = "Game Options (Advanced)"
+        .category = "Advanced Game Options"
     },
     {
         // PCKnobMode
@@ -2417,7 +2434,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "Does not work for all games; can possibly make the game crash! "
             "Can also be changed in Screen Resize window (default F11).",
         .type = OptionType::Enum,
-        .category = "Graphics (Windowed)",
+        .category = "Windowed",
         // match cfg::WindowDecorationMode
         .elements = {
             {"0", "default"},
@@ -2435,7 +2452,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "Can also be changed in Screen Resize window (default F11).",
         .type = OptionType::Text,
         .setting_name = "1280,720",
-        .category = "Graphics (Windowed)",
+        .category = "Windowed",
     },
     {
         // spice2x_WindowPosition
@@ -2447,7 +2464,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "Can also be changed in Screen Resize window (default F11).",
         .type = OptionType::Text,
         .setting_name = "120,240",
-        .category = "Graphics (Windowed)",
+        .category = "Windowed",
     },
     {
         // spice2x_WindowAlwaysOnTop
@@ -2458,7 +2475,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "For windowed mode: make window to be always on top of other windows. "
             "Can also be changed in Screen Resize window (default F11).",
         .type = OptionType::Bool,
-        .category = "Graphics (Windowed)",
+        .category = "Windowed",
     },
     {
         // WindowForceScaling
@@ -2467,7 +2484,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "For windowed mode: forcibly set DX9 back buffer dimensions to match window size. "
             "Reduces pixelated scaling artifacts. Works great for some games, but can COMPLETELY BREAK other games - YMMV!",
         .type = OptionType::Bool,
-        .category = "Graphics (Windowed)",
+        .category = "Windowed",
     },
     {
         // WindowDisableRoundedCorners
@@ -2475,7 +2492,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .name = "windownoroundcorners",
         .desc = "Windows 11 and above only: Disables rounded corners on the game window(s).",
         .type = OptionType::Bool,
-        .category = "Graphics (Windowed)",
+        .category = "Windowed",
     },
     {
         // GitaDoraWindowedMainMonitor
@@ -2486,7 +2503,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "\\\\.\\DISPLAY1",
         .game_name = "GitaDora",
-        .category = "Graphics (Windowed)",
+        .category = "Windowed",
         .picker = OptionPickerType::Monitor,
     },
     {
@@ -2498,7 +2515,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "\\\\.\\DISPLAY2",
         .game_name = "GitaDora",
-        .category = "Graphics (Windowed)",
+        .category = "Windowed",
         .picker = OptionPickerType::Monitor,
     },
     {
@@ -2510,7 +2527,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "\\\\.\\DISPLAY3",
         .game_name = "GitaDora",
-        .category = "Graphics (Windowed)",
+        .category = "Windowed",
         .picker = OptionPickerType::Monitor,
     },
     {
@@ -2522,7 +2539,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "\\\\.\\DISPLAY4",
         .game_name = "GitaDora",
-        .category = "Graphics (Windowed)",
+        .category = "Windowed",
         .picker = OptionPickerType::Monitor,
     },
     {
@@ -2533,7 +2550,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "1280,720",
         .game_name = "Beatmania IIDX",
-        .category = "Graphics (Windowed)",
+        .category = "Windowed",
     },
     {
         // spice2x_IIDXWindowedSubscreenPosition
@@ -2543,7 +2560,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "0,0",
         .game_name = "Beatmania IIDX",
-        .category = "Graphics (Windowed)",
+        .category = "Windowed",
     },
     {
         // IIDXWindowedSubscreenBorderless
@@ -2552,7 +2569,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Remove window decoration from windowed subscreen.",
         .type = OptionType::Bool,
         .game_name = "Beatmania IIDX",
-        .category = "Graphics (Windowed)",
+        .category = "Windowed",
     },
     {
         // IIDXWindowedSubscreenAlwaysOnTop
@@ -2561,7 +2578,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Keep windowed subscreen on top.",
         .type = OptionType::Bool,
         .game_name = "Beatmania IIDX",
-        .category = "Graphics (Windowed)",
+        .category = "Windowed",
     },
     {
         // spice2x_JubeatLegacyTouch
@@ -2649,7 +2666,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Bool,
         .hidden = true,
         .game_name = "Beatmania IIDX",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         // spice2x_IIDXWindowedTDJ
@@ -2695,7 +2712,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "Note: this is NOT for the motion camera - you still need a real RealSense camera for that!",
         .type = OptionType::Bool,
         .game_name = "DANCERUSH",
-        .category = "Game Options (Peripherals)",
+        .category = "Cab Peripherals",
     },
     {
         // spice2x_IIDXNativeTouch
@@ -2709,7 +2726,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
                 "Enable this when you get duplicate touch inputs from an actual touch screen.",
         .type = OptionType::Bool,
         .game_name = "Beatmania IIDX",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         // spice2x_IIDXNoSub
@@ -2730,7 +2747,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "\\\\.\\DISPLAY3",
         .game_name = "Beatmania IIDX",
-        .category = "Graphics (Full Screen)",
+        .category = "Full Screen",
         .picker = OptionPickerType::Monitor,
     },
     {
@@ -2744,7 +2761,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "00 is mapped to erase button, and Decimal shows/hides the keypad.",
         .type = OptionType::Bool,
         .game_name = "Beatmania IIDX",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         // spice2x_AutoCard
@@ -2793,7 +2810,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "results to the game (e.g., wrong values from NvDisplayConfig for SDVX). You may need to apply additional "
             "hex edits to boot the game correctly.",
         .type = OptionType::Bool,
-        .category = "Graphics (Common)",
+        .category = "Graphics",
     },
     {
         // spice2x_NoD3D9DeviceHook
@@ -2806,7 +2823,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "screenshots, screen resize, touch emulation, streaming to Companion, etc.",
         .type = OptionType::Bool,
         .hidden = true,
-        .category = "Graphics (Common)",
+        .category = "Graphics",
     },
     {
         // spice2x_SDVXNoSub
@@ -2864,7 +2881,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "Two options: specify a single number (20) to set CQ Level, or specify comma-separated numbers (23,25,20) to set P, B, I levels.",
         .type = OptionType::Text,
         .game_name = "Beatmania IIDX",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         // IIDXRecDisable
@@ -2873,7 +2890,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "When enabled, this prevents the play record feature from being used.",
         .type = OptionType::Bool,
         .game_name = "Beatmania IIDX",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
     },
     {
         // MidiAlgoVer
@@ -2922,7 +2939,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "Only has an effect when emulating P4IO (arkmdxp4.dll).",
         .type = OptionType::Enum,
         .game_name = "Dance Dance Revolution",
-        .category = "Game Options (Advanced)",
+        .category = "Advanced Game Options",
         .elements = {
             {"auto", ""},
             {"thread", ""},
@@ -2965,7 +2982,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .name = "vsyncbuffer",
         .desc = "Using triple buffering may improve cases of micro-stuttering but increases input latency.",
         .type = OptionType::Enum,
-        .category = "Graphics (Common)",
+        .category = "Graphics",
         .elements = {
             {"2", "double buffer"},
             {"3", "triple buffer"},
@@ -2979,7 +2996,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "1920,1080",
         .game_name = "Sound Voltex",
-        .category = "Graphics (Windowed)",
+        .category = "Windowed",
     },
     {
         // SDVXWindowedSubscreenPosition
@@ -2989,7 +3006,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "0,0",
         .game_name = "Sound Voltex",
-        .category = "Graphics (Windowed)",
+        .category = "Windowed",
     },
     {
         // SDVXWindowedSubscreenBorderless
@@ -2998,7 +3015,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Remove window decoration from windowed subscreen.",
         .type = OptionType::Bool,
         .game_name = "Sound Voltex",
-        .category = "Graphics (Windowed)",
+        .category = "Windowed",
     },
     {
         // SDVXWindowedSubscreenAlwaysOnTop
@@ -3007,7 +3024,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Keep windowed subscreen on top.",
         .type = OptionType::Bool,
         .game_name = "Sound Voltex",
-        .category = "Graphics (Windowed)",
+        .category = "Windowed",
     },
     {
         // LovePlusCamEnable
@@ -3016,7 +3033,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Allow game to access camera; camera must be compatible with game.",
         .type = OptionType::Bool,
         .game_name = "LovePlus",
-        .category = "Game Options (Peripherals)",
+        .category = "Cab Peripherals",
     },
     {
         // LovePlusPrinterOutputPath
@@ -3025,7 +3042,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Path to folder where images will be stored.",
         .type = OptionType::Text,
         .game_name = "LovePlus",
-        .category = "Game Options (Peripherals)",
+        .category = "Cab Peripherals",
         .picker = OptionPickerType::DirectoryPath,
     },
     {
@@ -3034,7 +3051,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Clean up saved images in the output directory on startup.",
         .type = OptionType::Bool,
         .game_name = "LovePlus",
-        .category = "Game Options (Peripherals)",
+        .category = "Cab Peripherals",
     },
     {
         .title = "LovePlus Printer Output Overwrite",
@@ -3042,7 +3059,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Always overwrite the same file in output directory.",
         .type = OptionType::Bool,
         .game_name = "LovePlus",
-        .category = "Game Options (Peripherals)",
+        .category = "Cab Peripherals",
     },
     {
         // LovePlusPrinterOutputFormat
@@ -3052,7 +3069,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Text,
         .setting_name = "(png/bmp/tga/jpg)",
         .game_name = "LovePlus",
-        .category = "Game Options (Peripherals)",
+        .category = "Cab Peripherals",
     },
     {
         .title = "LovePlus Printer JPG Quality",
@@ -3061,7 +3078,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .type = OptionType::Integer,
         .setting_name = "(0-100)",
         .game_name = "LovePlus",
-        .category = "Game Options (Peripherals)",
+        .category = "Cab Peripherals",
     },
     {
         // OptionConflictResolution
@@ -3082,7 +3099,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "option to bypass camera error during boot, allowing you to try out the game.",
         .type = OptionType::Bool,
         .game_name = "Otoca D'or",
-        .category = "Game Options (Peripherals)",
+        .category = "Cab Peripherals",
     },
     {
         // DisableHighResTimer
@@ -3092,7 +3109,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
             "Recommended that you leave this OFF for optimal input latency, "
             "unless you're on a resource-constrained system (e.g., old cabinet PC)",
         .type = OptionType::Bool,
-        .category = "Development"
+        .category = "Performance"
     },
     {
         // EnableICMPHook
@@ -3136,6 +3153,14 @@ const std::vector<std::string> &launcher::get_categories(Options::OptionsCategor
             return CATEGORY_ORDER_API;
         case Options::OptionsCategory::Basic:
             return CATEGORY_ORDER_BASIC;
+        case Options::OptionsCategory::GameOptions:
+            return CATEGORY_ORDER_GAME_OPTIONS;
+        case Options::OptionsCategory::Display:
+            return CATEGORY_ORDER_DISPLAY;
+        case Options::OptionsCategory::Audio:
+            return CATEGORY_ORDER_AUDIO;
+        case Options::OptionsCategory::Network:
+            return CATEGORY_ORDER_NETWORK;
         case Options::OptionsCategory::Advanced:
             return CATEGORY_ORDER_ADVANCED;
         case Options::OptionsCategory::Dev:

--- a/src/spice2x/launcher/options.cpp
+++ b/src/spice2x/launcher/options.cpp
@@ -53,8 +53,11 @@ static const std::vector<std::string> CATEGORY_ORDER_NETWORK = {
     "Network (Development)",
 };
 
-static const std::vector<std::string> CATEGORY_ORDER_ADVANCED = {
+static const std::vector<std::string> CATEGORY_ORDER_OVERLAY = {
     "Overlay",
+};
+
+static const std::vector<std::string> CATEGORY_ORDER_ADVANCED = {
     "Performance",
     "Miscellaneous",
     "Touch Parameters",
@@ -3161,6 +3164,8 @@ const std::vector<std::string> &launcher::get_categories(Options::OptionsCategor
             return CATEGORY_ORDER_AUDIO;
         case Options::OptionsCategory::Network:
             return CATEGORY_ORDER_NETWORK;
+        case Options::OptionsCategory::Overlay:
+            return CATEGORY_ORDER_OVERLAY;
         case Options::OptionsCategory::Advanced:
             return CATEGORY_ORDER_ADVANCED;
         case Options::OptionsCategory::Dev:

--- a/src/spice2x/launcher/options.cpp
+++ b/src/spice2x/launcher/options.cpp
@@ -16,7 +16,7 @@
 
 static const std::vector<std::string> CATEGORY_ORDER_API = {
     "Companion & API",
-    "API over Serial",
+    "Serial API",
     "API Dev",
     "BT5 API",
 };
@@ -1640,14 +1640,14 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .name = "apiserial",
         .desc = "Serial port the API should be listening on.",
         .type = OptionType::Text,
-        .category = "API over Serial",
+        .category = "Serial API",
     },
     {
         .title = "API Serial Baud",
         .name = "apiserialbaud",
         .desc = "Baud rate for the serial port.",
         .type = OptionType::Integer,
-        .category = "API over Serial",
+        .category = "Serial API",
     },
     {
         .title = "API Pretty",

--- a/src/spice2x/launcher/options.h
+++ b/src/spice2x/launcher/options.h
@@ -325,6 +325,7 @@ namespace launcher {
     const std::vector<std::string> &get_categories(Options::OptionsCategory category);
     const std::vector<std::string> &get_quick_setting_categories();
     const std::vector<OptionDefinition> &get_option_definitions();
+    void validate_option_categories();
     std::unique_ptr<std::vector<Option>> parse_options(int argc, char *argv[]);
     std::vector<Option> merge_options(const std::vector<Option> &options, const std::vector<Option> &overrides);
 

--- a/src/spice2x/launcher/options.h
+++ b/src/spice2x/launcher/options.h
@@ -309,7 +309,6 @@ namespace launcher {
 
         enum class OptionsCategory {
             Everything,
-            Basic,
             GameOptions,
             Display,
             Audio,
@@ -324,6 +323,7 @@ namespace launcher {
     extern bool USE_CMD_OVERRIDE;
     
     const std::vector<std::string> &get_categories(Options::OptionsCategory category);
+    const std::vector<std::string> &get_quick_setting_categories();
     const std::vector<OptionDefinition> &get_option_definitions();
     std::unique_ptr<std::vector<Option>> parse_options(int argc, char *argv[]);
     std::vector<Option> merge_options(const std::vector<Option> &options, const std::vector<Option> &overrides);

--- a/src/spice2x/launcher/options.h
+++ b/src/spice2x/launcher/options.h
@@ -40,6 +40,7 @@ namespace launcher {
             spice2x_Dx9On12,
             NoLegacy,
             RichPresence,
+            DiscordAppID,
             SmartEAmusement,
             EAmusementMaintenance,
             spice2x_EAmusementMaintenance,
@@ -218,7 +219,6 @@ namespace launcher {
             LogLevel,
             EAAutomap,
             EANetdump,
-            DiscordAppID,
             BlockingLogger,
             DebugCreateFile,
             VerboseGraphicsLogging,
@@ -310,6 +310,10 @@ namespace launcher {
         enum class OptionsCategory {
             Everything,
             Basic,
+            GameOptions,
+            Display,
+            Audio,
+            Network,
             Advanced,
             Dev,
             API

--- a/src/spice2x/launcher/options.h
+++ b/src/spice2x/launcher/options.h
@@ -314,6 +314,7 @@ namespace launcher {
             Display,
             Audio,
             Network,
+            Overlay,
             Advanced,
             Dev,
             API

--- a/src/spice2x/overlay/windows/config.cpp
+++ b/src/spice2x/overlay/windows/config.cpp
@@ -64,7 +64,7 @@ namespace overlay::windows {
     constexpr ImVec4 TEXT_COLOR_RED(1.f, 0.f, 0.f, 1.f);
     constexpr uint32_t OPTION_INPUT_TEXT_WIDTH = 512;
 
-    // subtab groups shown in the "All" tab left navigation, in display order
+    // subtab groups shown in the Options tab left navigation, in display order
     static const std::vector<std::pair<const char *, launcher::Options::OptionsCategory>> OPTIONS_TAB_GROUPS = {
         { "Game Options", launcher::Options::OptionsCategory::GameOptions },
         { "Display", launcher::Options::OptionsCategory::Display },
@@ -243,8 +243,8 @@ namespace overlay::windows {
         const float nav_width = overlay::apply_scaling(130);
 
         // default to the first group on first display
-        if (this->all_nav_group_selected.empty()) {
-            this->all_nav_group_selected = OPTIONS_TAB_QUICK;
+        if (this->options_group_selected.empty()) {
+            this->options_group_selected = OPTIONS_TAB_QUICK;
         }
 
         auto options = games::get_options(this->games_selected_name);
@@ -275,7 +275,7 @@ namespace overlay::windows {
 
         // left navigation: one header per subtab, each listing its categories. clicking a
         // header selects that group; clicking a category scrolls the content to that section.
-        ImGui::BeginChild("AllNav", ImVec2(nav_width, content_height), false);
+        ImGui::BeginChild("OptionsNav", ImVec2(nav_width, content_height), false);
 
         // exact height of the global option controls pinned at the bottom of the nav
         const bool show_restart = !cfg::CONFIGURATOR_STANDALONE && this->options_dirty;
@@ -287,7 +287,7 @@ namespace overlay::windows {
         nav_controls_height += ctrl_spacing * 2.0f + 1.0f; // separator + padding
 
         // scrollable nav list (group headers and categories)
-        ImGui::BeginChild("AllNavList",
+        ImGui::BeginChild("OptionsNavList",
             ImVec2(0, content_height - nav_controls_height - ctrl_spacing), false);
 
         // extra vertical padding between nav rows (headers and tree items)
@@ -297,7 +297,7 @@ namespace overlay::windows {
 
         // arrow-less, non-collapsible nav header; selecting it clears any highlighted category
         auto nav_header = [this](const char *label) {
-            const bool active = this->all_nav_group_selected == label;
+            const bool active = this->options_group_selected == label;
             ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_Leaf;
             if (active) {
                 flags |= ImGuiTreeNodeFlags_Selected;
@@ -327,10 +327,22 @@ namespace overlay::windows {
             }
 
             if (ImGui::IsItemClicked()) {
-                this->all_nav_group_selected = label;
-                this->all_nav_selected.clear();
-                this->all_nav_scroll_top = true;
+                this->options_group_selected = label;
+                this->options_category_selected.clear();
+                this->options_scroll_top = true;
             }
+        };
+
+        // indented, selectable category row under a header; clicking it flags the
+        // content pane to scroll to that category's section
+        auto nav_category = [this](const char *group_label, const std::string &category) {
+            ImGui::Indent(INDENT * 0.5f);
+            if (ImGui::Selectable(category.c_str(), this->options_category_selected == category)) {
+                this->options_group_selected = group_label;
+                this->options_category_selected = category;
+                this->options_scroll_pending = true;
+            }
+            ImGui::Unindent(INDENT * 0.5f);
         };
 
         // search entry: selecting it shows the search box in the content pane
@@ -340,19 +352,12 @@ namespace overlay::windows {
         nav_header(OPTIONS_TAB_QUICK);
 
         // when quick settings is selected, list its categories so they can be jumped to
-        if (this->all_nav_group_selected == OPTIONS_TAB_QUICK) {
+        if (this->options_group_selected == OPTIONS_TAB_QUICK) {
             ImGui::PushID(OPTIONS_TAB_QUICK);
             for (const auto &category : launcher::get_quick_setting_categories()) {
-                if (!quick_categories.contains(category)) {
-                    continue;
+                if (quick_categories.contains(category)) {
+                    nav_category(OPTIONS_TAB_QUICK, category);
                 }
-                ImGui::Indent(INDENT * 0.5f);
-                if (ImGui::Selectable(category.c_str(), this->all_nav_selected == category)) {
-                    this->all_nav_group_selected = OPTIONS_TAB_QUICK;
-                    this->all_nav_selected = category;
-                    this->all_nav_scroll_pending = true;
-                }
-                ImGui::Unindent(INDENT * 0.5f);
             }
             ImGui::PopID();
         }
@@ -361,34 +366,22 @@ namespace overlay::windows {
             nav_header(group.first);
 
             // only the selected group expands to show its categories
-            if (this->all_nav_group_selected != group.first) {
+            if (this->options_group_selected != group.first) {
                 continue;
             }
 
             ImGui::PushID(group.first);
-
             for (const auto &category : launcher::get_categories(group.second)) {
-                if (category.empty()) {
-                    continue;
+                if (!category.empty() && visible_categories.contains(category)) {
+                    nav_category(group.first, category);
                 }
-                if (!visible_categories.contains(category)) {
-                    continue;
-                }
-                ImGui::Indent(INDENT * 0.5f);
-                if (ImGui::Selectable(category.c_str(), this->all_nav_selected == category)) {
-                    this->all_nav_group_selected = group.first;
-                    this->all_nav_selected = category;
-                    this->all_nav_scroll_pending = true;
-                }
-                ImGui::Unindent(INDENT * 0.5f);
             }
-
             ImGui::PopID();
         }
 
         ImGui::PopStyleVar();
 
-        ImGui::EndChild(); // AllNavList
+        ImGui::EndChild(); // OptionsNavList
 
         // global option controls pinned to the bottom of the nav
         ImGui::SetCursorPosY(content_height - nav_controls_height);
@@ -408,20 +401,29 @@ namespace overlay::windows {
 
         ImGui::PopStyleVar(); // ButtonTextAlign
 
-        ImGui::EndChild(); // AllNav
+        ImGui::EndChild(); // OptionsNav
         ImGui::SameLine();
 
         // content: only the options belonging to the selected group.
-        ImGui::BeginChild("AllOptions", ImVec2(0, content_height), false);
-        if (this->all_nav_scroll_top) {
+        ImGui::BeginChild("OptionsContent", ImVec2(0, content_height), false);
+        if (this->options_scroll_top) {
             ImGui::SetScrollY(0.0f);
-            this->all_nav_scroll_top = false;
+            this->options_scroll_top = false;
         }
 
         // breathing room at the top of the content area
         ImGui::Dummy(ImVec2(0.0f, overlay::apply_scaling(4)));
 
-        if (this->all_nav_group_selected == OPTIONS_TAB_SEARCH) {
+        // when a category was clicked in the nav, scroll the content to its section
+        auto scroll_anchor = [this](const std::string &category) {
+            if (this->options_scroll_pending && this->options_category_selected == category) {
+                ImGui::Dummy(ImVec2(0.0f, 0.0f));
+                ImGui::SetScrollHereY(0.0f);
+                this->options_scroll_pending = false;
+            }
+        };
+
+        if (this->options_group_selected == OPTIONS_TAB_SEARCH) {
 
             // search from all options
             ImGui::SetNextItemWidth(420.f);
@@ -448,39 +450,25 @@ namespace overlay::windows {
                         const_cast<std::string *>(&this->search_filter_in_lower_case));
                 }
             }
-        } else if (this->all_nav_group_selected == OPTIONS_TAB_QUICK) {
+        } else if (this->options_group_selected == OPTIONS_TAB_QUICK) {
             for (const auto &category : launcher::get_quick_setting_categories()) {
                 if (!quick_categories.contains(category)) {
                     continue;
                 }
-
-                // scroll anchor: when this category was clicked in the nav, jump to it
-                if (this->all_nav_scroll_pending && this->all_nav_selected == category) {
-                    ImGui::Dummy(ImVec2(0.0f, 0.0f));
-                    ImGui::SetScrollHereY(0.0f);
-                    this->all_nav_scroll_pending = false;
-                }
-
+                scroll_anchor(category);
                 this->build_options(options, category, nullptr, true);
             }
 
         } else {
             for (const auto &group : OPTIONS_TAB_GROUPS) {
-                if (this->all_nav_group_selected != group.first) {
+                if (this->options_group_selected != group.first) {
                     continue;
                 }
                 for (const auto &category : launcher::get_categories(group.second)) {
                     if (category.empty()) {
                         continue;
                     }
-
-                    // scroll anchor: when this category was clicked in the nav, jump to it
-                    if (this->all_nav_scroll_pending && this->all_nav_selected == category) {
-                        ImGui::Dummy(ImVec2(0.0f, 0.0f));
-                        ImGui::SetScrollHereY(0.0f);
-                        this->all_nav_scroll_pending = false;
-                    }
-
+                    scroll_anchor(category);
                     this->build_options(options, category);
                 }
             }
@@ -666,7 +654,7 @@ namespace overlay::windows {
                 ImGui::EndTabItem();
             }
             if (ImGui::BeginTabItem("Options")) {
-                tab_selected_new = ConfigTab::CONFIG_TAB_ALL_OPTIONS;
+                tab_selected_new = ConfigTab::CONFIG_TAB_OPTIONS;
                 this->build_options_tab(page_offset2);
                 ImGui::EndTabItem();
             }
@@ -4853,6 +4841,8 @@ namespace overlay::windows {
                 // option name
                 ImGui::TableNextColumn();
                 ImGui::PushStyleVarY(ImGuiStyleVar_ItemSpacing, 0);
+                const float row_indent = overlay::apply_scaling(8);
+                ImGui::Indent(row_indent);
 
                 if (option.is_active()) {
                     // active option
@@ -4894,6 +4884,7 @@ namespace overlay::windows {
                     clipboard::copy_text(param.c_str());
                 }
 
+                ImGui::Unindent(row_indent);
                 ImGui::PopStyleVar(); // ImGuiStyleVar_ItemSpacing
 
                 // option widgets

--- a/src/spice2x/overlay/windows/config.cpp
+++ b/src/spice2x/overlay/windows/config.cpp
@@ -63,6 +63,17 @@ namespace overlay::windows {
     constexpr ImVec4 TEXT_COLOR_RED(1.f, 0.f, 0.f, 1.f);
     constexpr uint32_t OPTION_INPUT_TEXT_WIDTH = 512;
 
+    // subtab groups shown in the "All" tab left navigation, in display order
+    static const std::vector<std::pair<const char *, launcher::Options::OptionsCategory>> ALL_TAB_GROUPS = {
+        { "API", launcher::Options::OptionsCategory::API },
+        { "Options", launcher::Options::OptionsCategory::Basic },
+        { "Advanced", launcher::Options::OptionsCategory::Advanced },
+        { "Development", launcher::Options::OptionsCategory::Dev },
+    };
+
+    // special "All" tab left-nav entry that shows the search box instead of a group
+    static const char *ALL_TAB_SEARCH = "Search";
+
     std::optional<std::vector<hooks::audio::AsioDriverScanEntry>> asio_driver_list;
 
     Config::Config(overlay::SpiceOverlay *overlay) : Window(overlay) {
@@ -219,6 +230,148 @@ namespace overlay::windows {
                 this->keypads_card_number[p][length < 16 ? length : 16] = 0;
                 f.close();
             }
+        }
+    }
+
+    void Config::build_options_tab(float page_offset) {
+        const float content_height = ImGui::GetWindowContentRegionMax().y - page_offset;
+        const float nav_width = overlay::apply_scaling(160);
+
+        // default to the first group on first display
+        if (this->all_nav_group_selected.empty()) {
+            this->all_nav_group_selected = ALL_TAB_GROUPS.front().first;
+        }
+
+        // left navigation: one header per subtab, each listing its categories. clicking a
+        // header selects that group; clicking a category scrolls the content to that section.
+        ImGui::BeginChild("AllNav", ImVec2(nav_width, content_height), true);
+
+        // arrow-less, non-collapsible nav header; selecting it clears any highlighted category
+        auto nav_header = [this](const char *label) {
+            ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_Leaf;
+            if (this->all_nav_group_selected == label) {
+                flags |= ImGuiTreeNodeFlags_Selected;
+            }
+            ImGui::CollapsingHeader(label, flags);
+            if (ImGui::IsItemClicked()) {
+                this->all_nav_group_selected = label;
+                this->all_nav_selected.clear();
+            }
+        };
+
+        // search entry: selecting it shows the search box in the content pane
+        nav_header(ALL_TAB_SEARCH);
+
+        for (const auto &group : ALL_TAB_GROUPS) {
+            nav_header(group.first);
+
+            ImGui::PushID(group.first);
+
+            // categories are always listed under the header
+            for (const auto &category : launcher::get_categories(group.second)) {
+                if (category.empty()) {
+                    continue;
+                }
+                ImGui::Indent(INDENT * 0.5f);
+                if (ImGui::Selectable(category.c_str(), this->all_nav_selected == category)) {
+                    this->all_nav_group_selected = group.first;
+                    this->all_nav_selected = category;
+                    this->all_nav_scroll_pending = true;
+                }
+                ImGui::Unindent(INDENT * 0.5f);
+            }
+
+            ImGui::PopID();
+        }
+
+        ImGui::EndChild();
+        ImGui::SameLine();
+
+        // content: only the options belonging to the selected group.
+        ImGui::BeginChild("AllOptions", ImVec2(0, content_height), false);
+        auto options = games::get_options(this->games_selected_name);
+        if (this->all_nav_group_selected == ALL_TAB_SEARCH) {
+
+            // search from all options
+            ImGui::Spacing();
+            ImGui::SetNextItemWidth(420.f);
+            if (ImGui::InputTextWithHint(
+                    "", "Type here to search in options..", &this->search_filter,
+                    ImGuiInputTextFlags_EscapeClearsAll)) {
+                this->search_filter_in_lower_case = strtolower(this->search_filter);
+            }
+            if (!this->search_filter.empty()) {
+                ImGui::SameLine();
+                if (ImGui::Button("Clear")) {
+                    this->search_filter.clear();
+                    this->search_filter_in_lower_case.clear();
+                }
+            }
+            ImGui::Spacing();
+
+            // draw matching options
+            if (!this->search_filter.empty()) {
+                for (auto category : launcher::get_categories(launcher::Options::OptionsCategory::Everything)) {
+                    this->build_options(
+                        options,
+                        category,
+                        const_cast<std::string *>(&this->search_filter_in_lower_case));
+                }
+            }
+        } else {
+            for (const auto &group : ALL_TAB_GROUPS) {
+                if (this->all_nav_group_selected != group.first) {
+                    continue;
+                }
+                ImGui::SeparatorText(group.first);
+                for (const auto &category : launcher::get_categories(group.second)) {
+                    if (category.empty()) {
+                        continue;
+                    }
+
+                    // scroll anchor: when this category was clicked in the nav, jump to it
+                    if (this->all_nav_scroll_pending && this->all_nav_selected == category) {
+                        ImGui::Dummy(ImVec2(0.0f, 0.0f));
+                        ImGui::SetScrollHereY(0.0f);
+                        this->all_nav_scroll_pending = false;
+                    }
+
+                    this->build_options(options, category);
+                }
+            }
+        }
+
+        ImGui::EndChild();
+
+        // hidden options checkbox
+        ImGui::Checkbox("Show Hidden Options", &this->options_show_hidden);
+        if (!cfg::CONFIGURATOR_STANDALONE && this->options_dirty) {
+            ImGui::SameLine();
+            if (ImGui::Button("Restart Game")) {
+                launcher::restart();
+            }
+            ImGui::SameLine();
+            ImGui::HelpMarker("You need to restart the game to apply the changed settings.");
+        }
+
+        // reset configuration button
+        ImGui::SameLine();
+        if (ImGui::Button("Reset Configuration")) {
+            ImGui::OpenPopup("Reset Config");
+        }
+        if (ImGui::BeginPopupModal("Reset Config", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+            ImGui::TextColored(ImVec4(1, 0.5f, 0.5f, 1.f),
+                    "Do you really want to reset your configuration for all games?\n"
+                    "Warning: This can't be reverted!");
+            if (ImGui::Button("Yes")) {
+                ::Config::getInstance().createConfigFile();
+                launcher::restart();
+            }
+            ImGui::SameLine();
+            if (ImGui::Button("Nope")) {
+                ImGui::CloseCurrentPopup();
+            }
+            ImGui::EndPopup();
         }
     }
 
@@ -399,163 +552,9 @@ namespace overlay::windows {
                 ImGui::EndChild();
                 ImGui::EndTabItem();
             }
-            if (ImGui::BeginTabItem("API")) {
-                tab_selected_new = ConfigTab::CONFIG_TAB_API;
-
-                // API options list
-                ImGui::BeginChild("ApiTab", ImVec2(
-                        0, ImGui::GetWindowContentRegionMax().y - page_offset2), false);
-                auto options = games::get_options(this->games_selected_name);
-                for (auto category : launcher::get_categories(launcher::Options::OptionsCategory::API)) {
-                    this->build_options(options, category);
-                }
-                ImGui::EndChild();
-                ImGui::EndTabItem();
-            }
             if (ImGui::BeginTabItem("Options")) {
-                tab_selected_new = ConfigTab::CONFIG_TAB_OPTIONS;
-
-                // options list
-                ImGui::BeginChild("Options", ImVec2(
-                        0, ImGui::GetWindowContentRegionMax().y - page_offset), false);
-                auto options = games::get_options(this->games_selected_name);
-                for (auto category : launcher::get_categories(launcher::Options::OptionsCategory::Basic)) {
-                    this->build_options(options, category);
-                }
-
-                ImGui::EndChild();
-
-                // hidden options checkbox
-                ImGui::Checkbox("Show Hidden Options", &this->options_show_hidden);
-                if (!cfg::CONFIGURATOR_STANDALONE && this->options_dirty) {
-                    ImGui::SameLine();
-                    if (ImGui::Button("Restart Game")) {
-                        launcher::restart();
-                    }
-                    ImGui::SameLine();
-                    ImGui::HelpMarker("You need to restart the game to apply the changed settings.");
-                }
-
-                ImGui::EndTabItem();
-            }
-            if (ImGui::BeginTabItem("Advanced")) {
-                tab_selected_new = ConfigTab::CONFIG_TAB_ADVANCED;
-
-                // advanced options list
-                ImGui::BeginChild("AdvancedOptions", ImVec2(
-                        0, ImGui::GetWindowContentRegionMax().y - page_offset), false);
-                auto options = games::get_options(this->games_selected_name);
-                for (auto category : launcher::get_categories(launcher::Options::OptionsCategory::Advanced)) {
-                    this->build_options(options, category);
-                }
-                ImGui::EndChild();
-
-                // hidden options checkbox
-                ImGui::Checkbox("Show Hidden Options", &this->options_show_hidden);
-                if (!cfg::CONFIGURATOR_STANDALONE && this->options_dirty) {
-                    ImGui::SameLine();
-                    if (ImGui::Button("Restart Game")) {
-                        launcher::restart();
-                    }
-                    ImGui::SameLine();
-                    ImGui::HelpMarker("You need to restart the game to apply the changed settings.");
-                }
-
-                // reset configuration button
-                ImGui::SameLine();
-                if (ImGui::Button("Reset Configuration")) {
-                    ImGui::OpenPopup("Reset Config");
-                }
-                if (ImGui::BeginPopupModal("Reset Config", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
-                    ImGui::TextColored(ImVec4(1, 0.5f, 0.5f, 1.f),
-                            "Do you really want to reset your configuration for all games?\n"
-                            "Warning: This can't be reverted!");
-                    if (ImGui::Button("Yes")) {
-                        ::Config::getInstance().createConfigFile();
-                        launcher::restart();
-                    }
-                    ImGui::SameLine();
-                    if (ImGui::Button("Nope")) {
-                        ImGui::CloseCurrentPopup();
-                    }
-                    ImGui::EndPopup();
-                }
-
-                ImGui::EndTabItem();
-            }
-            if (ImGui::BeginTabItem("Development")) {
-                tab_selected_new = ConfigTab::CONFIG_TAB_DEV;
-
-                // dev options list
-                ImGui::BeginChild("DevOptions", ImVec2(
-                        0, ImGui::GetWindowContentRegionMax().y - page_offset), false);
-                auto options = games::get_options(this->games_selected_name);
-                for (auto category : launcher::get_categories(launcher::Options::OptionsCategory::Dev)) {
-                    this->build_options(options, category);
-                }
-
-                ImGui::EndChild();
-
-                // hidden options checkbox
-                ImGui::Checkbox("Show Hidden Options", &this->options_show_hidden);
-                if (!cfg::CONFIGURATOR_STANDALONE && this->options_dirty) {
-                    ImGui::SameLine();
-                    if (ImGui::Button("Restart Game")) {
-                        launcher::restart();
-                    }
-                    ImGui::SameLine();
-                    ImGui::HelpMarker("You need to restart the game to apply the changed settings.");
-                }
-
-                ImGui::EndTabItem();
-            }
-            if (ImGui::BeginTabItem("Search")) {
-                tab_selected_new = ConfigTab::CONFIG_TAB_SEARCH;
-
-                ImGui::BeginChild("SearchOptions", ImVec2(
-                        0, ImGui::GetWindowContentRegionMax().y - page_offset), false);
-
-                // search from all options
-                ImGui::Spacing();
-                ImGui::SetNextItemWidth(420.f);
-                if (ImGui::InputTextWithHint(
-                        "", "Type here to search in options..", &this->search_filter,
-                        ImGuiInputTextFlags_EscapeClearsAll)) {
-                    this->search_filter_in_lower_case = strtolower(this->search_filter);
-                }
-                if (!this->search_filter.empty()) {
-                    ImGui::SameLine();
-                    if (ImGui::Button("Clear")) {
-                        this->search_filter.clear();
-                        this->search_filter_in_lower_case.clear();
-                    }
-                }
-                ImGui::Spacing();
-
-                // draw all options
-                auto options = games::get_options(this->games_selected_name);
-                if (!this->search_filter.empty()) {
-                    for (auto category : launcher::get_categories(launcher::Options::OptionsCategory::Everything)) {
-                        this->build_options(
-                            options,
-                            category,
-                            const_cast<std::string *>(&this->search_filter_in_lower_case));
-                    }
-                }
-
-                ImGui::EndChild();
-
-                // hidden options checkbox
-                ImGui::Checkbox("Show Hidden Options", &this->options_show_hidden);
-                if (!cfg::CONFIGURATOR_STANDALONE && this->options_dirty) {
-                    ImGui::SameLine();
-                    if (ImGui::Button("Restart Game")) {
-                        launcher::restart();
-                    }
-                    ImGui::SameLine();
-                    ImGui::HelpMarker("You need to restart the game to apply the changed settings.");
-                }
-
+                tab_selected_new = ConfigTab::CONFIG_TAB_ALL_OPTIONS;
+                this->build_options_tab(page_offset);
                 ImGui::EndTabItem();
             }
             ImGui::EndTabBar();
@@ -4669,7 +4668,6 @@ namespace overlay::windows {
 
     void Config::build_options(
         std::vector<Option> *options, const std::string &category, const std::string *filter) {
-        int options_count;
 
         // category name
         std::string cat = "Options";
@@ -4683,21 +4681,13 @@ namespace overlay::windows {
 
         // render table
         // tables must share the same ID to have synced column settings
-        const int num_columns = (filter != nullptr) ? 3 : 2;
-        if (ImGui::BeginTable("OptionsTable", num_columns, ImGuiTableFlags_Resizable | ImGuiTableFlags_RowBg)) {
-            auto widget_col_width = 0;
-            if (filter != nullptr) {
-                ImGui::TableSetupColumn("Category", ImGuiTableColumnFlags_WidthFixed, overlay::apply_scaling(160));
-                ImGui::TableSetupColumn("Option", ImGuiTableColumnFlags_WidthStretch);
-                widget_col_width = overlay::apply_scaling(220);
-            } else {
-                ImGui::TableSetupColumn("Option", ImGuiTableColumnFlags_WidthStretch);
-                widget_col_width = overlay::apply_scaling(264);
-            }
+        if (ImGui::BeginTable("OptionsTable", 2, ImGuiTableFlags_Resizable | ImGuiTableFlags_RowBg)) {
+            const int widget_col_width = overlay::apply_scaling(264);
+            ImGui::TableSetupColumn("Option", ImGuiTableColumnFlags_WidthStretch);
             ImGui::TableSetupColumn("Setting", ImGuiTableColumnFlags_WidthFixed, widget_col_width);
 
             // iterate options
-            options_count = 0;
+            int options_count = 0;
             for (auto &option : *options) {
 
                 // get option definition
@@ -4743,24 +4733,9 @@ namespace overlay::windows {
                 ImGui::PushID(&option);
                 ImGui::TableNextRow();
 
-                // category (only shown for search results)
-                if (filter != nullptr) {
-                    ImGui::TableNextColumn();
-                    ImGui::AlignTextToFramePadding();
-                    if (definition.category.empty()) {
-                        ImGui::TextDisabled("-");
-                    } else {
-                        ImGui::TextDisabled("%s", definition.category.c_str());
-                    }
-                }
-
                 // option name
                 ImGui::TableNextColumn();
                 ImGui::AlignTextToFramePadding();
-                if (filter == nullptr) {
-                    // add indent to make options align under category header
-                    ImGui::Indent(INDENT);
-                }
                 if (option.is_active()) {
                     // active option
                     if (option.disabled || definition.disabled) {
@@ -4775,9 +4750,6 @@ namespace overlay::windows {
                 } else {
                     // normal text
                     ImGui::TextUnformatted(definition.title.c_str());
-                }
-                if (filter == nullptr) {
-                    ImGui::Unindent(INDENT);
                 }
                 if (ImGui::IsItemHovered(ImGui::TOOLTIP_FLAGS)) {
                     ImGui::HelpTooltip(definition.desc.c_str());

--- a/src/spice2x/overlay/windows/config.cpp
+++ b/src/spice2x/overlay/windows/config.cpp
@@ -65,10 +65,14 @@ namespace overlay::windows {
 
     // subtab groups shown in the "All" tab left navigation, in display order
     static const std::vector<std::pair<const char *, launcher::Options::OptionsCategory>> ALL_TAB_GROUPS = {
-        { "API", launcher::Options::OptionsCategory::API },
-        { "Options", launcher::Options::OptionsCategory::Basic },
+        { "Quick Options", launcher::Options::OptionsCategory::Basic },
+        { "Game Options", launcher::Options::OptionsCategory::GameOptions },
+        { "Display", launcher::Options::OptionsCategory::Display },
+        { "Audio", launcher::Options::OptionsCategory::Audio },
+        { "Network", launcher::Options::OptionsCategory::Network },
         { "Advanced", launcher::Options::OptionsCategory::Advanced },
         { "Development", launcher::Options::OptionsCategory::Dev },
+        { "API", launcher::Options::OptionsCategory::API },
     };
 
     // special "All" tab left-nav entry that shows the search box instead of a group
@@ -235,7 +239,7 @@ namespace overlay::windows {
 
     void Config::build_options_tab(float page_offset) {
         const float content_height = ImGui::GetWindowContentRegionMax().y - page_offset;
-        const float nav_width = overlay::apply_scaling(160);
+        const float nav_width = overlay::apply_scaling(130);
 
         // default to the first group on first display
         if (this->all_nav_group_selected.empty()) {
@@ -244,18 +248,62 @@ namespace overlay::windows {
 
         // left navigation: one header per subtab, each listing its categories. clicking a
         // header selects that group; clicking a category scrolls the content to that section.
-        ImGui::BeginChild("AllNav", ImVec2(nav_width, content_height), true);
+        ImGui::BeginChild("AllNav", ImVec2(nav_width, content_height), false);
+
+        // exact height of the global option controls pinned at the bottom of the nav
+        const bool show_restart = !cfg::CONFIGURATOR_STANDALONE && this->options_dirty;
+        const float ctrl_spacing = ImGui::GetStyle().ItemSpacing.y;
+        float nav_controls_height = ImGui::GetFrameHeight(); // "Show Hidden" checkbox
+        nav_controls_height += ctrl_spacing + ImGui::GetFrameHeight(); // "Reset All" button
+        if (show_restart) {
+            nav_controls_height += ctrl_spacing + ImGui::GetFrameHeight(); // "Restart Game" button
+        }
+        nav_controls_height += ctrl_spacing * 2.0f + 1.0f; // separator + padding
+
+        // scrollable nav list (group headers and categories)
+        ImGui::BeginChild("AllNavList",
+            ImVec2(0, content_height - nav_controls_height - ctrl_spacing), false);
+
+        // extra vertical padding between nav rows (headers and tree items)
+        const ImVec2 nav_item_spacing = ImGui::GetStyle().ItemSpacing;
+        ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing,
+            ImVec2(nav_item_spacing.x, nav_item_spacing.y + overlay::apply_scaling(2)));
 
         // arrow-less, non-collapsible nav header; selecting it clears any highlighted category
         auto nav_header = [this](const char *label) {
+            const bool active = this->all_nav_group_selected == label;
             ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_Leaf;
-            if (this->all_nav_group_selected == label) {
+            if (active) {
                 flags |= ImGuiTreeNodeFlags_Selected;
             }
+
+            // give the active header a clear, distinct highlight
+            int colors_pushed = 0;
+            if (active) {
+                const ImVec4 accent = ImGui::GetStyleColorVec4(ImGuiCol_ButtonActive);
+                ImGui::PushStyleColor(ImGuiCol_Header, accent);
+                ImGui::PushStyleColor(ImGuiCol_HeaderHovered, accent);
+                ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_Text));
+                colors_pushed = 3;
+            }
+
+            // taller frame padding so headers match the height of the category rows below
+            const ImVec2 frame_padding = ImGui::GetStyle().FramePadding;
+            ImGui::PushStyleVar(ImGuiStyleVar_FramePadding,
+                ImVec2(frame_padding.x, frame_padding.y + overlay::apply_scaling(4)));
+
             ImGui::CollapsingHeader(label, flags);
+
+            ImGui::PopStyleVar();
+
+            if (colors_pushed) {
+                ImGui::PopStyleColor(colors_pushed);
+            }
+
             if (ImGui::IsItemClicked()) {
                 this->all_nav_group_selected = label;
                 this->all_nav_selected.clear();
+                this->all_nav_scroll_top = true;
             }
         };
 
@@ -265,9 +313,13 @@ namespace overlay::windows {
         for (const auto &group : ALL_TAB_GROUPS) {
             nav_header(group.first);
 
+            // only the selected group expands to show its categories
+            if (this->all_nav_group_selected != group.first) {
+                continue;
+            }
+
             ImGui::PushID(group.first);
 
-            // categories are always listed under the header
             for (const auto &category : launcher::get_categories(group.second)) {
                 if (category.empty()) {
                     continue;
@@ -284,16 +336,64 @@ namespace overlay::windows {
             ImGui::PopID();
         }
 
-        ImGui::EndChild();
+        ImGui::PopStyleVar();
+
+        ImGui::EndChild(); // AllNavList
+
+        // global option controls pinned to the bottom of the nav
+        ImGui::SetCursorPosY(content_height - nav_controls_height);
+        ImGui::Separator();
+        ImGui::Checkbox("Show Hidden", &this->options_show_hidden);
+
+        // left-align the text inside the full-width control buttons
+        ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0.0f, 0.5f));
+
+        // reset configuration button
+        if (ImGui::Button("Reset All", ImVec2(ImGui::GetContentRegionAvail().x, 0))) {
+            ImGui::OpenPopup("Reset Config");
+        }
+        if (ImGui::BeginPopupModal("Reset Config", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+            ImGui::TextColored(ImVec4(1, 0.5f, 0.5f, 1.f),
+                    "Do you really want to reset your configuration for all games?\n"
+                    "Warning: This can't be reverted!");
+            if (ImGui::Button("Yes")) {
+                ::Config::getInstance().createConfigFile();
+                launcher::restart();
+            }
+            ImGui::SameLine();
+            if (ImGui::Button("Nope")) {
+                ImGui::CloseCurrentPopup();
+            }
+            ImGui::EndPopup();
+        }
+
+        if (show_restart) {
+            if (ImGui::Button("Restart Game")) {
+                launcher::restart();
+            }
+            ImGui::SameLine();
+            ImGui::HelpMarker("You need to restart the game to apply the changed settings.");
+        }
+
+        ImGui::PopStyleVar(); // ButtonTextAlign
+
+        ImGui::EndChild(); // AllNav
         ImGui::SameLine();
 
         // content: only the options belonging to the selected group.
         ImGui::BeginChild("AllOptions", ImVec2(0, content_height), false);
+        if (this->all_nav_scroll_top) {
+            ImGui::SetScrollY(0.0f);
+            this->all_nav_scroll_top = false;
+        }
+
+        // breathing room at the top of the content area
+        ImGui::Dummy(ImVec2(0.0f, overlay::apply_scaling(4)));
+
         auto options = games::get_options(this->games_selected_name);
         if (this->all_nav_group_selected == ALL_TAB_SEARCH) {
 
             // search from all options
-            ImGui::Spacing();
             ImGui::SetNextItemWidth(420.f);
             if (ImGui::InputTextWithHint(
                     "", "Type here to search in options..", &this->search_filter,
@@ -323,7 +423,6 @@ namespace overlay::windows {
                 if (this->all_nav_group_selected != group.first) {
                     continue;
                 }
-                ImGui::SeparatorText(group.first);
                 for (const auto &category : launcher::get_categories(group.second)) {
                     if (category.empty()) {
                         continue;
@@ -342,37 +441,6 @@ namespace overlay::windows {
         }
 
         ImGui::EndChild();
-
-        // hidden options checkbox
-        ImGui::Checkbox("Show Hidden Options", &this->options_show_hidden);
-        if (!cfg::CONFIGURATOR_STANDALONE && this->options_dirty) {
-            ImGui::SameLine();
-            if (ImGui::Button("Restart Game")) {
-                launcher::restart();
-            }
-            ImGui::SameLine();
-            ImGui::HelpMarker("You need to restart the game to apply the changed settings.");
-        }
-
-        // reset configuration button
-        ImGui::SameLine();
-        if (ImGui::Button("Reset Configuration")) {
-            ImGui::OpenPopup("Reset Config");
-        }
-        if (ImGui::BeginPopupModal("Reset Config", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
-            ImGui::TextColored(ImVec4(1, 0.5f, 0.5f, 1.f),
-                    "Do you really want to reset your configuration for all games?\n"
-                    "Warning: This can't be reverted!");
-            if (ImGui::Button("Yes")) {
-                ::Config::getInstance().createConfigFile();
-                launcher::restart();
-            }
-            ImGui::SameLine();
-            if (ImGui::Button("Nope")) {
-                ImGui::CloseCurrentPopup();
-            }
-            ImGui::EndPopup();
-        }
     }
 
     void Config::build_content() {
@@ -421,7 +489,6 @@ namespace overlay::windows {
         // tab selection
         auto tab_selected_new = ConfigTab::CONFIG_TAB_INVALID;
         if (ImGui::BeginTabBar("Config Tabs", ImGuiTabBarFlags_NoCloseWithMiddleMouseButton)) {
-            const int page_offset = overlay::apply_scaling(cfg::CONFIGURATOR_STANDALONE ? 88 : 110);
             const int page_offset2 = overlay::apply_scaling(cfg::CONFIGURATOR_STANDALONE ? 65 : 87);
 
             if (ImGui::BeginTabItem("Buttons")) {
@@ -554,7 +621,7 @@ namespace overlay::windows {
             }
             if (ImGui::BeginTabItem("Options")) {
                 tab_selected_new = ConfigTab::CONFIG_TAB_ALL_OPTIONS;
-                this->build_options_tab(page_offset);
+                this->build_options_tab(page_offset2);
                 ImGui::EndTabItem();
             }
             ImGui::EndTabBar();
@@ -4682,7 +4749,7 @@ namespace overlay::windows {
         // render table
         // tables must share the same ID to have synced column settings
         if (ImGui::BeginTable("OptionsTable", 2, ImGuiTableFlags_Resizable | ImGuiTableFlags_RowBg)) {
-            const int widget_col_width = overlay::apply_scaling(264);
+            const int widget_col_width = overlay::apply_scaling(250);
             ImGui::TableSetupColumn("Option", ImGuiTableColumnFlags_WidthStretch);
             ImGui::TableSetupColumn("Setting", ImGuiTableColumnFlags_WidthFixed, widget_col_width);
 
@@ -5015,21 +5082,9 @@ namespace overlay::windows {
             if (options_count == 0) {
                 ImGui::TableNextRow();
 
-                // option category
-                if (filter != nullptr) {
-                    ImGui::TableNextColumn();
-                    ImGui::TextDisabled("-");
-                }
-
                 // name of option
                 ImGui::TableNextColumn();
-                if (filter == nullptr) {
-                    ImGui::Indent(INDENT);
-                }
                 ImGui::TextDisabled("-");
-                if (filter == nullptr) {
-                    ImGui::Unindent(INDENT);
-                }
 
                 // widget
                 ImGui::TableNextColumn();

--- a/src/spice2x/overlay/windows/config.cpp
+++ b/src/spice2x/overlay/windows/config.cpp
@@ -70,6 +70,7 @@ namespace overlay::windows {
         { "Display", launcher::Options::OptionsCategory::Display },
         { "Audio", launcher::Options::OptionsCategory::Audio },
         { "Network", launcher::Options::OptionsCategory::Network },
+        { "Overlay", launcher::Options::OptionsCategory::Overlay },
         { "Advanced", launcher::Options::OptionsCategory::Advanced },
         { "Development", launcher::Options::OptionsCategory::Dev },
         { "API", launcher::Options::OptionsCategory::API },

--- a/src/spice2x/overlay/windows/config.cpp
+++ b/src/spice2x/overlay/windows/config.cpp
@@ -1,6 +1,7 @@
 #include "config.h"
 
 #include <algorithm>
+#include <set>
 #include <thread>
 
 #include <windows.h>
@@ -64,20 +65,19 @@ namespace overlay::windows {
     constexpr uint32_t OPTION_INPUT_TEXT_WIDTH = 512;
 
     // subtab groups shown in the "All" tab left navigation, in display order
-    static const std::vector<std::pair<const char *, launcher::Options::OptionsCategory>> ALL_TAB_GROUPS = {
-        { "Quick Options", launcher::Options::OptionsCategory::Basic },
+    static const std::vector<std::pair<const char *, launcher::Options::OptionsCategory>> OPTIONS_TAB_GROUPS = {
         { "Game Options", launcher::Options::OptionsCategory::GameOptions },
         { "Display", launcher::Options::OptionsCategory::Display },
         { "Audio", launcher::Options::OptionsCategory::Audio },
         { "Network", launcher::Options::OptionsCategory::Network },
         { "Overlay", launcher::Options::OptionsCategory::Overlay },
-        { "Advanced", launcher::Options::OptionsCategory::Advanced },
+        { "Others", launcher::Options::OptionsCategory::Advanced },
         { "Development", launcher::Options::OptionsCategory::Dev },
         { "API", launcher::Options::OptionsCategory::API },
     };
 
-    // special "All" tab left-nav entry that shows the search box instead of a group
-    static const char *ALL_TAB_SEARCH = "Search";
+    static const char *OPTIONS_TAB_SEARCH = "Search";
+    static const char *OPTIONS_TAB_QUICK = "Quick Settings";
 
     std::optional<std::vector<hooks::audio::AsioDriverScanEntry>> asio_driver_list;
 
@@ -244,7 +244,33 @@ namespace overlay::windows {
 
         // default to the first group on first display
         if (this->all_nav_group_selected.empty()) {
-            this->all_nav_group_selected = ALL_TAB_GROUPS.front().first;
+            this->all_nav_group_selected = OPTIONS_TAB_QUICK;
+        }
+
+        auto options = games::get_options(this->games_selected_name);
+
+        // collect the set of categories that currently have at least one option that
+        // would be rendered by build_options(), in a single pass. used to keep the nav
+        // in sync with the content so categories that only contain hidden options appear
+        // in the nav exactly when "Show Hidden" is enabled. quick_categories tracks the
+        // distinct quick_setting_category names (quick settings group under their own
+        // categories, separate from the regular option categories).
+        std::set<std::string> visible_categories;
+        std::set<std::string> quick_categories;
+        if (options) {
+            for (auto &option : *options) {
+                auto &definition = option.get_definition();
+                if (!this->options_show_hidden && option.value.empty() && definition.hidden) {
+                    continue;
+                }
+                if (!definition.game_name.empty() && definition.game_name != this->games_selected_name) {
+                    continue;
+                }
+                visible_categories.insert(definition.category);
+                if (!definition.quick_setting_category.empty()) {
+                    quick_categories.insert(definition.quick_setting_category);
+                }
+            }
         }
 
         // left navigation: one header per subtab, each listing its categories. clicking a
@@ -255,7 +281,6 @@ namespace overlay::windows {
         const bool show_restart = !cfg::CONFIGURATOR_STANDALONE && this->options_dirty;
         const float ctrl_spacing = ImGui::GetStyle().ItemSpacing.y;
         float nav_controls_height = ImGui::GetFrameHeight(); // "Show Hidden" checkbox
-        nav_controls_height += ctrl_spacing + ImGui::GetFrameHeight(); // "Reset All" button
         if (show_restart) {
             nav_controls_height += ctrl_spacing + ImGui::GetFrameHeight(); // "Restart Game" button
         }
@@ -309,9 +334,30 @@ namespace overlay::windows {
         };
 
         // search entry: selecting it shows the search box in the content pane
-        nav_header(ALL_TAB_SEARCH);
+        nav_header(OPTIONS_TAB_SEARCH);
 
-        for (const auto &group : ALL_TAB_GROUPS) {
+        // quick settings entry: selecting it shows the quick settings in the content pane
+        nav_header(OPTIONS_TAB_QUICK);
+
+        // when quick settings is selected, list its categories so they can be jumped to
+        if (this->all_nav_group_selected == OPTIONS_TAB_QUICK) {
+            ImGui::PushID(OPTIONS_TAB_QUICK);
+            for (const auto &category : launcher::get_quick_setting_categories()) {
+                if (!quick_categories.contains(category)) {
+                    continue;
+                }
+                ImGui::Indent(INDENT * 0.5f);
+                if (ImGui::Selectable(category.c_str(), this->all_nav_selected == category)) {
+                    this->all_nav_group_selected = OPTIONS_TAB_QUICK;
+                    this->all_nav_selected = category;
+                    this->all_nav_scroll_pending = true;
+                }
+                ImGui::Unindent(INDENT * 0.5f);
+            }
+            ImGui::PopID();
+        }
+
+        for (const auto &group : OPTIONS_TAB_GROUPS) {
             nav_header(group.first);
 
             // only the selected group expands to show its categories
@@ -323,6 +369,9 @@ namespace overlay::windows {
 
             for (const auto &category : launcher::get_categories(group.second)) {
                 if (category.empty()) {
+                    continue;
+                }
+                if (!visible_categories.contains(category)) {
                     continue;
                 }
                 ImGui::Indent(INDENT * 0.5f);
@@ -349,25 +398,6 @@ namespace overlay::windows {
         // left-align the text inside the full-width control buttons
         ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0.0f, 0.5f));
 
-        // reset configuration button
-        if (ImGui::Button("Reset All", ImVec2(ImGui::GetContentRegionAvail().x, 0))) {
-            ImGui::OpenPopup("Reset Config");
-        }
-        if (ImGui::BeginPopupModal("Reset Config", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
-            ImGui::TextColored(ImVec4(1, 0.5f, 0.5f, 1.f),
-                    "Do you really want to reset your configuration for all games?\n"
-                    "Warning: This can't be reverted!");
-            if (ImGui::Button("Yes")) {
-                ::Config::getInstance().createConfigFile();
-                launcher::restart();
-            }
-            ImGui::SameLine();
-            if (ImGui::Button("Nope")) {
-                ImGui::CloseCurrentPopup();
-            }
-            ImGui::EndPopup();
-        }
-
         if (show_restart) {
             if (ImGui::Button("Restart Game")) {
                 launcher::restart();
@@ -391,8 +421,7 @@ namespace overlay::windows {
         // breathing room at the top of the content area
         ImGui::Dummy(ImVec2(0.0f, overlay::apply_scaling(4)));
 
-        auto options = games::get_options(this->games_selected_name);
-        if (this->all_nav_group_selected == ALL_TAB_SEARCH) {
+        if (this->all_nav_group_selected == OPTIONS_TAB_SEARCH) {
 
             // search from all options
             ImGui::SetNextItemWidth(420.f);
@@ -419,8 +448,24 @@ namespace overlay::windows {
                         const_cast<std::string *>(&this->search_filter_in_lower_case));
                 }
             }
+        } else if (this->all_nav_group_selected == OPTIONS_TAB_QUICK) {
+            for (const auto &category : launcher::get_quick_setting_categories()) {
+                if (!quick_categories.contains(category)) {
+                    continue;
+                }
+
+                // scroll anchor: when this category was clicked in the nav, jump to it
+                if (this->all_nav_scroll_pending && this->all_nav_selected == category) {
+                    ImGui::Dummy(ImVec2(0.0f, 0.0f));
+                    ImGui::SetScrollHereY(0.0f);
+                    this->all_nav_scroll_pending = false;
+                }
+
+                this->build_options(options, category, nullptr, true);
+            }
+
         } else {
-            for (const auto &group : ALL_TAB_GROUPS) {
+            for (const auto &group : OPTIONS_TAB_GROUPS) {
                 if (this->all_nav_group_selected != group.first) {
                     continue;
                 }
@@ -4735,12 +4780,52 @@ namespace overlay::windows {
     }
 
     void Config::build_options(
-        std::vector<Option> *options, const std::string &category, const std::string *filter) {
+        std::vector<Option> *options, const std::string &category, const std::string *filter, bool quick_only) {
+
+        // collect the options that match the current filters. doing this once lets us
+        // skip rendering an empty header + table for categories with no matches, and
+        // avoids iterating the full option list a second time during rendering.
+        std::vector<Option *> matching;
+        for (auto &option : *options) {
+            auto &definition = option.get_definition();
+            if (quick_only) {
+                // quick settings group under quick_setting_category, not the regular category
+                if (definition.quick_setting_category.empty()) {
+                    continue;
+                }
+                if (!category.empty() && definition.quick_setting_category != category) {
+                    continue;
+                }
+            } else if (!category.empty() && definition.category != category) {
+                continue;
+            }
+            if (!this->options_show_hidden && option.value.empty() && definition.hidden) {
+                continue;
+            }
+            if (!definition.game_name.empty() && definition.game_name != this->games_selected_name) {
+                continue;
+            }
+            if (filter != nullptr) {
+                if (filter->empty() || !option.search_match(*filter)) {
+                    continue;
+                }
+                // limit to 30 results
+                if (matching.size() > 30) {
+                    continue;
+                }
+            }
+            matching.push_back(&option);
+        }
+        if (matching.empty()) {
+            return;
+        }
 
         // category name
         std::string cat = "Options";
         if (!category.empty()) {
             cat = category;
+        } else if (quick_only) {
+            cat = "Quick Settings";
         } else if (filter != nullptr) {
             cat = "Search results";
         }
@@ -4749,53 +4834,17 @@ namespace overlay::windows {
 
         // render table
         // tables must share the same ID to have synced column settings
+        ImGui::PushStyleVarY(ImGuiStyleVar_CellPadding,
+                ImGui::GetStyle().CellPadding.y + overlay::apply_scaling(2));
         if (ImGui::BeginTable("OptionsTable", 2, ImGuiTableFlags_Resizable | ImGuiTableFlags_RowBg)) {
-            const int widget_col_width = overlay::apply_scaling(250);
+            const int widget_col_width = overlay::apply_scaling(260);
             ImGui::TableSetupColumn("Option", ImGuiTableColumnFlags_WidthStretch);
             ImGui::TableSetupColumn("Setting", ImGuiTableColumnFlags_WidthFixed, widget_col_width);
 
             // iterate options
-            int options_count = 0;
-            for (auto &option : *options) {
-
-                // get option definition
+            for (auto *option_ptr : matching) {
+                auto &option = *option_ptr;
                 auto &definition = option.get_definition();
-
-                // check category
-                if (!category.empty() && definition.category != category) {
-                    continue;
-                }
-
-                // check hidden option
-                if (!this->options_show_hidden && option.value.empty()) {
-                    // skip hidden entries
-                    if (definition.hidden) {
-                        continue;
-                    }
-                }
-
-                // check for game exclusivity
-                if (!definition.game_name.empty()) {
-                    if (definition.game_name != this->games_selected_name) {
-                        continue;
-                    }
-                }
-
-                // filter
-                if (filter != nullptr) {
-                    if (filter->empty()) {
-                        continue;
-                    }
-                    if (!option.search_match(*filter)) {
-                        continue;
-                    }
-                    // limit to 30 results
-                    if (30 < options_count) {
-                        continue;
-                    }
-                }
-
-                options_count += 1;
 
                 // list entry
                 ImGui::PushID(&option);
@@ -4803,7 +4852,8 @@ namespace overlay::windows {
 
                 // option name
                 ImGui::TableNextColumn();
-                ImGui::AlignTextToFramePadding();
+                ImGui::PushStyleVarY(ImGuiStyleVar_ItemSpacing, 0);
+
                 if (option.is_active()) {
                     // active option
                     if (option.disabled || definition.disabled) {
@@ -4830,8 +4880,7 @@ namespace overlay::windows {
                 } else {
                     param += definition.display_name;
                 }
-                ImGui::SameLine();
-                ImGui::TextColored(ImVec4(0.27f, 0.27f, 0.27f, 1.f), " %s", param.c_str());
+                ImGui::TextDisabled("%s", param.c_str());
                 if (ImGui::IsItemHovered(ImGui::TOOLTIP_FLAGS)) {
                     const auto help =
                         param +
@@ -4845,8 +4894,20 @@ namespace overlay::windows {
                     clipboard::copy_text(param.c_str());
                 }
 
+                ImGui::PopStyleVar(); // ImGuiStyleVar_ItemSpacing
+
                 // option widgets
                 ImGui::TableNextColumn();
+
+                // make widgets span two text lines tall to match the two-line name column
+                ImGui::PushStyleVarY(ImGuiStyleVar_FramePadding, ImGui::GetFontSize() * 0.36f);
+                // vertically center the widget within the two-line row
+                float row_h = ImGui::GetTextLineHeight() * 2.f;
+                float widget_h = ImGui::GetFrameHeight();
+                if (row_h > widget_h) {
+                    ImGui::SetCursorPosY(ImGui::GetCursorPosY() + (row_h - widget_h) * 0.5f);
+                }
+
                 ImGui::PushStyleVarX(ImGuiStyleVar_ItemSpacing, 4.f);
                 if (option.disabled || definition.disabled) {
                     ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
@@ -5019,6 +5080,7 @@ namespace overlay::windows {
                 }
 
                 ImGui::PopStyleVar(); // ImGuiStyleVar_ItemSpacing
+                ImGui::PopStyleVar(); // ImGuiStyleVar_FramePadding
 
                 // clean up disabled item flags
                 if (option.disabled || definition.disabled) {
@@ -5079,20 +5141,9 @@ namespace overlay::windows {
                 ImGui::PopID();
             }
 
-            // check if empty
-            if (options_count == 0) {
-                ImGui::TableNextRow();
-
-                // name of option
-                ImGui::TableNextColumn();
-                ImGui::TextDisabled("-");
-
-                // widget
-                ImGui::TableNextColumn();
-                ImGui::TextDisabled("-");
-            }
             ImGui::EndTable();
         }
+        ImGui::PopStyleVar(); // ImGuiStyleVar_CellPadding
 
         ImGui::TextUnformatted("");
     }
@@ -5146,6 +5197,7 @@ namespace overlay::windows {
 
     void Config::build_menu(int *game_selected) {
         bool about_popup = false;
+        bool reset_config_popup = false;
         ImGui::PushStyleColor(ImGuiCol_PopupBg, ImVec4(0.14f, 0.14f, 0.14f, 1.0f));
         if (ImGui::BeginMenuBar()) {
 
@@ -5158,6 +5210,10 @@ namespace overlay::windows {
                 }
                 if (ImGui::MenuItem("About")) {
                     about_popup = true;
+                }
+                ImGui::Separator();
+                if (ImGui::MenuItem("Reset to Default")) {
+                    reset_config_popup = true;
                 }
                 ImGui::EndMenu();
             } else {
@@ -5216,6 +5272,25 @@ namespace overlay::windows {
         // workaround for popups triggered by menu, see https://github.com/ocornut/imgui/issues/331
         if (about_popup) {
             ImGui::OpenPopup("About##topbarpopup");
+        }
+        if (reset_config_popup) {
+            ImGui::OpenPopup("Reset Config");
+        }
+
+        // reset configuration confirmation popup
+        if (ImGui::BeginPopupModal("Reset Config", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+            ImGui::TextColored(ImVec4(1, 0.5f, 0.5f, 1.f),
+                    "Do you really want to reset your configuration for all games?\n"
+                    "Warning: This can't be reverted!");
+            if (ImGui::Button("Yes")) {
+                ::Config::getInstance().createConfigFile();
+                launcher::restart();
+            }
+            ImGui::SameLine();
+            if (ImGui::Button("Nope")) {
+                ImGui::CloseCurrentPopup();
+            }
+            ImGui::EndPopup();
         }
 
         // draw popups

--- a/src/spice2x/overlay/windows/config.h
+++ b/src/spice2x/overlay/windows/config.h
@@ -20,12 +20,8 @@ namespace overlay::windows {
         CONFIG_TAB_LIGHTS,
         CONFIG_TAB_CARDS,
         CONFIG_TAB_PATCHES,
-        CONFIG_TAB_API,
-        CONFIG_TAB_OPTIONS,
-        CONFIG_TAB_ADVANCED,
-        CONFIG_TAB_DEV,
+        CONFIG_TAB_ALL_OPTIONS,
         CONFIG_TAB_PRESETS,
-        CONFIG_TAB_SEARCH,
     };
 
     struct MatchEntry {
@@ -134,6 +130,11 @@ namespace overlay::windows {
         std::string search_filter = "";
         std::string search_filter_in_lower_case = "";
 
+        // "All" tab left-nav: selected group, currently highlighted category, and a pending scroll
+        std::string all_nav_group_selected = "";
+        std::string all_nav_selected = "";
+        bool all_nav_scroll_pending = false;
+
         std::filesystem::path file_picker_path;
         std::thread *file_picker_thread = nullptr;
         bool file_picker_done = false;
@@ -191,6 +192,7 @@ namespace overlay::windows {
         void build_option_value_picker(Option& option);
         void build_options(
             std::vector<Option> *options, const std::string &category, const std::string *filter=nullptr);
+        void build_options_tab(float page_offset);
         void build_about();
         void build_launcher();
         void build_keypad_warning();

--- a/src/spice2x/overlay/windows/config.h
+++ b/src/spice2x/overlay/windows/config.h
@@ -20,7 +20,7 @@ namespace overlay::windows {
         CONFIG_TAB_LIGHTS,
         CONFIG_TAB_CARDS,
         CONFIG_TAB_PATCHES,
-        CONFIG_TAB_ALL_OPTIONS,
+        CONFIG_TAB_OPTIONS,
         CONFIG_TAB_PRESETS,
     };
 
@@ -130,11 +130,11 @@ namespace overlay::windows {
         std::string search_filter = "";
         std::string search_filter_in_lower_case = "";
 
-        // "All" tab left-nav: selected group, currently highlighted category, and a pending scroll
-        std::string all_nav_group_selected = "";
-        std::string all_nav_selected = "";
-        bool all_nav_scroll_pending = false;
-        bool all_nav_scroll_top = false;
+        // Options tab left-nav: selected group, currently highlighted category, and a pending scroll
+        std::string options_group_selected = "";
+        std::string options_category_selected = "";
+        bool options_scroll_pending = false;
+        bool options_scroll_top = false;
 
         std::filesystem::path file_picker_path;
         std::thread *file_picker_thread = nullptr;

--- a/src/spice2x/overlay/windows/config.h
+++ b/src/spice2x/overlay/windows/config.h
@@ -134,6 +134,7 @@ namespace overlay::windows {
         std::string all_nav_group_selected = "";
         std::string all_nav_selected = "";
         bool all_nav_scroll_pending = false;
+        bool all_nav_scroll_top = false;
 
         std::filesystem::path file_picker_path;
         std::thread *file_picker_thread = nullptr;

--- a/src/spice2x/overlay/windows/config.h
+++ b/src/spice2x/overlay/windows/config.h
@@ -192,7 +192,8 @@ namespace overlay::windows {
         std::string build_option_value_picker_title(const OptionDefinition& option);
         void build_option_value_picker(Option& option);
         void build_options(
-            std::vector<Option> *options, const std::string &category, const std::string *filter=nullptr);
+            std::vector<Option> *options, const std::string &category, const std::string *filter=nullptr,
+            bool quick_only=false);
         void build_options_tab(float page_offset);
         void build_about();
         void build_launcher();


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
#0

## Description of change
Combine API/Options/Advanced/Development/Search tabs into one Options tab and add a left nav for navigation categories.

Reduce information density for options table by making each row double the height and slightly increasing widget sizes.

## Testing
