### PR TITLE
iidx: set SOUND_OUTPUT_DEVICE even when -iidx is not enabled

### DIFF
--- a/src/spice2x/games/iidx/iidx.cpp
+++ b/src/spice2x/games/iidx/iidx.cpp
@@ -543,11 +543,7 @@ namespace games::iidx {
         // if the user specified a value (other than auto), use it as the environment var
         // probably "wasapi" or "asio", but it's not explicitly checked here for forward compat
         if (SOUND_OUTPUT_DEVICE.has_value() && SOUND_OUTPUT_DEVICE.value() != "auto") {
-            log_info(
-                "iidx",
-                "using user-supplied \"{}\" for SOUND_OUTPUT_DEVICE",
-                SOUND_OUTPUT_DEVICE.value());
-            SetEnvironmentVariable("SOUND_OUTPUT_DEVICE", SOUND_OUTPUT_DEVICE.value().c_str());
+            // the environemnt variable was already set in launcher.cpp
             SOUND_OUTPUT_DEVICE_IN_EFFECT = SOUND_OUTPUT_DEVICE;
             return;
         }

--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -1644,11 +1644,22 @@ int main_implementation(int argc, char *argv[]) {
         GRAPHICS_FS_ORIENTATION_SWAP = true;
     }
 
+
+    // for cab usage - set environment variables (outside of -iidx module)
     if (games::iidx::DISABLE_CAMS.has_value() &&
         games::iidx::DISABLE_CAMS.value() &&
         !cfg::CONFIGURATOR_STANDALONE) {
-        log_misc("launcher", "CONNECT_CAMERA env var set to 0");
+        log_misc("launcher::iidx", "CONNECT_CAMERA env var set to 0");
         SetEnvironmentVariable("CONNECT_CAMERA", "0");
+    }
+    if (games::iidx::SOUND_OUTPUT_DEVICE.has_value() &&
+        games::iidx::SOUND_OUTPUT_DEVICE.value() != "auto" &&
+        !cfg::CONFIGURATOR_STANDALONE) {
+        log_info(
+            "launcher::iidx",
+            "using user-supplied \"{}\" for SOUND_OUTPUT_DEVICE",
+            games::iidx::SOUND_OUTPUT_DEVICE.value());
+        SetEnvironmentVariable("SOUND_OUTPUT_DEVICE", games::iidx::SOUND_OUTPUT_DEVICE.value().c_str());
     }
 
     // deleted options


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
n/a

## Description of change
For cab usage, when `-exec bm2dx.dll` is used without `-iidx` then SOUND_OUTPUT_DEVICE never gets set. 

Change this so that `SOUND_OUTPUT_DEVICE` gets set unconditionally if `-iidxsounddevice` is set.

## Testing
