### PR TITLE
ccj: fix mouse wheel input in overlay

### DIFF
--- a/src/spice2x/games/ccj/trackball.cpp
+++ b/src/spice2x/games/ccj/trackball.cpp
@@ -203,10 +203,19 @@ namespace games::ccj {
     }
 
     static BOOL WINAPI RegisterRawInputDevices_hook(PCRAWINPUTDEVICE pRawInputDevices, UINT uiNumDevices, UINT cbSize) {
-        if (uiNumDevices == 2 && pRawInputDevices[1].usUsage == HID_USAGE_GENERIC_GAMEPAD)
-            uiNumDevices = 1;
 
-        return RegisterRawInputDevices_orig(pRawInputDevices, uiNumDevices, cbSize);
+        // if the caller is spice itself, then pass through.
+        if (pRawInputDevices &&
+            (uiNumDevices > 0) &&
+            (pRawInputDevices[0].hwndTarget == RI_MGR->input_hwnd)) {
+
+            return RegisterRawInputDevices_orig(pRawInputDevices, uiNumDevices, cbSize);
+        }
+
+        // otherwise, it must be the game; prevent the game from registering for raw input
+        // and hijacking WM_INPUT messages; we need that for rawinput to work.
+        // even if we drop this, trackball emulation and mouse-as-touch input still work
+        return TRUE;
     }
 
 

--- a/src/spice2x/overlay/overlay.cpp
+++ b/src/spice2x/overlay/overlay.cpp
@@ -844,7 +844,10 @@ void overlay::SpiceOverlay::show_main_menu() {
         }
         return;
     }
-    if (ImGui::IsPopupOpen(0, ImGuiPopupFlags_AnyPopup)) {
+
+    // don't open on top of another genuinely-visible popup, but ONLY guard while
+    // the overlay is active
+    if (this->get_active() && ImGui::IsPopupOpen(0, ImGuiPopupFlags_AnyPopup)) {
         return;
     }
 


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
#251 

## Description of change
CCJ registers for rawinput mouse. We allowed the rawinput registration to go through to the OS, which prevents spice's rawinput stack from using the mouse. This caused the overlay to not accept mouse input. Fix it by not letting the rawinput registration through. Luckily, mouse input continues to work properly in CCJ (for touch).

Also, fix a bug in DX11 overlay when toggling the main menu.

## Testing
