### PR TITLE
overlay: remove keyboard / gamepad tab navigation

### DIFF
--- a/src/spice2x/overlay/overlay.cpp
+++ b/src/spice2x/overlay/overlay.cpp
@@ -308,10 +308,7 @@ void overlay::SpiceOverlay::init() {
     // configure IO
     auto &io = ImGui::GetIO();
     io.UserData = this;
-    io.ConfigFlags = ImGuiConfigFlags_NavEnableKeyboard
-                     | ImGuiConfigFlags_NavEnableGamepad
-                     | ImGuiConfigFlags_NavEnableSetMousePos;
-
+    io.ConfigFlags = ImGuiConfigFlags_None;
     if (!cfg::CONFIGURATOR_STANDALONE) {
         io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
     }

--- a/src/spice2x/overlay/overlay.cpp
+++ b/src/spice2x/overlay/overlay.cpp
@@ -312,9 +312,6 @@ void overlay::SpiceOverlay::init() {
     if (!cfg::CONFIGURATOR_STANDALONE) {
         io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
     }
-    if (is_touch_available("SpiceOverlay::init")) {
-        io.ConfigFlags |= ImGuiConfigFlags_IsTouchScreen;
-    }
 
     // temporarily turn this off as it can cause crashes during font load failures
     // turns back on in ImGui_ImplSpice_Init


### PR DESCRIPTION
Tired of constantly fighting unintentional keyboard navigation behavior.

Also, remove `ImGuiConfigFlags_IsTouchScreen` which literally does nothing.