### PR TITLE
overlay: toggle main menu independently

### DIFF
--- a/src/spice2x/overlay/overlay.cpp
+++ b/src/spice2x/overlay/overlay.cpp
@@ -832,10 +832,6 @@ void overlay::SpiceOverlay::show_main_menu() {
     if (this->window_main_menu->get_active()) {
         // window already visible - close the window
         this->window_main_menu->set_active(false);
-        // if the overlay was not visible when this came into view, turn off overlay as well
-        if (!this->overlay_active_when_main_menu_shown) {
-            this->set_active(false);
-        }
         return;
     }
 
@@ -845,7 +841,6 @@ void overlay::SpiceOverlay::show_main_menu() {
         return;
     }
 
-    this->overlay_active_when_main_menu_shown = this->get_active();
     if (this->get_active()) {
         if (!ImGui::IsAnyItemActive() && !ImGui::IsAnyItemFocused()) {
             this->window_main_menu->set_active(true);

--- a/src/spice2x/overlay/overlay.h
+++ b/src/spice2x/overlay/overlay.h
@@ -202,7 +202,6 @@ namespace overlay {
         bool active = false;
         bool toggle_down = false;
         bool main_menu_down = false;
-        bool overlay_active_when_main_menu_shown = false;
         bool fps_down = false;
         bool hotkey_toggle = false;
         bool hotkey_toggle_last = false;


### PR DESCRIPTION
Recently there was a change to make the main menu also toggle the overlay; revert that.