### PR TITLE
cfg: ignore nolegacy

### DIFF
--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -1068,7 +1068,7 @@ int main_implementation(int argc, char *argv[]) {
         // do not explicitly set GRAPHICS_9_ON_12_STATE to default here; must respect
         // legacy Graphics9On12 option from above if set
     }
-    if (options[launcher::Options::NoLegacy].value_bool() && !cfg_run) {
+    if (options[launcher::Options::NoLegacy].value_bool() && !cfg_run && !cfg::CONFIGURATOR_STANDALONE) {
         rawinput::NOLEGACY = true;
     }
     if (options[launcher::Options::RichPresence].value_bool()) {


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
Fixes #762

## Description of change
Fix -nolegacy causing input to be not processed in spicecfg

Need to fix `run_cfg` and `CONFIGURATOR_STANDALONE` for real soon.

## Testing

