### PR TITLE
graphics: respect Windows dark mode

### DIFF
--- a/src/spice2x/cfg/configurator_wnd.cpp
+++ b/src/spice2x/cfg/configurator_wnd.cpp
@@ -12,18 +12,10 @@
 #include "overlay/overlay.h"
 #include "util/logging.h"
 #include "util/precise_timer.h"
+#include "util/utils.h"
 #include "cfg/configurator.h"
 
 #include "icon.h"
-
-#if !SPICE_XP
-#include <dwmapi.h>
-#ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
-#define DWMWA_USE_IMMERSIVE_DARK_MODE 20
-#endif
-// older numbering used by Win10 1809..1909
-#define DWMWA_USE_IMMERSIVE_DARK_MODE_OLD 19
-#endif
 
 static const char *CLASS_NAME = "ConfiguratorWindow";
 static std::string WINDOW_TITLE;
@@ -32,35 +24,6 @@ static int WINDOW_SIZE_Y = 600;
 static HICON WINDOW_ICON = LoadIcon(GetModuleHandle(nullptr), MAKEINTRESOURCE(MAINICON));
 
 static const UINT_PTR RENDER_TIMER_ID = 1;
-
-// make the native title bar follow the Windows dark/light app theme
-static void apply_dark_titlebar(HWND hWnd) {
-#if !SPICE_XP
-
-    // AppsUseLightTheme == 0 means the dark app theme is selected
-    DWORD light = 1;
-    DWORD size = sizeof(light);
-    HKEY key;
-    if (RegOpenKeyExW(HKEY_CURRENT_USER,
-            L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
-            0, KEY_QUERY_VALUE, &key) == ERROR_SUCCESS) {
-        RegQueryValueExW(key, L"AppsUseLightTheme", nullptr, nullptr,
-            reinterpret_cast<LPBYTE>(&light), &size);
-        RegCloseKey(key);
-    }
-
-    BOOL dark = (light == 0) ? TRUE : FALSE;
-
-    // fall back to the older attribute numbering on Win10 1809..1909
-    if (FAILED(DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE,
-            &dark, sizeof(dark)))) {
-        DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE_OLD,
-            &dark, sizeof(dark));
-    }
-#else
-    (void) hWnd;
-#endif
-}
 
 // Map a virtual key code to the matching ImGuiKey. Mirrors the table used by
 // the in-game ImGui spice backend so navigation keys behave identically when
@@ -252,7 +215,7 @@ cfg::ConfiguratorWindow::ConfiguratorWindow() {
 
     if (this->hWnd) {
         overlay::USE_WM_CHAR_FOR_IMGUI_CHAR_INPUT = true;
-        apply_dark_titlebar(this->hWnd);
+        set_window_dark_titlebar(this->hWnd);
     }
 }
 
@@ -339,7 +302,7 @@ LRESULT CALLBACK cfg::ConfiguratorWindow::window_proc(HWND hWnd, UINT uMsg, WPAR
             // re-apply the dark/light caption when the app theme changes. This is
             // an ANSI window, so lParam is an ANSI string - compare with lstrcmpiA.
             if (lParam && lstrcmpiA(reinterpret_cast<LPCSTR>(lParam), "ImmersiveColorSet") == 0) {
-                apply_dark_titlebar(hWnd);
+                set_window_dark_titlebar(hWnd);
             }
 
             break;

--- a/src/spice2x/cfg/configurator_wnd.cpp
+++ b/src/spice2x/cfg/configurator_wnd.cpp
@@ -215,7 +215,8 @@ cfg::ConfiguratorWindow::ConfiguratorWindow() {
 
     if (this->hWnd) {
         overlay::USE_WM_CHAR_FOR_IMGUI_CHAR_INPUT = true;
-        set_window_dark_titlebar(this->hWnd);
+        // force dark title bar
+        set_window_dark_titlebar(this->hWnd, true);
     }
 }
 
@@ -294,16 +295,6 @@ LRESULT CALLBACK cfg::ConfiguratorWindow::window_proc(HWND hWnd, UINT uMsg, WPAR
             // set user data of window to class pointer
             auto create_struct = reinterpret_cast<LPCREATESTRUCT>(lParam);
             SetWindowLongPtrW(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(create_struct->lpCreateParams));
-
-            break;
-        }
-        case WM_SETTINGCHANGE: {
-
-            // re-apply the dark/light caption when the app theme changes. This is
-            // an ANSI window, so lParam is an ANSI string - compare with lstrcmpiA.
-            if (lParam && lstrcmpiA(reinterpret_cast<LPCSTR>(lParam), "ImmersiveColorSet") == 0) {
-                set_window_dark_titlebar(hWnd);
-            }
 
             break;
         }

--- a/src/spice2x/cfg/configurator_wnd.cpp
+++ b/src/spice2x/cfg/configurator_wnd.cpp
@@ -16,6 +16,15 @@
 
 #include "icon.h"
 
+#if !SPICE_XP
+#include <dwmapi.h>
+#ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
+#define DWMWA_USE_IMMERSIVE_DARK_MODE 20
+#endif
+// older numbering used by Win10 1809..1909
+#define DWMWA_USE_IMMERSIVE_DARK_MODE_OLD 19
+#endif
+
 static const char *CLASS_NAME = "ConfiguratorWindow";
 static std::string WINDOW_TITLE;
 static int WINDOW_SIZE_X = 800;
@@ -23,6 +32,35 @@ static int WINDOW_SIZE_Y = 600;
 static HICON WINDOW_ICON = LoadIcon(GetModuleHandle(nullptr), MAKEINTRESOURCE(MAINICON));
 
 static const UINT_PTR RENDER_TIMER_ID = 1;
+
+// make the native title bar follow the Windows dark/light app theme
+static void apply_dark_titlebar(HWND hWnd) {
+#if !SPICE_XP
+
+    // AppsUseLightTheme == 0 means the dark app theme is selected
+    DWORD light = 1;
+    DWORD size = sizeof(light);
+    HKEY key;
+    if (RegOpenKeyExW(HKEY_CURRENT_USER,
+            L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
+            0, KEY_QUERY_VALUE, &key) == ERROR_SUCCESS) {
+        RegQueryValueExW(key, L"AppsUseLightTheme", nullptr, nullptr,
+            reinterpret_cast<LPBYTE>(&light), &size);
+        RegCloseKey(key);
+    }
+
+    BOOL dark = (light == 0) ? TRUE : FALSE;
+
+    // fall back to the older attribute numbering on Win10 1809..1909
+    if (FAILED(DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE,
+            &dark, sizeof(dark)))) {
+        DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE_OLD,
+            &dark, sizeof(dark));
+    }
+#else
+    (void) hWnd;
+#endif
+}
 
 // Map a virtual key code to the matching ImGuiKey. Mirrors the table used by
 // the in-game ImGui spice backend so navigation keys behave identically when
@@ -214,6 +252,7 @@ cfg::ConfiguratorWindow::ConfiguratorWindow() {
 
     if (this->hWnd) {
         overlay::USE_WM_CHAR_FOR_IMGUI_CHAR_INPUT = true;
+        apply_dark_titlebar(this->hWnd);
     }
 }
 
@@ -292,6 +331,16 @@ LRESULT CALLBACK cfg::ConfiguratorWindow::window_proc(HWND hWnd, UINT uMsg, WPAR
             // set user data of window to class pointer
             auto create_struct = reinterpret_cast<LPCREATESTRUCT>(lParam);
             SetWindowLongPtrW(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(create_struct->lpCreateParams));
+
+            break;
+        }
+        case WM_SETTINGCHANGE: {
+
+            // re-apply the dark/light caption when the app theme changes. This is
+            // an ANSI window, so lParam is an ANSI string - compare with lstrcmpiA.
+            if (lParam && lstrcmpiA(reinterpret_cast<LPCSTR>(lParam), "ImmersiveColorSet") == 0) {
+                apply_dark_titlebar(hWnd);
+            }
 
             break;
         }

--- a/src/spice2x/hooks/graphics/backends/d3d11/d3d11_swapchain.cpp
+++ b/src/spice2x/hooks/graphics/backends/d3d11/d3d11_swapchain.cpp
@@ -27,6 +27,7 @@
 #include "hooks/graphics/graphics.h"
 #include "launcher/launcher.h"
 #include "misc/eamuse.h"
+#include "util/utils.h"
 
 // --------------------------------------------------------------------------
 // overlay render bridge
@@ -122,6 +123,10 @@ void try_create_overlay(IDXGISwapChain *swapchain) {
     if (main && desc.OutputWindow != main) {
         return;
     }
+
+    // theme the native title bar; first present is the only reliable point for
+    // windows whose swapchain bypasses our factory hooks (e.g. UnityPlayer.dll)
+    set_window_dark_titlebar(desc.OutputWindow);
 
     ID3D11Device *device = nullptr;
     if (FAILED(swapchain->GetDevice(IID_PPV_ARGS(&device))) || !device) {

--- a/src/spice2x/hooks/graphics/graphics.cpp
+++ b/src/spice2x/hooks/graphics/graphics.cpp
@@ -585,6 +585,9 @@ static HWND WINAPI CreateWindowExA_hook(DWORD dwExStyle, LPCSTR lpClassName, LPC
             hWndParent, hMenu, hInstance, lpParam);
     GRAPHICS_WINDOWS.push_back(result);
 
+    // theme the native title bar (dark/light)
+    set_window_dark_titlebar(result);
+
     if (is_tdj_sub_window) {
         // TDJ windowed mode: remember the subscreen window handle for later
         TDJ_SUBSCREEN_WINDOW = result;
@@ -705,6 +708,9 @@ static HWND WINAPI CreateWindowExW_hook(DWORD dwExStyle, LPCWSTR lpClassName, LP
             dwExStyle, lpClassName, lpWindowName, dwStyle, x, y, nWidth, nHeight,
             hWndParent, hMenu, hInstance, lpParam);
     GRAPHICS_WINDOWS.push_back(result);
+
+    // theme the native title bar (dark/light)
+    set_window_dark_titlebar(result);
 
     log_misc(
         "graphics",

--- a/src/spice2x/util/utils.cpp
+++ b/src/spice2x/util/utils.cpp
@@ -134,7 +134,7 @@ void generate_ea_card(char card[17]) {
     card[16] = 0;
 }
 
-void set_window_dark_titlebar(HWND hWnd) {
+void set_window_dark_titlebar(HWND hWnd, bool force_dark) {
 #if !SPICE_XP
     if (hWnd == nullptr) {
         return;
@@ -142,17 +142,19 @@ void set_window_dark_titlebar(HWND hWnd) {
 
     // AppsUseLightTheme == 0 means the dark app theme is selected
     DWORD light = 1;
-    DWORD size = sizeof(light);
-    HKEY key;
-    if (RegOpenKeyExW(HKEY_CURRENT_USER,
-            L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
-            0, KEY_QUERY_VALUE, &key) == ERROR_SUCCESS) {
-        RegQueryValueExW(key, L"AppsUseLightTheme", nullptr, nullptr,
-            reinterpret_cast<LPBYTE>(&light), &size);
-        RegCloseKey(key);
+    if (!force_dark) {
+        DWORD size = sizeof(light);
+        HKEY key;
+        if (RegOpenKeyExW(HKEY_CURRENT_USER,
+                L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
+                0, KEY_QUERY_VALUE, &key) == ERROR_SUCCESS) {
+            RegQueryValueExW(key, L"AppsUseLightTheme", nullptr, nullptr,
+                reinterpret_cast<LPBYTE>(&light), &size);
+            RegCloseKey(key);
+        }
     }
 
-    BOOL dark = (light == 0) ? TRUE : FALSE;
+    BOOL dark = (force_dark || light == 0) ? TRUE : FALSE;
 
     // fall back to the older attribute numbering on Win10 1809..1909
     if (FAILED(DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE,
@@ -162,5 +164,6 @@ void set_window_dark_titlebar(HWND hWnd) {
     }
 #else
     (void) hWnd;
+    (void) force_dark;
 #endif
 }

--- a/src/spice2x/util/utils.cpp
+++ b/src/spice2x/util/utils.cpp
@@ -4,6 +4,15 @@
 
 #include "utils.h"
 
+#if !SPICE_XP
+#include <dwmapi.h>
+#ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
+#define DWMWA_USE_IMMERSIVE_DARK_MODE 20
+#endif
+// older numbering used by Win10 1809..1909
+#define DWMWA_USE_IMMERSIVE_DARK_MODE_OLD 19
+#endif
+
 const char *inet_ntop(short af, const void *src, char *dst, DWORD size) {
 
     // prepare storage
@@ -123,4 +132,35 @@ void generate_ea_card(char card[17]) {
 
     // terminate and flush
     card[16] = 0;
+}
+
+void set_window_dark_titlebar(HWND hWnd) {
+#if !SPICE_XP
+    if (hWnd == nullptr) {
+        return;
+    }
+
+    // AppsUseLightTheme == 0 means the dark app theme is selected
+    DWORD light = 1;
+    DWORD size = sizeof(light);
+    HKEY key;
+    if (RegOpenKeyExW(HKEY_CURRENT_USER,
+            L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
+            0, KEY_QUERY_VALUE, &key) == ERROR_SUCCESS) {
+        RegQueryValueExW(key, L"AppsUseLightTheme", nullptr, nullptr,
+            reinterpret_cast<LPBYTE>(&light), &size);
+        RegCloseKey(key);
+    }
+
+    BOOL dark = (light == 0) ? TRUE : FALSE;
+
+    // fall back to the older attribute numbering on Win10 1809..1909
+    if (FAILED(DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE,
+            &dark, sizeof(dark)))) {
+        DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE_OLD,
+            &dark, sizeof(dark));
+    }
+#else
+    (void) hWnd;
+#endif
 }

--- a/src/spice2x/util/utils.h
+++ b/src/spice2x/util/utils.h
@@ -28,8 +28,9 @@ static const char HEX_LOOKUP_UPPERCASE[16] = {
 
 const char *inet_ntop(short af, const void *src, char *dst, DWORD size);
 
-// make a window's native title bar follow the Windows dark/light app theme
-void set_window_dark_titlebar(HWND hWnd);
+// make a window's native title bar follow the Windows dark/light app theme.
+// pass force_dark=true to always use the dark caption regardless of the system theme.
+void set_window_dark_titlebar(HWND hWnd, bool force_dark = false);
 
 static inline bool string_begins_with(const std::string &s, const std::string &prefix) {
     return s.compare(0, prefix.size(), prefix) == 0;

--- a/src/spice2x/util/utils.h
+++ b/src/spice2x/util/utils.h
@@ -28,6 +28,9 @@ static const char HEX_LOOKUP_UPPERCASE[16] = {
 
 const char *inet_ntop(short af, const void *src, char *dst, DWORD size);
 
+// make a window's native title bar follow the Windows dark/light app theme
+void set_window_dark_titlebar(HWND hWnd);
+
 static inline bool string_begins_with(const std::string &s, const std::string &prefix) {
     return s.compare(0, prefix.size(), prefix) == 0;
 }


### PR DESCRIPTION
Only affects the caption bar.

Should work for:

- [x] standalone configurator (always launches in dark mode)
- [x] dx9 games, including multi-window games like gitadora (checks OS settings)
- [x] Unity games (checks OS settings - not all games will work)