### PR TITLE
overlay: fix highlights, alignment in presets table

### DIFF
--- a/src/spice2x/overlay/imgui/extensions.cpp
+++ b/src/spice2x/overlay/imgui/extensions.cpp
@@ -2,6 +2,7 @@
 #include <cmath>
 
 #include "external/imgui/imgui.h"
+#include "external/imgui/imgui_internal.h"
 #include "overlay/overlay.h"
 
 
@@ -209,17 +210,17 @@ namespace ImGui {
         return open;
     }
 
-    void InvisibleTableRowSelectable() {
-        ImGui::TableSetColumnIndex(0);
-        ImGui::PushStyleColor(ImGuiCol_Header, 0);
-        ImGui::PushStyleColor(ImGuiCol_HeaderHovered, 0);
-        ImGui::PushStyleColor(ImGuiCol_HeaderActive, 0);
-        ImGui::PushTabStop(false); // prevent tab navigation
-        ImGui::Selectable("##row", false,
-            ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_AllowOverlap);
-        ImGui::PopTabStop();
-        ImGui::PopStyleColor(3);
-        if (ImGui::IsItemHovered()) {
+    void HighlightTableRowOnHover() {
+        // hit-test the row rect directly so the row layout and height are untouched
+        ImGuiTable *table = ImGui::GetCurrentTable();
+        if (table == nullptr) {
+            return;
+        }
+        if (ImGui::IsWindowHovered() &&
+            ImGui::IsMouseHoveringRect(
+                ImVec2(table->WorkRect.Min.x, table->RowPosY1),
+                ImVec2(table->WorkRect.Max.x, table->RowPosY2),
+                false)) {
             ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg1, IM_COL32(200, 200, 200, 24));
         }
     }

--- a/src/spice2x/overlay/imgui/extensions.h
+++ b/src/spice2x/overlay/imgui/extensions.h
@@ -20,7 +20,7 @@ namespace ImGui {
     void TextTruncated(const std::string& p_text, float p_truncated_width);
     bool DeleteButton(const std::string& tooltip);
     bool ClearButton(const std::string& tooltip);
-    void InvisibleTableRowSelectable();
+    void HighlightTableRowOnHover();
 
     // Config tab bar with extra label padding and uniform, centered tab widths.
     // Wrap items in BeginPaddedTabItem between BeginPaddedTabBar/EndTabBar.

--- a/src/spice2x/overlay/windows/config.cpp
+++ b/src/spice2x/overlay/windows/config.cpp
@@ -928,18 +928,14 @@ namespace overlay::windows {
 
                     // primary
                     build_button(name, primary_button, &primary_button, button_it, button_it_max, 0);
-                    ImGui::PushID(&primary_button);
-                    ImGui::InvisibleTableRowSelectable();
-                    ImGui::PopID();
+                    ImGui::HighlightTableRowOnHover();
 
                     // alternatives
                     int alt_index = 1; // 0 is primary
                     for (auto &alt : primary_button.getAlternatives()) {
                         if (alt.isValid()) {
                             build_button(name, primary_button, &alt, button_it, button_it_max, alt_index);
-                            ImGui::PushID(&alt);
-                            ImGui::InvisibleTableRowSelectable();
-                            ImGui::PopID();
+                            ImGui::HighlightTableRowOnHover();
                         }
                         alt_index++;
                     }
@@ -2519,8 +2515,7 @@ namespace overlay::windows {
 
                     edit_analog_popup(analog, title);
 
-                    // row hover detection (invisible selectable that spans entire row)
-                    ImGui::InvisibleTableRowSelectable();
+                    ImGui::HighlightTableRowOnHover();
 
                     // clean up
                     ImGui::PopID();
@@ -3174,16 +3169,12 @@ namespace overlay::windows {
             }
 
             build_light(light, &light, i, 0);
-            ImGui::PushID(&light);
-            ImGui::InvisibleTableRowSelectable();
-            ImGui::PopID();
+            ImGui::HighlightTableRowOnHover();
             int alt_index = 1;
             for (auto &alt : light.getAlternatives()) {
                 if (alt.isValid()) {
                     build_light(light, &alt, i, alt_index);
-                    ImGui::PushID(&alt);
-                    ImGui::InvisibleTableRowSelectable();
-                    ImGui::PopID();
+                    ImGui::HighlightTableRowOnHover();
                 }
                 alt_index++;
             }
@@ -5296,8 +5287,7 @@ namespace overlay::windows {
                     }
                 }
 
-                // row hover detection (invisible selectable that spans entire row)
-                ImGui::InvisibleTableRowSelectable();
+                ImGui::HighlightTableRowOnHover();
 
                 // next item
                 ImGui::PopID();
@@ -5790,23 +5780,28 @@ namespace overlay::windows {
 
                     // name
                     ImGui::TableNextColumn();
+                    ImGui::AlignTextToFramePadding();
                     ImGui::TextTruncated(
                         t.name, ImGui::GetContentRegionAvail().x - overlay::apply_scaling(20));
 
                     // type
                     ImGui::TableNextColumn();
+                    ImGui::AlignTextToFramePadding();
                     ImGui::TextUnformatted(t.is_builtin ? "Built-in" : "User");
 
                     // buttons
                     ImGui::TableNextColumn();
+                    ImGui::AlignTextToFramePadding();
                     ImGui::Text("%d", (int)t.buttons.size());
 
                     // analogs
                     ImGui::TableNextColumn();
+                    ImGui::AlignTextToFramePadding();
                     ImGui::Text("%d", (int)t.analogs.size());
 
                     // lights
                     ImGui::TableNextColumn();
+                    ImGui::AlignTextToFramePadding();
                     ImGui::Text("%d", (int)t.lights.size());
 
                     // actions
@@ -5834,7 +5829,7 @@ namespace overlay::windows {
                         }
                     }
 
-                    ImGui::InvisibleTableRowSelectable();
+                    ImGui::HighlightTableRowOnHover();
                     ImGui::PopID();
                 }
 

--- a/src/spice2x/overlay/windows/patch_manager.cpp
+++ b/src/spice2x/overlay/windows/patch_manager.cpp
@@ -876,8 +876,7 @@ namespace overlay::windows {
                         ImGui::EndDisabled();
                     }
 
-                    // row hover detection (invisible selectable that spans entire row)
-                    ImGui::InvisibleTableRowSelectable();
+                    ImGui::HighlightTableRowOnHover();
 
                     ImGui::PopID();
                 }


### PR DESCRIPTION
* Fix table row highlight hover detection in Options tab when row has two lines of text
* Fix text alignment in controller presets table