### PR TITLE
popn: make Force Sub Redraw an option

### DIFF
--- a/src/spice2x/hooks/graphics/backends/d3d9/d3d9_backend.cpp
+++ b/src/spice2x/hooks/graphics/backends/d3d9/d3d9_backend.cpp
@@ -1273,9 +1273,11 @@ static void graphics_d3d9_ldj_on_present(IDirect3DDevice9 *wrapped_device) {
         wintouchemu::update();
 
         // newer versions of exceed gear needs SUBSCREEN_FORCE_REDRAW
-        // (when enabled on older versions of EG, you end up with graphical glitches on the subscreen
-        // early versions of popn HC needs this as well, otherwise the subscreen doesn't update at all
-        if (GRAPHICS_WINDOWED || SUBSCREEN_FORCE_REDRAW || games::popn::is_pikapika_model()) {
+        // (when enabled on older versions of EG, you end up with graphical glitches on the subscreen)
+        //
+        // early versions of popn HC needs this as well, but not on by default as it can cause
+        // graphical glitches on some GPUs 
+        if (GRAPHICS_WINDOWED || SUBSCREEN_FORCE_REDRAW) {
             SUB_SWAP_CHAIN->Present(nullptr, nullptr, nullptr, nullptr, 0);
         }
     }

--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -643,6 +643,9 @@ int main_implementation(int argc, char *argv[]) {
     if (options[launcher::Options::PopnNativeTouch].value_bool()) {
         games::popn::NATIVE_TOUCH = true;
     }
+    if (options[launcher::Options::PopnSubRedraw].value_bool()) {
+        SUBSCREEN_FORCE_REDRAW = true;
+    }
     if (options[launcher::Options::LoadMetalGearArcadeModule].value_bool()) {
         attach_mga = true;
     }

--- a/src/spice2x/launcher/options.cpp
+++ b/src/spice2x/launcher/options.cpp
@@ -1139,6 +1139,17 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .category = "Advanced Game Options",
     },
     {
+        // PopnSubRedraw
+        .title = "Pop'n Music PikaPika Subscreen Force Redraw",
+        .name = "popnsubredraw",
+        .desc = "Check if submonitor in fullscreen mode appears stuck; "
+            "this option forces subscreen to redraw every frame.",
+        .type = OptionType::Bool,
+        .game_name = "Pop'n Music",
+        .category = "Advanced Game Options",
+        .quick_setting_category = "Game",
+    },
+    {
         .title = "Force Load HELLO! Pop'n Music Module",
         .name = "hpm",
         .desc = "Manually enable HELLO! Pop'n Music module.",

--- a/src/spice2x/launcher/options.h
+++ b/src/spice2x/launcher/options.h
@@ -108,6 +108,7 @@ namespace launcher {
             PopnNoSub,
             PopnSubMonitorOverride,
             PopnNativeTouch,
+            PopnSubRedraw,
             LoadHelloPopnMusicModule,
             LoadGitaDoraModule,
             GitaDoraTwoChannelAudio,


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
n/a

## Description of change
Similar to how it is on SDVX, turning this on can cause graphical glitches depending on the GPU, so it needs to be an option that users can toggle.

## Testing
