### PR TITLE
rawinput: handle midi scanning asynchronously, fix midi hotplug

### DIFF
--- a/src/spice2x/cfg/api.cpp
+++ b/src/spice2x/cfg/api.cpp
@@ -411,6 +411,12 @@ GameAPI::Buttons::State GameAPI::Buttons::getState(rawinput::RawInputManager *ma
                         BUTTON_PRESSED : BUTTON_NOT_PRESSED;
                     break;
                 }
+                case rawinput::DESTROYED:
+                    // device was unplugged. release the button instead of leaving
+                    // state at getLastState(), which would latch a held button on
+                    // forever (e.g. a MIDI note held while the device is removed)
+                    state = BUTTON_NOT_PRESSED;
+                    break;
                 default:
                     break;
             }

--- a/src/spice2x/rawinput/hotplug.cpp
+++ b/src/spice2x/rawinput/hotplug.cpp
@@ -54,7 +54,7 @@ namespace rawinput {
                     switch (hdr->dbch_devicetype) {
                         case DBT_DEVTYP_DEVICEINTERFACE: {
                             auto dev = (const DEV_BROADCAST_DEVICEINTERFACE *) hdr;
-                            this->ri_mgr->devices_scan_midi();
+                            this->ri_mgr->midi_scan_start();
 
                             // check if class is not HID
                             if (memcmp(&dev->dbcc_classguid, &GUID_HID, sizeof(GUID_HID)) != 0)
@@ -120,8 +120,10 @@ namespace rawinput {
                     return TRUE;
                 }
                 case DBT_DEVNODES_CHANGED: {
-                    // TODO: this can be a little noisy as it gets called on every device
-                    this->ri_mgr->devices_scan_midi();
+                    // catch-all device-tree change: MIDI and XInput have no targeted
+                    // arrival/removal notification, so this is our only hook to detect them
+                    // can be a little noisy as it gets called on every device
+                    this->ri_mgr->midi_scan_start();
                     this->ri_mgr->devices_scan_xinput();
                     break;
                 }

--- a/src/spice2x/rawinput/hotplug.cpp
+++ b/src/spice2x/rawinput/hotplug.cpp
@@ -112,6 +112,7 @@ namespace rawinput {
                             std::string name(dev->dbcc_name);
 
                             // destruct device
+                            log_misc("hotplug", "device interface removal: {}", name);
                             this->ri_mgr->devices_remove(name);
                         }
                     }
@@ -123,6 +124,7 @@ namespace rawinput {
                     // catch-all device-tree change: MIDI and XInput have no targeted
                     // arrival/removal notification, so this is our only hook to detect them
                     // can be a little noisy as it gets called on every device
+                    log_misc("hotplug", "device tree changed, rescanning MIDI + XInput");
                     this->ri_mgr->midi_scan_start();
                     this->ri_mgr->devices_scan_xinput();
                     break;

--- a/src/spice2x/rawinput/rawinput.cpp
+++ b/src/spice2x/rawinput/rawinput.cpp
@@ -100,6 +100,9 @@ void rawinput::RawInputManager::stop() {
         this->hotplug = nullptr;
     }
 
+    // wait for any in-flight async MIDI scan before tearing down devices
+    this->midi_scan_join();
+
     // unregister device messages
     this->devices_unregister();
 
@@ -182,12 +185,18 @@ void rawinput::RawInputManager::input_hwnd_destroy() {
 }
 
 void rawinput::RawInputManager::devices_reload() {
+    std::lock_guard<std::recursive_mutex> lock(this->devices_mutex);
     this->devices_destruct();
     log_info("rawinput", "reloading devices...");
 
     // scan for devices
     this->devices_scan_rawinput();
-    this->devices_scan_midi();
+
+    // MIDI enumeration can block for ~10s while the Windows MIDI subsystem starts
+    // up, so run it off the init path instead of gating startup on it. it locks
+    // devices_mutex only for the vector mutation, so it is safe to run concurrently
+    this->midi_scan_start();
+
     this->devices_scan_piuio();
 
     if (ENABLE_SMX_STAGE) {
@@ -207,7 +216,39 @@ void rawinput::RawInputManager::devices_reload() {
     this->devices_register();
 }
 
+void rawinput::RawInputManager::midi_scan_start() {
+
+    // single-flight: if a scan is already running, skip. the Windows MIDI
+    // enumeration can take several seconds and repeated hotplug events would
+    // otherwise queue up redundant scans on the input thread
+    bool expected = false;
+    if (!this->midi_scan_active.compare_exchange_strong(expected, true)) {
+        return;
+    }
+
+    // clean up the previous (already finished) scan thread handle
+    this->midi_scan_join();
+
+    // run the (potentially slow) MIDI enumeration on its own thread so callers
+    // are not blocked while the Windows MIDI subsystem starts up
+    this->midi_thread = new std::thread([this]() {
+        this->devices_scan_midi();
+        this->midi_scan_active.store(false);
+    });
+}
+
+void rawinput::RawInputManager::midi_scan_join() {
+    if (this->midi_thread) {
+        if (this->midi_thread->joinable()) {
+            this->midi_thread->join();
+        }
+        delete this->midi_thread;
+        this->midi_thread = nullptr;
+    }
+}
+
 void rawinput::RawInputManager::devices_scan_rawinput(const std::string &device_name) {
+    std::lock_guard<std::recursive_mutex> lock(this->devices_mutex);
     log_misc("rawinput", "scan rawinput devices...");
 
     // get number of devices
@@ -239,6 +280,7 @@ void rawinput::RawInputManager::devices_scan_rawinput(const std::string &device_
 }
 
 void rawinput::RawInputManager::devices_scan_rawinput(RAWINPUTDEVICELIST *device, bool log) {
+    std::lock_guard<std::recursive_mutex> lock(this->devices_mutex);
 
     // get device name
     std::string device_name = rawinput_get_device_name(device->hDevice);
@@ -832,6 +874,12 @@ void rawinput::RawInputManager::devices_scan_rawinput(RAWINPUTDEVICELIST *device
 void rawinput::RawInputManager::devices_scan_midi() {
     log_misc("rawinput", "scan MIDI devices...");
 
+    // note: the WinMM MIDI calls below (midiInGetNumDevs / midiInGetDevCaps /
+    // midiInOpen / midiInStart) can block for many seconds while the Windows MIDI
+    // subsystem starts up. they must NOT run under devices_mutex, otherwise other
+    // threads (input, config) would stall for the same duration. only the vector
+    // mutation at the end of each iteration is guarded.
+
     // add midi devices
     auto midi_device_count = midiInGetNumDevs();
     for (size_t midi_device_id = 0; midi_device_id < midi_device_count; midi_device_id++) {
@@ -903,7 +951,6 @@ void rawinput::RawInputManager::devices_scan_midi() {
 
         // build device
         Device midi_device {};
-        midi_device.id = devices.size() + 1;
         midi_device.type = MIDI;
         midi_device.handle = midi_device_handle;
         midi_device.name = midi_identifier.str();
@@ -912,6 +959,11 @@ void rawinput::RawInputManager::devices_scan_midi() {
         midi_device.mutex = new std::mutex();
         midi_device.mutex_out = new std::mutex();
         midi_device.midiInfo = midi_device_midi_info;
+
+        // mutate the shared device list under lock (the slow WinMM calls above
+        // ran without it so other threads were not blocked)
+        std::lock_guard<std::recursive_mutex> lock(this->devices_mutex);
+        midi_device.id = devices.size() + 1;
 
         // check for duplicate handle
         for (auto &device : this->devices) {
@@ -941,10 +993,14 @@ void rawinput::RawInputManager::devices_scan_midi() {
             cb.f(cb.data, &device);
         }
     }
+
+    log_misc("rawinput", "scan MIDI devices done ({} enumerated)", (unsigned) midi_device_count);
 }
 
 void rawinput::RawInputManager::devices_scan_piuio() {
     log_misc("rawinput", "scan PIUIO devices...");
+
+    std::lock_guard<std::recursive_mutex> lock(this->devices_mutex);
 
     // add device to vector first so pointer is valid
     auto *new_piuio_device = new Device();
@@ -978,6 +1034,8 @@ void rawinput::RawInputManager::devices_scan_piuio() {
 void rawinput::RawInputManager::devices_scan_smxstage() {
     log_misc("rawinput", "scan SMX Stage devices...");
 
+    std::lock_guard<std::recursive_mutex> lock(this->devices_mutex);
+
     auto *new_smxstage_device = new Device();
     new_smxstage_device->id = this->devices.size() + 1;
     new_smxstage_device->type = SMX_STAGE;
@@ -1005,6 +1063,8 @@ void rawinput::RawInputManager::devices_scan_smxstage() {
 void rawinput::RawInputManager::devices_scan_smxdedicab() {
     log_misc("rawinput", "scan SMX Dedicated Cabinet devices...");
 
+    std::lock_guard<std::recursive_mutex> lock(this->devices_mutex);
+
     auto *new_smxdedicab_device = new Device();
     new_smxdedicab_device->id = this->devices.size() + 1;
     new_smxdedicab_device->type = SMX_DEDICAB;
@@ -1031,6 +1091,8 @@ void rawinput::RawInputManager::devices_scan_smxdedicab() {
 
 void rawinput::RawInputManager::devices_scan_xinput() {
     log_misc("rawinput", "scan XInput devices...");
+
+    std::lock_guard<std::recursive_mutex> lock(this->devices_mutex);
 
     const auto connected_players = XINPUT_MGR->get_available_players();
 
@@ -1336,6 +1398,8 @@ void rawinput::RawInputManager::sextet_register(const std::string &port_name, co
 
     log_misc("rawinput", "checking for sextet-stream device on {}...", port_name);
 
+    std::lock_guard<std::recursive_mutex> lock(this->devices_mutex);
+
     // check for any sextet-stream devices
     Device device {};
     device.type = SEXTET_OUTPUT;
@@ -1361,6 +1425,7 @@ void rawinput::RawInputManager::sextet_register(const std::string &port_name, co
 }
 
 void rawinput::RawInputManager::devices_remove(const std::string &name) {
+    std::lock_guard<std::recursive_mutex> lock(this->devices_mutex);
 
     // iterate devices
     for (auto &device : this->devices) {
@@ -1509,6 +1574,7 @@ void rawinput::RawInputManager::devices_unregister() {
 }
 
 void rawinput::RawInputManager::devices_destruct() {
+    std::lock_guard<std::recursive_mutex> lock(this->devices_mutex);
 
     // check if there's something to destruct
     if (this->devices.empty()) {
@@ -1635,6 +1701,8 @@ LRESULT CALLBACK rawinput::RawInputManager::input_wnd_proc(
 
             // find device
             HANDLE device_handle = data->header.hDevice;
+            // lock the device list so a concurrent scan can't reallocate it while we iterate
+            std::lock_guard<std::recursive_mutex> devices_lock(ref->devices_mutex);
             for (auto &device : ref->devices_get()) {
 
                 // skip if this is the wrong device
@@ -2044,6 +2112,9 @@ void CALLBACK rawinput::RawInputManager::input_midi_proc(HMIDIIN hMidiIn, UINT w
             break;
         case MIM_MOREDATA:
         case MIM_DATA: {
+
+            // lock the device list so a concurrent scan can't reallocate it while we iterate
+            std::lock_guard<std::recursive_mutex> devices_lock(ri_mgr->devices_mutex);
 
             // param mapping
             auto dwMidiMessage = dwParam1;

--- a/src/spice2x/rawinput/rawinput.cpp
+++ b/src/spice2x/rawinput/rawinput.cpp
@@ -877,12 +877,11 @@ void rawinput::RawInputManager::devices_scan_midi() {
     log_misc("rawinput", "scan MIDI devices...");
 
     // note: the WinMM MIDI calls below (midiInGetNumDevs / midiInGetDevCaps /
-    // midiInOpen / midiInStart) can block for many seconds while the Windows MIDI
-    // subsystem starts up. they must NOT run under devices_mutex, otherwise other
-    // threads (input, config) would stall for the same duration. only the list
-    // mutation at the end of each iteration is guarded.
+    // midiInOpen / midiInStart) can block for seconds while the Windows MIDI
+    // subsystem starts up, so they must NOT run under devices_mutex. only the
+    // list mutation at the end of each iteration is guarded.
 
-    // identifiers of every MIDI device present in this scan; used afterwards to
+    // identifiers of every MIDI device seen in this scan; used below to
     // tombstone devices that have since been unplugged
     std::vector<std::string> present_identifiers;
 
@@ -913,10 +912,9 @@ void rawinput::RawInputManager::devices_scan_midi() {
         // record that this device is currently present
         present_identifiers.push_back(midi_identifier);
 
-        // if this device is already open, leave it alone. hotplug fires many device
-        // change events, and re-opening on every rescan would needlessly close and
-        // reopen the WinMM handle (dropping MIDI state and input). only (re)open when
-        // the device is missing or a previously destroyed tombstone
+        // if already open, leave it alone: hotplug fires many change events, and
+        // reopening on every rescan would drop the WinMM handle (and its input).
+        // only (re)open when the device is missing or a destroyed tombstone
         {
             std::lock_guard<std::recursive_mutex> lock(this->devices_mutex);
             bool already_open = false;
@@ -1029,8 +1027,8 @@ void rawinput::RawInputManager::devices_scan_midi() {
     }
 
     // tombstone MIDI devices that were open but are no longer present (unplugged).
-    // without this, a replugged device matches the stale live entry in the skip
-    // check above and never gets reopened, so its input is silently lost
+    // otherwise a replugged device matches the stale live entry in the skip check
+    // above and never gets reopened, silently losing its input
     {
         std::lock_guard<std::recursive_mutex> lock(this->devices_mutex);
         for (auto &device : this->devices) {
@@ -1291,10 +1289,9 @@ void rawinput::RawInputManager::output_start() {
                 do {
                     output_thread_ready = false;
 
-                    // snapshot device pointers under devices_mutex so a concurrent scan
-                    // can't mutate the list mid-iteration. the std::list keeps addresses
-                    // stable, so the (potentially blocking) writes below run without
-                    // holding devices_mutex
+                    // snapshot device pointers under devices_mutex, then write without
+                    // it. the std::list keeps addresses stable, so the (potentially
+                    // blocking) writes below don't hold devices_mutex against input
                     std::vector<Device *> snapshot;
                     {
                         std::lock_guard<std::recursive_mutex> devices_lock(this->devices_mutex);
@@ -1769,7 +1766,7 @@ LRESULT CALLBACK rawinput::RawInputManager::input_wnd_proc(
 
             // find device
             HANDLE device_handle = data->header.hDevice;
-            // lock the device list so a concurrent scan can't reallocate it while we iterate
+            // lock the device list so a concurrent scan can't mutate it while we iterate
             std::lock_guard<std::recursive_mutex> devices_lock(ref->devices_mutex);
             for (auto &device : ref->devices_get()) {
 
@@ -2181,7 +2178,7 @@ void CALLBACK rawinput::RawInputManager::input_midi_proc(HMIDIIN hMidiIn, UINT w
         case MIM_MOREDATA:
         case MIM_DATA: {
 
-            // lock the device list so a concurrent scan can't reallocate it while we iterate
+            // lock the device list so a concurrent scan can't mutate it while we iterate
             std::lock_guard<std::recursive_mutex> devices_lock(ri_mgr->devices_mutex);
 
             // param mapping
@@ -2835,10 +2832,9 @@ void rawinput::RawInputManager::devices_flush_output(bool optimized) {
     }
 
     // blocking routine
-    // snapshot device pointers under the lock so a concurrent scan can't mutate the
-    // list while we iterate. the std::list keeps element addresses stable, so the
-    // pointers remain valid after the lock is released and the (potentially blocking)
-    // output writes below do not run under devices_mutex
+    // snapshot device pointers under the lock, then write without it. the std::list
+    // keeps addresses stable, so the (potentially blocking) writes below don't hold
+    // devices_mutex against input
     std::vector<Device *> snapshot;
     {
         std::lock_guard<std::recursive_mutex> lock(this->devices_mutex);

--- a/src/spice2x/rawinput/rawinput.cpp
+++ b/src/spice2x/rawinput/rawinput.cpp
@@ -238,11 +238,19 @@ void rawinput::RawInputManager::midi_scan_start() {
 
     // single-flight: only one scan runs at a time. if one is already running, set
     // the pending flag so it rescans once more when it finishes - MIDI hotplug
-    // events fire while the slow enumeration is still going and must not be lost
-    bool expected = false;
-    if (!this->midi_scan_active.compare_exchange_strong(expected, true)) {
-        this->midi_scan_pending.store(true);
-        return;
+    // events fire while the slow enumeration is still going and must not be lost.
+    // the scheduler mutex makes this check-and-set atomic with the worker's
+    // exit-or-rescan decision below, so a request set while a scan is running is
+    // never dropped
+    {
+        std::lock_guard<std::mutex> lock(this->midi_scan_m);
+        if (this->midi_scan_active) {
+            this->midi_scan_pending = true;
+            log_misc("rawinput", "MIDI scan already running, queued rescan");
+            return;
+        }
+        this->midi_scan_active = true;
+        this->midi_scan_pending = false;
     }
 
     // clean up the previous (already finished) scan thread handle
@@ -251,19 +259,38 @@ void rawinput::RawInputManager::midi_scan_start() {
     // run the (potentially slow) MIDI enumeration on its own thread so callers are
     // not blocked while the Windows MIDI subsystem starts up. rescan if a request
     // arrived while we were scanning
+    log_misc("rawinput", "starting async MIDI scan thread");
     this->midi_thread = new std::thread([this]() {
-        do {
-            this->midi_scan_pending.store(false);
+        for (;;) {
             this->devices_scan_midi();
-        } while (this->midi_scan_pending.exchange(false));
-        this->midi_scan_active.store(false);
+
+            // decide whether to exit under the scheduler lock, atomically with any
+            // concurrent midi_scan_start(): if a rescan was requested, consume it
+            // and loop; otherwise clear active and exit. because both sides take
+            // the same lock, a request set while active is true is never lost, so
+            // we never strand a hotplug event waiting for a future one
+            std::lock_guard<std::mutex> lock(this->midi_scan_m);
+            if (!this->midi_scan_pending) {
+                this->midi_scan_active = false;
+                log_misc("rawinput", "async MIDI scan thread finished");
+                return;
+            }
+            this->midi_scan_pending = false;
+            log_misc("rawinput", "async MIDI scan rescanning (event arrived during scan)");
+        }
     });
 }
 
 void rawinput::RawInputManager::midi_scan_join() {
     if (this->midi_thread) {
         if (this->midi_thread->joinable()) {
+
+            // this blocks until the scan worker returns. if it ever hangs here the
+            // worker is stuck - most likely in midi_close_deferred_flush() waiting
+            // on a WinMM close. a missing "joined" line pinpoints the hang
+            log_misc("rawinput", "joining MIDI scan thread...");
             this->midi_thread->join();
+            log_misc("rawinput", "MIDI scan thread joined");
         }
         delete this->midi_thread;
         this->midi_thread = nullptr;
@@ -281,10 +308,21 @@ void rawinput::RawInputManager::midi_close_deferred_flush() {
         std::lock_guard<std::recursive_mutex> lock(this->devices_mutex);
         handles.swap(this->midi_close_deferred);
     }
-    for (auto handle : handles) {
-        midiInReset(handle);
-        midiInClose(handle);
+    if (handles.empty()) {
+        return;
     }
+
+    // if a hang is ever reported here it is the classic WinMM deadlock: an
+    // in-flight input_midi_proc callback is blocked on devices_mutex while
+    // midiInReset/midiInClose waits for that callback to return. the per-handle
+    // log below pinpoints exactly which close did not come back
+    log_misc("rawinput", "closing {} deferred MIDI handle(s)", handles.size());
+    for (size_t i = 0; i < handles.size(); i++) {
+        log_misc("rawinput", "closing deferred MIDI handle {}/{}", i + 1, handles.size());
+        midiInReset(handles[i]);
+        midiInClose(handles[i]);
+    }
+    log_misc("rawinput", "deferred MIDI handles closed");
 }
 
 void rawinput::RawInputManager::devices_scan_rawinput(const std::string &device_name) {
@@ -1528,19 +1566,26 @@ void rawinput::RawInputManager::sextet_register(const std::string &port_name, co
 }
 
 void rawinput::RawInputManager::devices_remove(const std::string &name) {
-    std::lock_guard<std::recursive_mutex> lock(this->devices_mutex);
+    {
+        std::lock_guard<std::recursive_mutex> lock(this->devices_mutex);
 
-    // iterate devices
-    for (auto &device : this->devices) {
+        // iterate devices
+        for (auto &device : this->devices) {
 
-        // check if name matches
-        if (device.name == name) {
+            // check if name matches
+            if (device.name == name) {
 
-            // remove device
-            this->devices_destruct(&device);
-            return;
+                // remove device
+                this->devices_destruct(&device);
+                break;
+            }
         }
     }
+
+    // close any MIDI handle detached above, now that devices_mutex is released.
+    // removing a MIDI device queues its handle for deferred close; flush it here
+    // since we cannot rely on a later scan happening to do it
+    this->midi_close_deferred_flush();
 }
 
 void rawinput::RawInputManager::devices_register() {
@@ -1747,6 +1792,7 @@ void rawinput::RawInputManager::devices_destruct(Device *device, bool log) {
             // return, callbacks that also take devices_mutex. detach the handle and
             // let midi_close_deferred_flush() close it once the lock is released
             if (device->handle != (HANDLE) INVALID_HANDLE_VALUE) {
+                log_misc("rawinput", "deferring MIDI handle close for: {}", device->desc);
                 this->midi_close_deferred.push_back((HMIDIIN) device->handle);
                 device->handle = (HANDLE) INVALID_HANDLE_VALUE;
             }

--- a/src/spice2x/rawinput/rawinput.cpp
+++ b/src/spice2x/rawinput/rawinput.cpp
@@ -46,6 +46,24 @@ namespace rawinput {
     bool OS_WINDOW_ACTIVE = false;
 }
 
+namespace {
+
+    // when replacing a device slot in place, keep the old slot's per-device mutexes
+    // instead of the freshly allocated pair on `replacement`. their addresses stay
+    // stable, so a thread still holding a snapshot pointer to the slot (e.g. the
+    // output thread blocked on mutex_out, which is taken without devices_mutex)
+    // never locks freed memory. the freshly allocated pair is freed here rather
+    // than leaking the old one. the slot must already be destructed so both
+    // mutexes are unlocked
+    void reuse_device_mutexes(rawinput::Device &replacement, const rawinput::Device &existing) {
+        delete replacement.mutex;
+        delete replacement.mutex_out;
+        replacement.mutex = existing.mutex;
+        replacement.mutex_out = existing.mutex_out;
+    }
+
+}
+
 rawinput::MidiNoteAlgorithm rawinput::get_midi_algorithm() {
     return rawinput::MIDI_NOTE_ALGORITHM;
 }
@@ -870,8 +888,9 @@ void rawinput::RawInputManager::devices_scan_rawinput(RAWINPUTDEVICELIST *device
             // carry over old device ID
             new_device.id = prev_device.id;
 
-            // destruct and replace
+            // destruct and replace, reusing the slot's existing mutexes
             this->devices_destruct(&prev_device);
+            reuse_device_mutexes(new_device, prev_device);
             prev_device = new_device;
 
             // notify change
@@ -1025,8 +1044,9 @@ void rawinput::RawInputManager::devices_scan_midi() {
                 // carry over ID
                 midi_device.id = device.id;
 
-                // destruct and replace
+                // destruct and replace, reusing the slot's existing mutexes
                 this->devices_destruct(&device);
+                reuse_device_mutexes(midi_device, device);
                 device = midi_device;
 
                 // notify change
@@ -1217,7 +1237,11 @@ void rawinput::RawInputManager::devices_scan_xinput() {
             if (prev_device.type == DESTROYED) {
                 log_info("rawinput", "overwriting previously destroyed XInput device: {}", prev_device.name);
                 const auto old_id = prev_device.id;
-                prev_device = create_device(player);
+
+                // replace in place, reusing the slot's existing mutexes
+                auto replacement = create_device(player);
+                reuse_device_mutexes(replacement, prev_device);
+                prev_device = replacement;
                 prev_device.id = old_id;
 
                 // notify change
@@ -1662,6 +1686,7 @@ void rawinput::RawInputManager::devices_destruct() {
             for (auto &device : this->devices) {
                 this->devices_destruct(&device, false);
                 delete device.mutex;
+                delete device.mutex_out;
             }
 
             // empty array
@@ -1748,7 +1773,10 @@ void rawinput::RawInputManager::devices_destruct(Device *device, bool log) {
     device->smxstageInfo = nullptr;
     delete device->smxdedicabInfo;
     device->smxdedicabInfo = nullptr;
-    // TODO: check if mutex can be deleted
+
+    // note: mutex and mutex_out are intentionally left alive here. other threads
+    // may still hold a snapshot pointer to this device and block on them, so they
+    // are only freed during full teardown; on reuse the slot keeps the same pair
 }
 
 LRESULT CALLBACK rawinput::RawInputManager::input_wnd_proc(

--- a/src/spice2x/rawinput/rawinput.cpp
+++ b/src/spice2x/rawinput/rawinput.cpp
@@ -194,7 +194,7 @@ void rawinput::RawInputManager::devices_reload() {
 
     // MIDI enumeration can block for ~10s while the Windows MIDI subsystem starts
     // up, so run it off the init path instead of gating startup on it. it locks
-    // devices_mutex only for the vector mutation, so it is safe to run concurrently
+    // devices_mutex only for the list mutation, so it is safe to run concurrently
     this->midi_scan_start();
 
     this->devices_scan_piuio();
@@ -304,11 +304,13 @@ void rawinput::RawInputManager::devices_scan_rawinput(RAWINPUTDEVICELIST *device
 
     // check for duplicate handle
     size_t unique_id = devices.size() + 1;
-    for (size_t i = 0; i < this->devices.size(); i++) {
-        if (this->devices[i].name == device_name) {
+    size_t i = 0;
+    for (const auto &existing : this->devices) {
+        if (existing.name == device_name) {
             unique_id = i;
             break;
         }
+        i++;
     }
 
     // build device
@@ -877,8 +879,12 @@ void rawinput::RawInputManager::devices_scan_midi() {
     // note: the WinMM MIDI calls below (midiInGetNumDevs / midiInGetDevCaps /
     // midiInOpen / midiInStart) can block for many seconds while the Windows MIDI
     // subsystem starts up. they must NOT run under devices_mutex, otherwise other
-    // threads (input, config) would stall for the same duration. only the vector
+    // threads (input, config) would stall for the same duration. only the list
     // mutation at the end of each iteration is guarded.
+
+    // identifiers of every MIDI device present in this scan; used afterwards to
+    // tombstone devices that have since been unplugged
+    std::vector<std::string> present_identifiers;
 
     // add midi devices
     auto midi_device_count = midiInGetNumDevs();
@@ -892,6 +898,38 @@ void rawinput::RawInputManager::devices_scan_midi() {
 
         log_misc("rawinput", "found MIDI device: id {}, name {}, mid {}, pid {}",
             midi_device_id, midi_device_caps.szPname, midi_device_caps.wMid, midi_device_caps.wPid);
+
+        // build identifier for MIDI
+        // ;MIDI; format is now set in stone (in other parts of the code base and in the config xml file)
+        // so it should never be changed
+        std::ostringstream midi_identifier_stream;
+        midi_identifier_stream << ";" << "MIDI";
+        midi_identifier_stream << ";" << midi_device_id;
+        midi_identifier_stream << ";" << midi_device_caps.szPname;
+        midi_identifier_stream << ";" << midi_device_caps.wMid;
+        midi_identifier_stream << ";" << midi_device_caps.wPid;
+        const auto midi_identifier = midi_identifier_stream.str();
+
+        // record that this device is currently present
+        present_identifiers.push_back(midi_identifier);
+
+        // if this device is already open, leave it alone. hotplug fires many device
+        // change events, and re-opening on every rescan would needlessly close and
+        // reopen the WinMM handle (dropping MIDI state and input). only (re)open when
+        // the device is missing or a previously destroyed tombstone
+        {
+            std::lock_guard<std::recursive_mutex> lock(this->devices_mutex);
+            bool already_open = false;
+            for (auto &device : this->devices) {
+                if (device.type == MIDI && device.name == midi_identifier) {
+                    already_open = true;
+                    break;
+                }
+            }
+            if (already_open) {
+                continue;
+            }
+        }
 
         // open device
         HMIDIIN midi_device_handle;
@@ -939,21 +977,11 @@ void rawinput::RawInputManager::devices_scan_midi() {
         midi_device_midi_info->pitch_bend = std::vector<int16_t>(16 * 6);
         midi_device_midi_info->pitch_bend_set = std::vector<bool>(16 * 6);
 
-        // build identifier for MIDI
-        // ;MIDI; format is now set in stone (in other parts of the code base and in the config xml file)
-        // so it should never be changed
-        std::ostringstream midi_identifier;
-        midi_identifier << ";" << "MIDI";
-        midi_identifier << ";" << midi_device_id;
-        midi_identifier << ";" << midi_device_caps.szPname;
-        midi_identifier << ";" << midi_device_caps.wMid;
-        midi_identifier << ";" << midi_device_caps.wPid;
-
         // build device
         Device midi_device {};
         midi_device.type = MIDI;
         midi_device.handle = midi_device_handle;
-        midi_device.name = midi_identifier.str();
+        midi_device.name = midi_identifier;
         midi_device.desc = to_string(midi_device_caps.szPname);
         midi_device.info = midi_device_info;
         midi_device.mutex = new std::mutex();
@@ -965,9 +993,11 @@ void rawinput::RawInputManager::devices_scan_midi() {
         std::lock_guard<std::recursive_mutex> lock(this->devices_mutex);
         midi_device.id = devices.size() + 1;
 
-        // check for duplicate handle
+        // reuse a previously destroyed tombstone with the same identifier, if any.
+        // (a live device with this identifier was already skipped above)
+        bool replaced = false;
         for (auto &device : this->devices) {
-            if (device.name == midi_identifier.str()) {
+            if (device.name == midi_identifier) {
 
                 // carry over ID
                 midi_device.id = device.id;
@@ -981,8 +1011,12 @@ void rawinput::RawInputManager::devices_scan_midi() {
                     cb.f(cb.data, &device);
                 }
 
-                return;
+                replaced = true;
+                break;
             }
+        }
+        if (replaced) {
+            continue;
         }
 
         // add device to list
@@ -991,6 +1025,29 @@ void rawinput::RawInputManager::devices_scan_midi() {
         // notify add
         for (auto &cb : this->callback_add) {
             cb.f(cb.data, &device);
+        }
+    }
+
+    // tombstone MIDI devices that were open but are no longer present (unplugged).
+    // without this, a replugged device matches the stale live entry in the skip
+    // check above and never gets reopened, so its input is silently lost
+    {
+        std::lock_guard<std::recursive_mutex> lock(this->devices_mutex);
+        for (auto &device : this->devices) {
+            if (device.type != MIDI) {
+                continue;
+            }
+            bool present = false;
+            for (const auto &identifier : present_identifiers) {
+                if (identifier == device.name) {
+                    present = true;
+                    break;
+                }
+            }
+            if (!present) {
+                log_info("rawinput", "MIDI device unplugged, releasing: {}", device.desc);
+                this->devices_destruct(&device);
+            }
         }
     }
 
@@ -1233,10 +1290,21 @@ void rawinput::RawInputManager::output_start() {
                 // iterate all devices
                 do {
                     output_thread_ready = false;
-                    for (auto &device : this->devices) {
 
-                        // write output
-                        device_write_output(&device, true);
+                    // snapshot device pointers under devices_mutex so a concurrent scan
+                    // can't mutate the list mid-iteration. the std::list keeps addresses
+                    // stable, so the (potentially blocking) writes below run without
+                    // holding devices_mutex
+                    std::vector<Device *> snapshot;
+                    {
+                        std::lock_guard<std::recursive_mutex> devices_lock(this->devices_mutex);
+                        snapshot.reserve(this->devices.size());
+                        for (auto &device : this->devices) {
+                            snapshot.push_back(&device);
+                        }
+                    }
+                    for (auto *device : snapshot) {
+                        device_write_output(device, true);
                     }
                 } while (output_thread_ready);
             }
@@ -2767,10 +2835,20 @@ void rawinput::RawInputManager::devices_flush_output(bool optimized) {
     }
 
     // blocking routine
-    for (auto &device : this->devices) {
-
-        // write output
-        device_write_output(&device, false);
+    // snapshot device pointers under the lock so a concurrent scan can't mutate the
+    // list while we iterate. the std::list keeps element addresses stable, so the
+    // pointers remain valid after the lock is released and the (potentially blocking)
+    // output writes below do not run under devices_mutex
+    std::vector<Device *> snapshot;
+    {
+        std::lock_guard<std::recursive_mutex> lock(this->devices_mutex);
+        snapshot.reserve(this->devices.size());
+        for (auto &device : this->devices) {
+            snapshot.push_back(&device);
+        }
+    }
+    for (auto *device : snapshot) {
+        device_write_output(device, false);
     }
 }
 
@@ -2782,6 +2860,9 @@ void rawinput::RawInputManager::devices_print() {
     }
 
     bool touchscreen_found = false;
+
+    // lock the device list while iterating
+    std::lock_guard<std::recursive_mutex> lock(this->devices_mutex);
 
     // iterate devices
     log_info("rawinput", "printing list of detected devices");
@@ -2975,6 +3056,10 @@ rawinput::Device *rawinput::RawInputManager::devices_get(const std::string &name
     if (name.empty()) {
         return nullptr;
     }
+
+    // lock the device list so a concurrent scan can't mutate it while we search.
+    // the returned pointer stays valid after unlock because devices is a std::list
+    std::lock_guard<std::recursive_mutex> lock(this->devices_mutex);
 
     // check if caller wants only updated devices
     if (updated) {

--- a/src/spice2x/rawinput/rawinput.cpp
+++ b/src/spice2x/rawinput/rawinput.cpp
@@ -218,21 +218,26 @@ void rawinput::RawInputManager::devices_reload() {
 
 void rawinput::RawInputManager::midi_scan_start() {
 
-    // single-flight: if a scan is already running, skip. the Windows MIDI
-    // enumeration can take several seconds and repeated hotplug events would
-    // otherwise queue up redundant scans on the input thread
+    // single-flight: only one scan runs at a time. if one is already running, set
+    // the pending flag so it rescans once more when it finishes - MIDI hotplug
+    // events fire while the slow enumeration is still going and must not be lost
     bool expected = false;
     if (!this->midi_scan_active.compare_exchange_strong(expected, true)) {
+        this->midi_scan_pending.store(true);
         return;
     }
 
     // clean up the previous (already finished) scan thread handle
     this->midi_scan_join();
 
-    // run the (potentially slow) MIDI enumeration on its own thread so callers
-    // are not blocked while the Windows MIDI subsystem starts up
+    // run the (potentially slow) MIDI enumeration on its own thread so callers are
+    // not blocked while the Windows MIDI subsystem starts up. rescan if a request
+    // arrived while we were scanning
     this->midi_thread = new std::thread([this]() {
-        this->devices_scan_midi();
+        do {
+            this->midi_scan_pending.store(false);
+            this->devices_scan_midi();
+        } while (this->midi_scan_pending.exchange(false));
         this->midi_scan_active.store(false);
     });
 }
@@ -244,6 +249,23 @@ void rawinput::RawInputManager::midi_scan_join() {
         }
         delete this->midi_thread;
         this->midi_thread = nullptr;
+    }
+}
+
+void rawinput::RawInputManager::midi_close_deferred_flush() {
+
+    // take the queued handles under the lock, then close them without it. WinMM
+    // midiInReset/midiInClose block until in-flight input_midi_proc callbacks
+    // return, and those callbacks take devices_mutex, so closing under the lock
+    // would deadlock
+    std::vector<HMIDIIN> handles;
+    {
+        std::lock_guard<std::recursive_mutex> lock(this->devices_mutex);
+        handles.swap(this->midi_close_deferred);
+    }
+    for (auto handle : handles) {
+        midiInReset(handle);
+        midiInClose(handle);
     }
 }
 
@@ -942,6 +964,9 @@ void rawinput::RawInputManager::devices_scan_midi() {
 
         // start input
         if (midiInStart(midi_device_handle) != MMSYSERR_NOERROR) {
+
+            // close the handle we just opened so it does not leak on repeated rescans
+            midiInClose(midi_device_handle);
             continue;
         }
 
@@ -1048,6 +1073,9 @@ void rawinput::RawInputManager::devices_scan_midi() {
             }
         }
     }
+
+    // close the MIDI handles detached above, now that devices_mutex is released
+    this->midi_close_deferred_flush();
 
     log_misc("rawinput", "scan MIDI devices done ({} enumerated)", (unsigned) midi_device_count);
 }
@@ -1288,21 +1316,7 @@ void rawinput::RawInputManager::output_start() {
                 // iterate all devices
                 do {
                     output_thread_ready = false;
-
-                    // snapshot device pointers under devices_mutex, then write without
-                    // it. the std::list keeps addresses stable, so the (potentially
-                    // blocking) writes below don't hold devices_mutex against input
-                    std::vector<Device *> snapshot;
-                    {
-                        std::lock_guard<std::recursive_mutex> devices_lock(this->devices_mutex);
-                        snapshot.reserve(this->devices.size());
-                        for (auto &device : this->devices) {
-                            snapshot.push_back(&device);
-                        }
-                    }
-                    for (auto *device : snapshot) {
-                        device_write_output(device, true);
-                    }
+                    this->devices_write_output_snapshot(true);
                 } while (output_thread_ready);
             }
         });
@@ -1639,22 +1653,24 @@ void rawinput::RawInputManager::devices_unregister() {
 }
 
 void rawinput::RawInputManager::devices_destruct() {
-    std::lock_guard<std::recursive_mutex> lock(this->devices_mutex);
+    {
+        std::lock_guard<std::recursive_mutex> lock(this->devices_mutex);
 
-    // check if there's something to destruct
-    if (this->devices.empty()) {
-        return;
+        // dispose devices (if there is anything to dispose)
+        if (!this->devices.empty()) {
+            log_info("rawinput", "disposing devices");
+            for (auto &device : this->devices) {
+                this->devices_destruct(&device, false);
+                delete device.mutex;
+            }
+
+            // empty array
+            this->devices.clear();
+        }
     }
 
-    // dispose devices
-    log_info("rawinput", "disposing devices");
-    for (auto &device : this->devices) {
-        this->devices_destruct(&device, false);
-        delete device.mutex;
-    }
-
-    // empty array
-    this->devices.clear();
+    // close any MIDI handles detached above, now that devices_mutex is released
+    this->midi_close_deferred_flush();
 }
 
 void rawinput::RawInputManager::devices_destruct(Device *device, bool log) {
@@ -1668,6 +1684,12 @@ void rawinput::RawInputManager::devices_destruct(Device *device, bool log) {
     if (log) {
         log_info("rawinput", "destroying device: {} / {}", device->desc, device->name);
     }
+
+    // hold the output mutex for the whole teardown, taken before we flip the type
+    // or free anything. device_write_output() locks mutex_out while dereferencing
+    // type-specific state (hidInfo/sextetInfo/...) on a snapshot taken outside
+    // devices_mutex, so mutex_out is what actually serializes it against us
+    std::lock_guard<std::mutex> lock_out(*device->mutex_out);
 
     // mark as destroyed
     auto device_type = device->type;
@@ -1695,8 +1717,14 @@ void rawinput::RawInputManager::devices_destruct(Device *device, bool log) {
             }
             break;
         case MIDI:
-            midiInReset((HMIDIIN) device->handle);
-            midiInClose((HMIDIIN) device->handle);
+            // never call midiInReset/midiInClose here: this runs under devices_mutex
+            // and those WinMM calls block until in-flight input_midi_proc callbacks
+            // return, callbacks that also take devices_mutex. detach the handle and
+            // let midi_close_deferred_flush() close it once the lock is released
+            if (device->handle != (HANDLE) INVALID_HANDLE_VALUE) {
+                this->midi_close_deferred.push_back((HMIDIIN) device->handle);
+                device->handle = (HANDLE) INVALID_HANDLE_VALUE;
+            }
             break;
         case SEXTET_OUTPUT:
             device->sextetInfo->disconnect();
@@ -2832,9 +2860,14 @@ void rawinput::RawInputManager::devices_flush_output(bool optimized) {
     }
 
     // blocking routine
-    // snapshot device pointers under the lock, then write without it. the std::list
-    // keeps addresses stable, so the (potentially blocking) writes below don't hold
-    // devices_mutex against input
+    this->devices_write_output_snapshot(false);
+}
+
+void rawinput::RawInputManager::devices_write_output_snapshot(bool only_updated) {
+
+    // snapshot device pointers under devices_mutex, then write without holding it.
+    // the std::list keeps addresses stable, so the (potentially blocking) writes
+    // below don't hold devices_mutex against input
     std::vector<Device *> snapshot;
     {
         std::lock_guard<std::recursive_mutex> lock(this->devices_mutex);
@@ -2844,7 +2877,7 @@ void rawinput::RawInputManager::devices_flush_output(bool optimized) {
         }
     }
     for (auto *device : snapshot) {
-        device_write_output(device, false);
+        device_write_output(device, only_updated);
     }
 }
 

--- a/src/spice2x/rawinput/rawinput.h
+++ b/src/spice2x/rawinput/rawinput.h
@@ -2,7 +2,6 @@
 
 #include <functional>
 #include <thread>
-#include <atomic>
 #include <condition_variable>
 #include <list>
 #include <mutex>
@@ -78,12 +77,20 @@ namespace rawinput {
         WNDCLASSEX input_hwnd_class {};
         std::thread *input_thread = nullptr;
         std::thread *midi_thread = nullptr;
-        std::atomic<bool> midi_scan_active { false };
+
+        // guards the MIDI scan scheduler flags below. only held around the flag
+        // checks, never across the (slow) enumeration, so it makes "is a scan
+        // running?" and the worker's "exit or rescan?" a single atomic decision -
+        // a request can never slip into the gap between the two
+        std::mutex midi_scan_m;
+
+        // true while a scan worker thread is running. only one runs at a time
+        bool midi_scan_active = false;
 
         // set when a scan is requested while one is already running, so the worker
         // rescans once instead of dropping the request (events that arrive during
         // the slow initial scan would otherwise be lost)
-        std::atomic<bool> midi_scan_pending { false };
+        bool midi_scan_pending = false;
 
         // MIDI handles pending close. devices_destruct() runs under devices_mutex but
         // midiInReset/midiInClose must not (they block on the MIDI callback, which

--- a/src/spice2x/rawinput/rawinput.h
+++ b/src/spice2x/rawinput/rawinput.h
@@ -66,15 +66,12 @@ namespace rawinput {
     class RawInputManager {
     private:
 
-        // must be null until constructed: input_hwnd_create() starts the message
-        // pump before the constructor assigns this, and a WM_DEVICECHANGE arriving
-        // in that window would otherwise deref an uninitialized pointer
         HotplugManager *hotplug = nullptr;
 
-        // note: std::list (not std::vector) so that adding/removing a device never
-        // invalidates pointers/references to the other elements. device pointers handed
-        // out by devices_get() escape the lock and are dereferenced later by pollers, so
-        // a concurrent scan mutating the list must not relocate the existing devices
+        // std::list (not std::vector) so adding/removing a device never invalidates
+        // pointers to other elements. devices_get() hands out pointers that escape the
+        // lock and are dereferenced later by pollers, so a concurrent scan must not
+        // relocate existing devices
         std::list<Device> devices;
         std::recursive_mutex devices_mutex;
 

--- a/src/spice2x/rawinput/rawinput.h
+++ b/src/spice2x/rawinput/rawinput.h
@@ -2,7 +2,9 @@
 
 #include <functional>
 #include <thread>
+#include <atomic>
 #include <condition_variable>
+#include <mutex>
 #include <vector>
 
 #include <windows.h>
@@ -63,10 +65,18 @@ namespace rawinput {
     class RawInputManager {
     private:
 
-        HotplugManager *hotplug;
+        // must be null until constructed: input_hwnd_create() starts the message
+        // pump before the constructor assigns this, and a WM_DEVICECHANGE arriving
+        // in that window would otherwise deref an uninitialized pointer
+        HotplugManager *hotplug = nullptr;
+
         std::vector<Device> devices;
+        std::recursive_mutex devices_mutex;
+
         WNDCLASSEX input_hwnd_class {};
         std::thread *input_thread = nullptr;
+        std::thread *midi_thread = nullptr;
+        std::atomic<bool> midi_scan_active { false };
         std::thread *flush_thread = nullptr;
         bool flush_thread_running = false;
         std::mutex flush_thread_m;
@@ -83,6 +93,7 @@ namespace rawinput {
         void input_hwnd_create();
         void input_hwnd_destroy();
         void devices_reload();
+        void midi_scan_join();
         void devices_scan_rawinput(RAWINPUTDEVICELIST *device, bool log = true);
         void devices_scan_piuio();
         void devices_scan_smxstage();
@@ -118,6 +129,7 @@ namespace rawinput {
 
         void devices_scan_rawinput(const std::string &device_name = "");
         void devices_scan_midi();
+        void midi_scan_start();
         void devices_scan_xinput();
         void devices_remove(const std::string &name);
 

--- a/src/spice2x/rawinput/rawinput.h
+++ b/src/spice2x/rawinput/rawinput.h
@@ -79,6 +79,17 @@ namespace rawinput {
         std::thread *input_thread = nullptr;
         std::thread *midi_thread = nullptr;
         std::atomic<bool> midi_scan_active { false };
+
+        // set when a scan is requested while one is already running, so the worker
+        // rescans once instead of dropping the request (events that arrive during
+        // the slow initial scan would otherwise be lost)
+        std::atomic<bool> midi_scan_pending { false };
+
+        // MIDI handles pending close. devices_destruct() runs under devices_mutex but
+        // midiInReset/midiInClose must not (they block on the MIDI callback, which
+        // also takes devices_mutex), so handles are queued here and closed by
+        // midi_close_deferred_flush() once the lock is released
+        std::vector<HMIDIIN> midi_close_deferred;
         std::thread *flush_thread = nullptr;
         bool flush_thread_running = false;
         std::mutex flush_thread_m;
@@ -96,6 +107,7 @@ namespace rawinput {
         void input_hwnd_destroy();
         void devices_reload();
         void midi_scan_join();
+        void midi_close_deferred_flush();
         void devices_scan_rawinput(RAWINPUTDEVICELIST *device, bool log = true);
         void devices_scan_piuio();
         void devices_scan_smxstage();
@@ -106,6 +118,7 @@ namespace rawinput {
         void flush_stop();
         void output_start();
         void output_stop();
+        void devices_write_output_snapshot(bool only_updated);
 
         static std::string rawinput_get_device_name(HANDLE hDevice);
         static std::string rawinput_get_device_description(const DeviceInfo& info, const std::string &device_name);

--- a/src/spice2x/rawinput/rawinput.h
+++ b/src/spice2x/rawinput/rawinput.h
@@ -4,6 +4,7 @@
 #include <thread>
 #include <atomic>
 #include <condition_variable>
+#include <list>
 #include <mutex>
 #include <vector>
 
@@ -70,7 +71,11 @@ namespace rawinput {
         // in that window would otherwise deref an uninitialized pointer
         HotplugManager *hotplug = nullptr;
 
-        std::vector<Device> devices;
+        // note: std::list (not std::vector) so that adding/removing a device never
+        // invalidates pointers/references to the other elements. device pointers handed
+        // out by devices_get() escape the lock and are dereferenced later by pollers, so
+        // a concurrent scan mutating the list must not relocate the existing devices
+        std::list<Device> devices;
         std::recursive_mutex devices_mutex;
 
         WNDCLASSEX input_hwnd_class {};
@@ -142,11 +147,12 @@ namespace rawinput {
         void __stdcall devices_print();
         Device *devices_get(const std::string &name, bool updated = false);
 
-        inline std::vector<Device> &devices_get() {
+        inline std::list<Device> &devices_get() {
             return devices;
         }
 
         inline std::vector<Device *> devices_get_updated() {
+            std::lock_guard<std::recursive_mutex> lock(devices_mutex);
             std::vector<Device *> updated;
             for (auto &device : devices_get()) {
                 device.mutex->lock();
@@ -162,6 +168,7 @@ namespace rawinput {
         }
 
         inline void devices_midi_freeze(bool freeze) {
+            std::lock_guard<std::recursive_mutex> lock(devices_mutex);
             for (auto &device : devices_get()) {
                 if (device.type == MIDI) {
                     device.midiInfo->freeze = freeze;


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
Fixes #603

## Description of change
Scanning for midi devices can take a while on Windows 11 with MIDI 2.0 service. Sometimes it'll take a couple seconds. Sometimes, on a PC with zero MIDI devices, it takes 10-11 seconds.

This was causing two issues:

1. slow startup time
2. crash on invalid memory access due to a race condition

Address both.

Also fix a bug: when a device change event fires, we do a MIDI scan, and invalidated all existing MIDI devices in favor of creating new handles. Stop doing this, and instead check for duplicates by matching the ID and keep existing device handles alone. Properly clean up devices on unplug.

Also: fix MIDI buttons being stuck on when unplugged while holding a key.

## Testing
Tested with Nostroller in MIDI mode. rtpMIDI works too.
