### PR TITLE
overlay: re-enable keyboard navigation

### DIFF
--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -1115,6 +1115,9 @@ int main_implementation(int argc, char *argv[]) {
     if (options[launcher::Options::DisableOverlay].value_bool()) {
         overlay::ENABLED = false;
     }
+    if (options[launcher::Options::OverlayKeyboardNavigation].value_bool()) {
+        overlay::ENABLE_KEYBOARD_NAVIGATION = true;
+    }
     if (options[launcher::Options::OverlayScaling].is_active() && !cfg::CONFIGURATOR_STANDALONE && !cfg_run) {
         const auto val = options[launcher::Options::OverlayScaling].value_uint32();
         if (10 <= val && val <= 400 && val != 100) {

--- a/src/spice2x/launcher/options.cpp
+++ b/src/spice2x/launcher/options.cpp
@@ -511,6 +511,13 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .category = "General Overlay",
     },
     {
+        .title = "Overlay Keyboard Navigation",
+        .name = "keyboardnav",
+        .desc = "Enables keyboard navigation in the in-game overlay.",
+        .type = OptionType::Bool,
+        .category = "General Overlay",
+    },
+    {
         // OverlayScaling
         .title = "Spice Overlay UI Scale %",
         .name = "overlayscale",

--- a/src/spice2x/launcher/options.h
+++ b/src/spice2x/launcher/options.h
@@ -53,6 +53,7 @@ namespace launcher {
             SOFTID,
             VREnable,
             DisableOverlay,
+            OverlayKeyboardNavigation,
             OverlayScaling,
             NotificationPosition,
             spice2x_FpsAutoShow,

--- a/src/spice2x/overlay/overlay.cpp
+++ b/src/spice2x/overlay/overlay.cpp
@@ -67,6 +67,7 @@ namespace overlay {
     bool AUTO_SHOW_IOPANEL = false;
     bool AUTO_SHOW_KEYPAD_P1 = false;
     bool AUTO_SHOW_KEYPAD_P2 = false;
+    bool ENABLE_KEYBOARD_NAVIGATION = false;
     bool USE_WM_CHAR_FOR_IMGUI_CHAR_INPUT = false;
     FpsLocation FPS_LOCATION = FpsLocation::TopRight;
     std::optional<uint32_t> UI_SCALE_PERCENT;
@@ -312,6 +313,9 @@ void overlay::SpiceOverlay::init() {
     auto &io = ImGui::GetIO();
     io.UserData = this;
     io.ConfigFlags = ImGuiConfigFlags_None;
+    if (cfg::CONFIGURATOR_STANDALONE || ENABLE_KEYBOARD_NAVIGATION) {
+        io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
+    }
     if (!cfg::CONFIGURATOR_STANDALONE) {
         io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
     }

--- a/src/spice2x/overlay/overlay.h
+++ b/src/spice2x/overlay/overlay.h
@@ -44,6 +44,7 @@ namespace overlay {
     extern bool AUTO_SHOW_IOPANEL;
     extern bool AUTO_SHOW_KEYPAD_P1;
     extern bool AUTO_SHOW_KEYPAD_P2;
+    extern bool ENABLE_KEYBOARD_NAVIGATION;
     extern bool USE_WM_CHAR_FOR_IMGUI_CHAR_INPUT;
     extern FpsLocation FPS_LOCATION;
     extern bool SHOW_DEBUG_LOG_WINDOW;


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
Fixes #800 

## Description of change
Restores keyboard navigation by default in spicecfg, and add an option to optionally enable it in the overlay.

## Testing
