### PR TITLE
jb, shogikai: double buffer overlay, run at ~60fps

### DIFF
--- a/src/spice2x/CMakeLists.txt
+++ b/src/spice2x/CMakeLists.txt
@@ -647,6 +647,7 @@ set(SOURCE_FILES ${SOURCE_FILES}
         stubs/stubs.cpp
 
         # touch
+        touch/gdi_overlay.cpp
         touch/touch.cpp
         touch/touch_gestures.cpp
         touch/win7.cpp

--- a/src/spice2x/touch/gdi_overlay.cpp
+++ b/src/spice2x/touch/gdi_overlay.cpp
@@ -120,6 +120,7 @@ namespace {
             SelectObject(OVERLAY_BUFFER.dc, OVERLAY_BUFFER.old_bitmap);
         if (overlay_bitmap == nullptr || overlay_bitmap == HGDI_ERROR) {
             log_warning("touch", "failed to deselect software overlay bitmap: {}", GetLastError());
+            release_buffer(OVERLAY_BUFFER);
             return false;
         }
 
@@ -151,6 +152,7 @@ namespace {
         if (copied_lines != height) {
             log_warning("touch", "failed to update software overlay bitmap: {} of {} lines copied",
                         copied_lines, height);
+            release_buffer(OVERLAY_BUFFER);
             return false;
         }
         return true;

--- a/src/spice2x/touch/gdi_overlay.cpp
+++ b/src/spice2x/touch/gdi_overlay.cpp
@@ -1,0 +1,169 @@
+#include "gdi_overlay.h"
+
+#include <cstddef>
+
+#include "util/logging.h"
+
+namespace {
+
+    // the back buffer matches the window DC; the software buffer has a fixed 32-bit layout
+    enum class BufferType {
+        TargetCompatible,
+        Bgra32,
+    };
+
+    struct GdiBuffer {
+        HDC dc = nullptr;
+        HBITMAP bitmap = nullptr;
+        // bitmap originally selected into the memory DC, restored before cleanup
+        HGDIOBJ old_bitmap = nullptr;
+        int width = 0;
+        int height = 0;
+    };
+
+    // back buffer holds the complete frame; overlay buffer holds ImGui software pixels
+    GdiBuffer BACK_BUFFER;
+    GdiBuffer OVERLAY_BUFFER;
+
+    void release_buffer(GdiBuffer &buffer) {
+        // destroy the DC before the bitmap so cleanup is safe even if restoration fails
+        if (buffer.dc != nullptr) {
+            if (buffer.old_bitmap != nullptr && buffer.old_bitmap != HGDI_ERROR) {
+                SelectObject(buffer.dc, buffer.old_bitmap);
+            }
+            DeleteDC(buffer.dc);
+        }
+        if (buffer.bitmap != nullptr) {
+            DeleteObject(buffer.bitmap);
+        }
+
+        buffer = {};
+    }
+
+    // ensures the buffer has a memory DC with a bitmap of the requested size and type
+    // selected into it. a matching allocation is reused; otherwise the old resources are
+    // released and recreated. returns false if the dimensions or any GDI operation fail.
+    bool ensure_buffer(
+            GdiBuffer &buffer,
+            HDC target_dc,
+            int width,
+            int height,
+            BufferType type,
+            const char *name) {
+        if (width <= 0 || height <= 0) {
+            return false;
+        }
+        if (buffer.dc != nullptr && buffer.bitmap != nullptr &&
+            buffer.width == width && buffer.height == height) {
+            return true;
+        }
+
+        // keep allocations across frames and recreate only after a size change
+        release_buffer(buffer);
+        buffer.dc = CreateCompatibleDC(target_dc);
+        if (buffer.dc == nullptr) {
+            log_warning("touch", "failed to create {} DC: {}", name, GetLastError());
+            return false;
+        }
+
+        // compatible bitmaps are fast presentation targets; BGRA bitmaps accept raw pixels
+        if (type == BufferType::TargetCompatible) {
+            buffer.bitmap = CreateCompatibleBitmap(target_dc, width, height);
+        } else {
+            buffer.bitmap = CreateBitmap(width, height, 1, sizeof(uint32_t) * 8, nullptr);
+        }
+        if (buffer.bitmap == nullptr) {
+            log_warning("touch", "failed to create {} bitmap: {}", name, GetLastError());
+            release_buffer(buffer);
+            return false;
+        }
+
+        buffer.old_bitmap = SelectObject(buffer.dc, buffer.bitmap);
+        if (buffer.old_bitmap == nullptr || buffer.old_bitmap == HGDI_ERROR) {
+            log_warning("touch", "failed to select {} bitmap: {}", name, GetLastError());
+            release_buffer(buffer);
+            return false;
+        }
+
+        buffer.width = width;
+        buffer.height = height;
+        return true;
+    }
+
+    bool update_overlay_buffer(
+            HDC target_dc,
+            const uint32_t *pixels,
+            int width,
+            int height) {
+        if (pixels == nullptr ||
+            !ensure_buffer(
+                OVERLAY_BUFFER,
+                target_dc,
+                width,
+                height,
+                BufferType::Bgra32,
+                "software overlay")) {
+            return false;
+        }
+
+        // update the cached bitmap contents without reallocating the bitmap or its DC
+        LONG bitmap_size = static_cast<LONG>(
+            static_cast<size_t>(width) * static_cast<size_t>(height) * sizeof(uint32_t));
+        if (SetBitmapBits(OVERLAY_BUFFER.bitmap, bitmap_size, pixels) != bitmap_size) {
+            log_warning("touch", "failed to update software overlay bitmap: {}", GetLastError());
+            return false;
+        }
+        return true;
+    }
+}
+
+HDC touch_gdi_overlay_begin_frame(
+        HDC target_dc,
+        HBRUSH background_brush,
+        int width,
+        int height,
+        const uint32_t *overlay_pixels,
+        int overlay_width,
+        int overlay_height) {
+    if (!ensure_buffer(
+            BACK_BUFFER,
+            target_dc,
+            width,
+            height,
+            BufferType::TargetCompatible,
+            "overlay back buffer")) {
+        return nullptr;
+    }
+
+    HDC draw_dc = BACK_BUFFER.dc;
+    SetBkMode(draw_dc, TRANSPARENT);
+
+    // start each frame from the transparent color-key background
+    RECT buffer_rect {0, 0, width, height};
+    FillRect(draw_dc, &buffer_rect, background_brush);
+
+    if (update_overlay_buffer(
+            target_dc,
+            overlay_pixels,
+            overlay_width,
+            overlay_height) &&
+        !BitBlt(draw_dc, 0, 0, overlay_width, overlay_height,
+                OVERLAY_BUFFER.dc, 0, 0, SRCCOPY)) {
+        log_warning("touch", "failed to draw software overlay bitmap: {}", GetLastError());
+    }
+
+    return draw_dc;
+}
+
+void touch_gdi_overlay_present(HDC target_dc) {
+    // one full-window blit exposes the completed frame without an intermediate erase
+    if (!BitBlt(target_dc, 0, 0, BACK_BUFFER.width, BACK_BUFFER.height,
+                BACK_BUFFER.dc, 0, 0, SRCCOPY)) {
+        log_warning("touch", "failed to present overlay back buffer: {}", GetLastError());
+    }
+}
+
+void touch_gdi_overlay_release() {
+    release_buffer(BACK_BUFFER);
+    release_buffer(OVERLAY_BUFFER);
+}

--- a/src/spice2x/touch/gdi_overlay.cpp
+++ b/src/spice2x/touch/gdi_overlay.cpp
@@ -93,10 +93,16 @@ namespace {
     bool update_overlay_buffer(
             HDC target_dc,
             const uint32_t *pixels,
+            bool pixels_dirty,
             int width,
             int height) {
-        if (pixels == nullptr ||
-            !ensure_buffer(
+        if (pixels == nullptr) {
+            return false;
+        }
+
+        bool needs_update = pixels_dirty || OVERLAY_BUFFER.bitmap == nullptr ||
+            OVERLAY_BUFFER.width != width || OVERLAY_BUFFER.height != height;
+        if (!ensure_buffer(
                 OVERLAY_BUFFER,
                 target_dc,
                 width,
@@ -105,12 +111,46 @@ namespace {
                 "software overlay")) {
             return false;
         }
+        if (!needs_update) {
+            return true;
+        }
 
-        // update the cached bitmap contents without reallocating the bitmap or its DC
-        LONG bitmap_size = static_cast<LONG>(
-            static_cast<size_t>(width) * static_cast<size_t>(height) * sizeof(uint32_t));
-        if (SetBitmapBits(OVERLAY_BUFFER.bitmap, bitmap_size, pixels) != bitmap_size) {
-            log_warning("touch", "failed to update software overlay bitmap: {}", GetLastError());
+        // SetDIBits requires the destination bitmap not to be selected into a DC
+        HGDIOBJ overlay_bitmap =
+            SelectObject(OVERLAY_BUFFER.dc, OVERLAY_BUFFER.old_bitmap);
+        if (overlay_bitmap == nullptr || overlay_bitmap == HGDI_ERROR) {
+            log_warning("touch", "failed to deselect software overlay bitmap: {}", GetLastError());
+            return false;
+        }
+
+        BITMAPINFO bitmap_info {};
+        bitmap_info.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+        bitmap_info.bmiHeader.biWidth = width;
+        bitmap_info.bmiHeader.biHeight = -height;
+        bitmap_info.bmiHeader.biPlanes = 1;
+        bitmap_info.bmiHeader.biBitCount = sizeof(uint32_t) * 8;
+        bitmap_info.bmiHeader.biCompression = BI_RGB;
+
+        int copied_lines = SetDIBits(
+            target_dc,
+            OVERLAY_BUFFER.bitmap,
+            0,
+            height,
+            pixels,
+            &bitmap_info,
+            DIB_RGB_COLORS);
+
+        HGDIOBJ old_bitmap = SelectObject(OVERLAY_BUFFER.dc, OVERLAY_BUFFER.bitmap);
+        if (old_bitmap == nullptr || old_bitmap == HGDI_ERROR) {
+            log_warning("touch", "failed to reselect software overlay bitmap: {}", GetLastError());
+            release_buffer(OVERLAY_BUFFER);
+            return false;
+        }
+        OVERLAY_BUFFER.old_bitmap = old_bitmap;
+
+        if (copied_lines != height) {
+            log_warning("touch", "failed to update software overlay bitmap: {} of {} lines copied",
+                        copied_lines, height);
             return false;
         }
         return true;
@@ -123,6 +163,7 @@ HDC touch_gdi_overlay_begin_frame(
         int width,
         int height,
         const uint32_t *overlay_pixels,
+        bool overlay_pixels_dirty,
         int overlay_width,
         int overlay_height) {
     if (!ensure_buffer(
@@ -145,6 +186,7 @@ HDC touch_gdi_overlay_begin_frame(
     if (update_overlay_buffer(
             target_dc,
             overlay_pixels,
+            overlay_pixels_dirty,
             overlay_width,
             overlay_height) &&
         !BitBlt(draw_dc, 0, 0, overlay_width, overlay_height,

--- a/src/spice2x/touch/gdi_overlay.h
+++ b/src/spice2x/touch/gdi_overlay.h
@@ -10,6 +10,7 @@ HDC touch_gdi_overlay_begin_frame(
     int width,
     int height,
     const uint32_t *overlay_pixels,
+    bool overlay_pixels_dirty,
     int overlay_width,
     int overlay_height);
 

--- a/src/spice2x/touch/gdi_overlay.h
+++ b/src/spice2x/touch/gdi_overlay.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <cstdint>
+#include <windows.h>
+
+// prepares a complete offscreen frame and returns its drawing DC; returns null on failure
+HDC touch_gdi_overlay_begin_frame(
+    HDC target_dc,
+    HBRUSH background_brush,
+    int width,
+    int height,
+    const uint32_t *overlay_pixels,
+    int overlay_width,
+    int overlay_height);
+
+// presents the frame prepared by the most recent successful begin call
+void touch_gdi_overlay_present(HDC target_dc);
+
+// releases all cached GDI resources
+void touch_gdi_overlay_release();

--- a/src/spice2x/touch/touch.cpp
+++ b/src/spice2x/touch/touch.cpp
@@ -23,6 +23,7 @@
 #include "util/time.h"
 #include "util/utils.h"
 
+#include "gdi_overlay.h"
 #include "handler.h"
 #include "touch_gestures.h"
 #include "win7.h"
@@ -354,20 +355,17 @@ static LRESULT CALLBACK SpiceTouchWndProc(HWND hWnd, UINT msg, WPARAM wParam, LP
                             SWP_NOZORDER | SWP_NOREDRAW | SWP_NOREPOSITION | SWP_NOACTIVATE);
                 }
 
-                // render the software overlay to a bitmap BEFORE BeginPaint: the imgui
-                // render is expensive, and running it between the background erase and the
-                // blit leaves the window transparent long enough to flicker
-                HBITMAP overlay_bitmap = nullptr;
+                // render the software overlay before BeginPaint so only GDI composition
+                // and the final blit happen while the window is being painted
                 int overlay_width = 0, overlay_height = 0;
+                uint32_t *overlay_pixels = nullptr;
                 if (overlay_enabled) {
                     overlay::OVERLAY->update();
                     overlay::OVERLAY->new_frame();
                     overlay::OVERLAY->render();
 
-                    uint32_t *pixel_data = overlay::OVERLAY.get()->sw_get_pixel_data(&overlay_width, &overlay_height);
-                    if (overlay_width > 0 && overlay_height > 0) {
-                        overlay_bitmap = CreateBitmap(overlay_width, overlay_height, 1, 8 * sizeof(uint32_t), pixel_data);
-                    }
+                    overlay_pixels = overlay::OVERLAY.get()->sw_get_pixel_data(
+                        &overlay_width, &overlay_height);
                 }
                 bool overlay_active = overlay_enabled && overlay::OVERLAY->get_active();
 
@@ -382,31 +380,19 @@ static LRESULT CALLBACK SpiceTouchWndProc(HWND hWnd, UINT msg, WPARAM wParam, LP
                 int buffer_width = bufferRect.right - bufferRect.left;
                 int buffer_height = bufferRect.bottom - bufferRect.top;
 
-                HDC back_dc = CreateCompatibleDC(hdc);
-                HBITMAP back_bitmap = CreateCompatibleBitmap(hdc, buffer_width, buffer_height);
-                HGDIOBJ back_old = SelectObject(back_dc, back_bitmap);
-                SetBkMode(back_dc, TRANSPARENT);
-
-                // clear the buffer to the color key so unpainted areas stay transparent
-                HBRUSH colorKeyBrush = CreateSolidBrush(RGB(255, 192, 203));
-                FillRect(back_dc, &bufferRect, colorKeyBrush);
-                DeleteObject(colorKeyBrush);
-
-                // blit the overlay bitmap
-                if (overlay_bitmap) {
-
-                    /*
-                     * draw bitmap
-                     * - this currently sets the background to black because of SRCCOPY
-                     * - SRCPAINT will blend but colors are wrong
-                     * - once this is figured out we could also try hooking WM_PAINT and
-                     *   draw directly to the game window
-                     */
-                    HDC hdcMem = CreateCompatibleDC(back_dc);
-                    SelectObject(hdcMem, overlay_bitmap);
-                    BitBlt(back_dc, 0, 0, overlay_width, overlay_height, hdcMem, 0, 0, SRCCOPY);
-                    DeleteDC(hdcMem);
-                    DeleteObject(overlay_bitmap);
+                HBRUSH color_key_brush =
+                    (HBRUSH) GetClassLongPtr(hWnd, GCLP_HBRBACKGROUND);
+                HDC draw_dc = touch_gdi_overlay_begin_frame(
+                    hdc,
+                    color_key_brush,
+                    buffer_width,
+                    buffer_height,
+                    overlay_pixels,
+                    overlay_width,
+                    overlay_height);
+                if (draw_dc == nullptr) {
+                    EndPaint(hWnd, &paint);
+                    return 0;
                 }
 
                 // draw the insert-card button below the jubeat debug overlay; it is
@@ -441,7 +427,7 @@ static LRESULT CALLBACK SpiceTouchWndProc(HWND hWnd, UINT msg, WPARAM wParam, LP
                     SPICETOUCH_CARD_RECT = boxRect;
 
                     // draw borders
-                    FillRect(back_dc, &boxRect, brushBorder);
+                    FillRect(draw_dc, &boxRect, brushBorder);
 
                     // modify box rect
                     boxRect.left += 1;
@@ -450,7 +436,7 @@ static LRESULT CALLBACK SpiceTouchWndProc(HWND hWnd, UINT msg, WPARAM wParam, LP
                     boxRect.bottom -= 1;
 
                     // fill box
-                    FillRect(back_dc, &boxRect, brushFill);
+                    FillRect(draw_dc, &boxRect, brushFill);
 
                     // modify box rect
                     if (should_rotate) {
@@ -462,9 +448,9 @@ static LRESULT CALLBACK SpiceTouchWndProc(HWND hWnd, UINT msg, WPARAM wParam, LP
                     }
 
                     // draw text
-                    SelectObject(back_dc, SPICETOUCH_FONT);
-                    SetTextColor(back_dc, RGB(0, 196, 0));
-                    DrawText(back_dc, INSERT_CARD_TEXT, -1, &boxRect, DT_LEFT | DT_BOTTOM | DT_NOCLIP);
+                    SelectObject(draw_dc, SPICETOUCH_FONT);
+                    SetTextColor(draw_dc, RGB(0, 196, 0));
+                    DrawText(draw_dc, INSERT_CARD_TEXT, -1, &boxRect, DT_LEFT | DT_BOTTOM | DT_NOCLIP);
 
                     // delete objects
                     DeleteObject(brushFill);
@@ -474,17 +460,12 @@ static LRESULT CALLBACK SpiceTouchWndProc(HWND hWnd, UINT msg, WPARAM wParam, LP
 #if !SPICE_XP
                 // draw the jubeat debug overlay on top (hidden while the overlay is active)
                 if (overlay_enabled && !overlay_active && games::jb::touch_debug_overlay_enabled()) {
-                    games::jb::touch_draw_debug_overlay(back_dc);
+                    games::jb::touch_draw_debug_overlay(draw_dc);
                 }
 #endif // !SPICE_XP
 
                 // present the composed frame in a single blit
-                BitBlt(hdc, 0, 0, buffer_width, buffer_height, back_dc, 0, 0, SRCCOPY);
-
-                // clean up the back buffer
-                SelectObject(back_dc, back_old);
-                DeleteObject(back_bitmap);
-                DeleteDC(back_dc);
+                touch_gdi_overlay_present(hdc);
 
                 EndPaint(hWnd, &paint);
                 return 0;
@@ -517,6 +498,11 @@ static LRESULT CALLBACK SpiceTouchWndProc(HWND hWnd, UINT msg, WPARAM wParam, LP
                 return 0;
             }
             case WM_DESTROY: {
+                touch_gdi_overlay_release();
+                if (SPICETOUCH_FONT != nullptr) {
+                    DeleteObject(SPICETOUCH_FONT);
+                    SPICETOUCH_FONT = nullptr;
+                }
                 PostQuitMessage(0);
                 return 0;
             }

--- a/src/spice2x/touch/touch.cpp
+++ b/src/spice2x/touch/touch.cpp
@@ -359,6 +359,7 @@ static LRESULT CALLBACK SpiceTouchWndProc(HWND hWnd, UINT msg, WPARAM wParam, LP
                 // and the final blit happen while the window is being painted
                 int overlay_width = 0, overlay_height = 0;
                 uint32_t *overlay_pixels = nullptr;
+                bool overlay_pixels_dirty = false;
                 if (overlay_enabled) {
                     overlay::OVERLAY->update();
                     overlay::OVERLAY->new_frame();
@@ -366,6 +367,7 @@ static LRESULT CALLBACK SpiceTouchWndProc(HWND hWnd, UINT msg, WPARAM wParam, LP
 
                     overlay_pixels = overlay::OVERLAY.get()->sw_get_pixel_data(
                         &overlay_width, &overlay_height);
+                    overlay_pixels_dirty = overlay::OVERLAY->sw_pixels_dirty;
                 }
                 bool overlay_active = overlay_enabled && overlay::OVERLAY->get_active();
 
@@ -388,6 +390,7 @@ static LRESULT CALLBACK SpiceTouchWndProc(HWND hWnd, UINT msg, WPARAM wParam, LP
                     buffer_width,
                     buffer_height,
                     overlay_pixels,
+                    overlay_pixels_dirty,
                     overlay_width,
                     overlay_height);
                 if (draw_dc == nullptr) {

--- a/src/spice2x/touch/touch.cpp
+++ b/src/spice2x/touch/touch.cpp
@@ -38,6 +38,16 @@ static const int TOUCH_EVENT_BUFFER_SIZE = 1024 * 4;
 static const int TOUCH_EVENT_BUFFER_THRESHOLD1 = 1024 * 2;
 static const int TOUCH_EVENT_BUFFER_THRESHOLD2 = 1024 * 3;
 
+// timer id for the overlay repaint tick
+static const UINT_PTR SPICETOUCH_OVERLAY_TIMER_ID = 1;
+
+// overlay repaint interval; the WinXP-compat build stays at 30 FPS
+#if !SPICE_XP
+static const int SPICETOUCH_OVERLAY_TIMER_MS = 1000 / 60;
+#else
+static const int SPICETOUCH_OVERLAY_TIMER_MS = 1000 / 30;
+#endif // !SPICE_XP
+
 // in mainline spicetools, this was false (show by default)
 // in spice2x, this is true (hide by default)
 bool SPICETOUCH_CARD_DISABLE = true;
@@ -309,7 +319,10 @@ static LRESULT CALLBACK SpiceTouchWndProc(HWND hWnd, UINT msg, WPARAM wParam, LP
                 break;
             }
             case WM_TIMER: {
-                InvalidateRect(hWnd, NULL, TRUE);
+
+                // request a repaint; the frame is composed into an offscreen buffer, so no
+                // background erase is needed (bErase = FALSE avoids a transparent flash)
+                InvalidateRect(hWnd, NULL, FALSE);
                 break;
             }
             case WM_PAINT: {
@@ -358,12 +371,26 @@ static LRESULT CALLBACK SpiceTouchWndProc(HWND hWnd, UINT msg, WPARAM wParam, LP
                 }
                 bool overlay_active = overlay_enabled && overlay::OVERLAY->get_active();
 
-                // draw everything in a single BeginPaint/EndPaint (a WM_PAINT has one update
-                // region, so a second BeginPaint would get an empty region), keeping only
-                // fast blits between the background erase and EndPaint
+                // compose the whole frame into an offscreen back buffer and present it with a
+                // single blit; the window never shows a half-erased (transparent) surface
+                // mid-paint, which is what caused the occasional flicker at higher frame rates
                 PAINTSTRUCT paint {};
                 HDC hdc = BeginPaint(hWnd, &paint);
-                SetBkMode(hdc, TRANSPARENT);
+
+                RECT bufferRect {};
+                GetClientRect(hWnd, &bufferRect);
+                int buffer_width = bufferRect.right - bufferRect.left;
+                int buffer_height = bufferRect.bottom - bufferRect.top;
+
+                HDC back_dc = CreateCompatibleDC(hdc);
+                HBITMAP back_bitmap = CreateCompatibleBitmap(hdc, buffer_width, buffer_height);
+                HGDIOBJ back_old = SelectObject(back_dc, back_bitmap);
+                SetBkMode(back_dc, TRANSPARENT);
+
+                // clear the buffer to the color key so unpainted areas stay transparent
+                HBRUSH colorKeyBrush = CreateSolidBrush(RGB(255, 192, 203));
+                FillRect(back_dc, &bufferRect, colorKeyBrush);
+                DeleteObject(colorKeyBrush);
 
                 // blit the overlay bitmap
                 if (overlay_bitmap) {
@@ -375,9 +402,9 @@ static LRESULT CALLBACK SpiceTouchWndProc(HWND hWnd, UINT msg, WPARAM wParam, LP
                      * - once this is figured out we could also try hooking WM_PAINT and
                      *   draw directly to the game window
                      */
-                    HDC hdcMem = CreateCompatibleDC(hdc);
+                    HDC hdcMem = CreateCompatibleDC(back_dc);
                     SelectObject(hdcMem, overlay_bitmap);
-                    BitBlt(hdc, 0, 0, overlay_width, overlay_height, hdcMem, 0, 0, SRCCOPY);
+                    BitBlt(back_dc, 0, 0, overlay_width, overlay_height, hdcMem, 0, 0, SRCCOPY);
                     DeleteDC(hdcMem);
                     DeleteObject(overlay_bitmap);
                 }
@@ -414,7 +441,7 @@ static LRESULT CALLBACK SpiceTouchWndProc(HWND hWnd, UINT msg, WPARAM wParam, LP
                     SPICETOUCH_CARD_RECT = boxRect;
 
                     // draw borders
-                    FillRect(hdc, &boxRect, brushBorder);
+                    FillRect(back_dc, &boxRect, brushBorder);
 
                     // modify box rect
                     boxRect.left += 1;
@@ -423,7 +450,7 @@ static LRESULT CALLBACK SpiceTouchWndProc(HWND hWnd, UINT msg, WPARAM wParam, LP
                     boxRect.bottom -= 1;
 
                     // fill box
-                    FillRect(hdc, &boxRect, brushFill);
+                    FillRect(back_dc, &boxRect, brushFill);
 
                     // modify box rect
                     if (should_rotate) {
@@ -435,19 +462,29 @@ static LRESULT CALLBACK SpiceTouchWndProc(HWND hWnd, UINT msg, WPARAM wParam, LP
                     }
 
                     // draw text
-                    SelectObject(hdc, SPICETOUCH_FONT);
-                    SetTextColor(hdc, RGB(0, 196, 0));
-                    DrawText(hdc, INSERT_CARD_TEXT, -1, &boxRect, DT_LEFT | DT_BOTTOM | DT_NOCLIP);
+                    SelectObject(back_dc, SPICETOUCH_FONT);
+                    SetTextColor(back_dc, RGB(0, 196, 0));
+                    DrawText(back_dc, INSERT_CARD_TEXT, -1, &boxRect, DT_LEFT | DT_BOTTOM | DT_NOCLIP);
 
                     // delete objects
                     DeleteObject(brushFill);
                     DeleteObject(brushBorder);
                 }
 
+#if !SPICE_XP
                 // draw the jubeat debug overlay on top (hidden while the overlay is active)
                 if (overlay_enabled && !overlay_active && games::jb::touch_debug_overlay_enabled()) {
-                    games::jb::touch_draw_debug_overlay(hdc);
+                    games::jb::touch_draw_debug_overlay(back_dc);
                 }
+#endif // !SPICE_XP
+
+                // present the composed frame in a single blit
+                BitBlt(hdc, 0, 0, buffer_width, buffer_height, back_dc, 0, 0, SRCCOPY);
+
+                // clean up the back buffer
+                SelectObject(back_dc, back_old);
+                DeleteObject(back_bitmap);
+                DeleteDC(back_dc);
 
                 EndPaint(hWnd, &paint);
                 return 0;
@@ -768,8 +805,8 @@ void touch_create_wnd(HWND hWnd, bool overlay) {
                 // create instance
                 overlay::OVERLAY.reset(new overlay::SpiceOverlay(touch_window));
 
-                // draw overlay in 30 FPS
-                SetTimer(touch_window, 1, 1000 / 30, NULL);
+                // draw overlay repaint timer (30 FPS on WinXP, 60 FPS otherwise)
+                SetTimer(touch_window, SPICETOUCH_OVERLAY_TIMER_ID, SPICETOUCH_OVERLAY_TIMER_MS, NULL);
             }
         }
 


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
n/a

## Description of change
GDI bit blit overlay used exclusively for jubeat & shogikai was running at 30fps, which caused the Jubeat touch debug UI to not render fast enough. Run it at 60 fps, and also perform double buffering to avoid flickering.

This could have been scoped to JB but I made the change for both. XP builds will keep running at 30fps since those people run on cabs with ancient hardware.

## Testing
Tested jubeat and shogikai, overlay renders without flickering at 60 fps

