### PR TITLE
audio: retain WASAPI clients only after initialization

### DIFF
--- a/src/spice2x/hooks/audio/audio.cpp
+++ b/src/spice2x/hooks/audio/audio.cpp
@@ -54,22 +54,26 @@ namespace hooks::audio {
     bool ASIO_FORCE_UNLOAD_ON_STOP = false;
 
     std::mutex INITIALIZE_LOCK; // for asio
-    
+
     IAudioClient *CLIENT = nullptr;
     static std::mutex CLIENT_LOCK;
+    static bool CLIENT_STOPPING = false;
 
     void set_active_client(IAudioClient *client, const char *source) {
-        std::lock_guard lock(CLIENT_LOCK);
+        IAudioClient *previous_client = nullptr;
+        {
+            std::lock_guard lock(CLIENT_LOCK);
 
-        if (CLIENT == client) {
-            return;
-        }
-        if (client) {
-            client->AddRef();
-        }
+            if (CLIENT_STOPPING || CLIENT == client) {
+                return;
+            }
+            if (client) {
+                client->AddRef();
+            }
 
-        IAudioClient *previous_client = CLIENT;
-        CLIENT = client;
+            previous_client = CLIENT;
+            CLIENT = client;
+        }
 
         if (previous_client) {
             previous_client->Release();
@@ -159,10 +163,16 @@ namespace hooks::audio {
 
     void stop() {
         log_info("audio", "stopping");
-        if (CLIENT) {
-            CLIENT->Stop();
-            CLIENT->Release();
+        IAudioClient *client = nullptr;
+        {
+            std::lock_guard lock(CLIENT_LOCK);
+            CLIENT_STOPPING = true;
+            client = CLIENT;
             CLIENT = nullptr;
+        }
+        if (client) {
+            client->Stop();
+            client->Release();
         }
         stop_low_latency();
 

--- a/src/spice2x/hooks/audio/audio.cpp
+++ b/src/spice2x/hooks/audio/audio.cpp
@@ -53,9 +53,32 @@ namespace hooks::audio {
     std::string ASIO_DRIVER_NAME = "";
     bool ASIO_FORCE_UNLOAD_ON_STOP = false;
 
-    // private globals
-    IAudioClient *CLIENT = nullptr;
     std::mutex INITIALIZE_LOCK; // for asio
+    
+    IAudioClient *CLIENT = nullptr;
+    static std::mutex CLIENT_LOCK;
+
+    void set_active_client(IAudioClient *client) {
+        std::lock_guard lock(CLIENT_LOCK);
+
+        if (CLIENT == client) {
+            return;
+        }
+        if (client) {
+            client->AddRef();
+        }
+
+        IAudioClient *previous_client = CLIENT;
+        CLIENT = client;
+
+        if (previous_client) {
+            previous_client->Release();
+        }
+
+        if (client) {
+            log_info("audio", "active client selected after successful initialization (issue-782-v2)");
+        }
+    }
 }
 
 static HRESULT STDAPICALLTYPE CoCreateInstance_hook(
@@ -123,7 +146,7 @@ namespace hooks::audio {
             return;
         }
 
-        log_info("audio", "initializing");
+        log_info("audio", "initializing (issue-782-v2)");
         init_low_latency();
         hooks::audio::acm::init();
 

--- a/src/spice2x/hooks/audio/audio.cpp
+++ b/src/spice2x/hooks/audio/audio.cpp
@@ -58,7 +58,7 @@ namespace hooks::audio {
     IAudioClient *CLIENT = nullptr;
     static std::mutex CLIENT_LOCK;
 
-    void set_active_client(IAudioClient *client) {
+    void set_active_client(IAudioClient *client, const char *source) {
         std::lock_guard lock(CLIENT_LOCK);
 
         if (CLIENT == client) {
@@ -76,7 +76,10 @@ namespace hooks::audio {
         }
 
         if (client) {
-            log_info("audio", "active client selected after successful initialization (issue-782-v2)");
+            log_info(
+                "audio",
+                "active client selected by {} after successful initialization",
+                source);
         }
     }
 }
@@ -146,7 +149,7 @@ namespace hooks::audio {
             return;
         }
 
-        log_info("audio", "initializing (issue-782-v2)");
+        log_info("audio", "initializing");
         init_low_latency();
         hooks::audio::acm::init();
 

--- a/src/spice2x/hooks/audio/audio_private.h
+++ b/src/spice2x/hooks/audio/audio_private.h
@@ -14,4 +14,6 @@ namespace hooks::audio {
     extern std::mutex INITIALIZE_LOCK;
     extern bool VOLUME_HOOK_ENABLED;
     extern LowLatencyAudioClient *LOW_LATENCY_CLIENT;
+
+    void set_active_client(IAudioClient *client);
 }

--- a/src/spice2x/hooks/audio/audio_private.h
+++ b/src/spice2x/hooks/audio/audio_private.h
@@ -15,5 +15,5 @@ namespace hooks::audio {
     extern bool VOLUME_HOOK_ENABLED;
     extern LowLatencyAudioClient *LOW_LATENCY_CLIENT;
 
-    void set_active_client(IAudioClient *client);
+    void set_active_client(IAudioClient *client, const char *source);
 }

--- a/src/spice2x/hooks/audio/backends/mmdevice/device.cpp
+++ b/src/spice2x/hooks/audio/backends/mmdevice/device.cpp
@@ -95,11 +95,6 @@ HRESULT STDMETHODCALLTYPE WrappedIMMDevice::Activate(
         }
         std::lock_guard initialize_guard(hooks::audio::INITIALIZE_LOCK, std::adopt_lock);
 
-        // release old audio client if initialized
-        if (hooks::audio::CLIENT) {
-            hooks::audio::CLIENT->Release();
-        }
-
         IAudioClient *client = nullptr;
         if (iid == IID_IAudioClient) {
             client = wrap_audio_client(reinterpret_cast<IAudioClient *>(*ppInterface));
@@ -107,9 +102,6 @@ HRESULT STDMETHODCALLTYPE WrappedIMMDevice::Activate(
             client = wrap_audio_client3(reinterpret_cast<IAudioClient3 *>(*ppInterface));
         }
         *ppInterface = client;
-        // persist the audio client
-        hooks::audio::CLIENT = client;
-        hooks::audio::CLIENT->AddRef();
 
     } else if (iid == __uuidof(IAudioEndpointVolume) && hooks::audio::VOLUME_HOOK_ENABLED) {
         *ppInterface = new WrappedIAudioEndpointVolume(reinterpret_cast<IAudioEndpointVolume *>(*ppInterface));

--- a/src/spice2x/hooks/audio/backends/mmdevice/null_device.cpp
+++ b/src/spice2x/hooks/audio/backends/mmdevice/null_device.cpp
@@ -153,18 +153,8 @@ HRESULT STDMETHODCALLTYPE NullMMDevice::Activate(
     log_info("audio::null", "NullMMDevice::Activate {}", guid2s(iid));
 
     if (iid == IID_IAudioClient) {
-
-        // release any previously persisted client
-        if (hooks::audio::CLIENT != nullptr) {
-            hooks::audio::CLIENT->Release();
-        }
-
         auto *client = static_cast<IAudioClient *>(new DummyIAudioClient(new NullDiscardBackend()));
         *ppInterface = client;
-
-        // persist the audio client
-        hooks::audio::CLIENT = client;
-        hooks::audio::CLIENT->AddRef();
 
         return S_OK;
     }

--- a/src/spice2x/hooks/audio/backends/wasapi/audio_client.cpp
+++ b/src/spice2x/hooks/audio/backends/wasapi/audio_client.cpp
@@ -302,6 +302,7 @@ HRESULT STDMETHODCALLTYPE WrappedIAudioClient::Initialize(
                 device_format->nChannels * (device_format->wBitsPerSample / 8));
     }
 
+    hooks::audio::set_active_client(this);
     return ret;
 }
 HRESULT STDMETHODCALLTYPE WrappedIAudioClient::GetBufferSize(UINT32 *pNumBufferFrames) {
@@ -651,5 +652,6 @@ HRESULT STDMETHODCALLTYPE WrappedIAudioClient::InitializeSharedAudioStream(
     log_info("audio::wasapi", "IAudioClient3::InitializeSharedAudioStream success, hr={}", FMT_HRESULT(ret));
     copy_wave_format(&hooks::audio::FORMAT, pFormat);
     copy_wave_format(&this->device_format, pFormat);
+    hooks::audio::set_active_client(this);
     return ret;
 }

--- a/src/spice2x/hooks/audio/backends/wasapi/audio_client.cpp
+++ b/src/spice2x/hooks/audio/backends/wasapi/audio_client.cpp
@@ -302,7 +302,7 @@ HRESULT STDMETHODCALLTYPE WrappedIAudioClient::Initialize(
                 device_format->nChannels * (device_format->wBitsPerSample / 8));
     }
 
-    hooks::audio::set_active_client(this);
+    hooks::audio::set_active_client(this, "WrappedIAudioClient::Initialize");
     return ret;
 }
 HRESULT STDMETHODCALLTYPE WrappedIAudioClient::GetBufferSize(UINT32 *pNumBufferFrames) {
@@ -652,6 +652,6 @@ HRESULT STDMETHODCALLTYPE WrappedIAudioClient::InitializeSharedAudioStream(
     log_info("audio::wasapi", "IAudioClient3::InitializeSharedAudioStream success, hr={}", FMT_HRESULT(ret));
     copy_wave_format(&hooks::audio::FORMAT, pFormat);
     copy_wave_format(&this->device_format, pFormat);
-    hooks::audio::set_active_client(this);
+    hooks::audio::set_active_client(this, "WrappedIAudioClient::InitializeSharedAudioStream");
     return ret;
 }

--- a/src/spice2x/hooks/audio/backends/wasapi/dummy_audio_client.cpp
+++ b/src/spice2x/hooks/audio/backends/wasapi/dummy_audio_client.cpp
@@ -75,13 +75,17 @@ HRESULT STDMETHODCALLTYPE DummyIAudioClient::Initialize(
     log_info("audio::wasapi", "IAudioClient::Initialize hook hit");
     print_format(ShareMode, StreamFlags, hnsBufferDuration, hnsPeriodicity, pFormat);
 
-    CHECK_RESULT(this->backend->on_initialize(
+    HRESULT ret = this->backend->on_initialize(
         &ShareMode,
         &StreamFlags,
         &hnsBufferDuration,
         &hnsPeriodicity,
         pFormat,
-        AudioSessionGuid));
+        AudioSessionGuid);
+    if (SUCCEEDED(ret)) {
+        hooks::audio::set_active_client(this);
+    }
+    CHECK_RESULT(ret);
 }
 HRESULT STDMETHODCALLTYPE DummyIAudioClient::GetBufferSize(UINT32 *pNumBufferFrames) {
     static std::once_flag printed;

--- a/src/spice2x/hooks/audio/backends/wasapi/dummy_audio_client.cpp
+++ b/src/spice2x/hooks/audio/backends/wasapi/dummy_audio_client.cpp
@@ -83,7 +83,7 @@ HRESULT STDMETHODCALLTYPE DummyIAudioClient::Initialize(
         pFormat,
         AudioSessionGuid);
     if (SUCCEEDED(ret)) {
-        hooks::audio::set_active_client(this);
+        hooks::audio::set_active_client(this, "DummyIAudioClient::Initialize");
     }
     CHECK_RESULT(ret);
 }


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
Fixes #782 

## Description of change

This addresses an issue only seen on Linux + WINE.

Defer retaining WASAPI clients until `Initialize` succeeds.

Before this PR, temporary clients created during DirectShow device capability probing were retained as active audio clients, causing Wine/Linux crashes in DDR and popn.

Also covers IAudioClient3, dummy, ASIO, WaveOut, and null-device initialization paths, for consistency.

## Testing
WIP