### PR TITLE
overlay: disable subscreen overlay if "native touch" option is on

### DIFF
--- a/src/spice2x/overlay/windows/iidx_sub.cpp
+++ b/src/spice2x/overlay/windows/iidx_sub.cpp
@@ -15,6 +15,8 @@ namespace overlay::windows {
             this->disabled_message = "Close this overlay and use the second window. (try ALT+TAB)";
         } else if (games::iidx::IIDX_TDJ_MONITOR_WARNING) {
             this->disabled_message = "TDJ mode subscreen overlay is not compatible with -dxmainadapter option; use -mainmonitor instead";
+        } else if (games::iidx::NATIVE_TOUCH) {
+            this->disabled_message = "Overlay disabled by user (-iidxnativetouch option is on, used for real touch screens)";
         }
 
         float size = 0.5f;

--- a/src/spice2x/overlay/windows/popn_sub.cpp
+++ b/src/spice2x/overlay/windows/popn_sub.cpp
@@ -15,6 +15,8 @@ namespace overlay::windows {
             this->disabled_message = "Game did not launch as Pikapika Pop-kun (invalid <spec>)!";
         } else if (games::popn::SHOW_PIKA_MONITOR_WARNING) {
             this->disabled_message = "Subscreen overlay is not compatible with -dxmainadapter option, use -mainmonitor instead";
+        } else if (games::popn::NATIVE_TOUCH) {
+            this->disabled_message = "Overlay disabled by user (-popnnativetouch option is on, used for real touch screens)";
         } else if (GRAPHICS_WINDOWED && !GRAPHICS_PREVENT_SECONDARY_WINDOWS) {
             this->disabled_message = "Subscren overlay was not enabled in spicecfg. Use the second window (ALT+TAB).";
         }

--- a/src/spice2x/overlay/windows/sdvx_sub.cpp
+++ b/src/spice2x/overlay/windows/sdvx_sub.cpp
@@ -14,6 +14,8 @@ namespace overlay::windows {
             this->disabled_message = "Valkyrie Model mode is not enabled!";
         } else if (games::sdvx::SHOW_VM_MONITOR_WARNING) {
             this->disabled_message = "VM mode subscreen overlay is not compatible with -dxmainadapter option, use -mainmonitor instead";
+        } else if (games::sdvx::NATIVETOUCH) {
+            this->disabled_message = "Overlay disabled by user (-sdvxnativetouch option is on, used for real touch screens)";
         } else if (GRAPHICS_WINDOWED) {
             if (GRAPHICS_PREVENT_SECONDARY_WINDOWS) {
                 this->disabled_message = "Subscreen has been disabled by the user (-sdvxnosub).";


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
#345 

## Description of change
If IIDX/SDVX/POPN "native touch" option is enabled, show an error message if user toggles subscreen window.

Those options are meant for users with touch screens, and disables mouse interactions. Users who like to randomly turn on options often latch on to this option and get confused when clicks don't register.

## Testing

