### PR TITLE
rawinput: avoid enumerating adapter modes on first touch

### DIFF
--- a/src/spice2x/games/jb/jb_touch.cpp
+++ b/src/spice2x/games/jb/jb_touch.cpp
@@ -202,10 +202,11 @@ namespace games::jb {
             IS_PORTRAIT = avs::game::is_model("L44");
 
             log_info("jubeat", "using window handle for touch: {}", fmt::ptr(wnd));
-            touch_create_wnd(wnd, true);
 
             // let the rawinput stack correct the aspect ratio
             ::rawinput::touch::ASPECT_COMPENSATION_GAME = true;
+
+            touch_create_wnd(wnd, true);
 
             if (GRAPHICS_SHOW_CURSOR) {
                 ShowCursor(TRUE);

--- a/src/spice2x/games/rb/touch.cpp
+++ b/src/spice2x/games/rb/touch.cpp
@@ -86,6 +86,9 @@ bool games::rb::ReflecBeatTouchDeviceHandle::open(LPCWSTR lpFileName) {
                          SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOOWNERZORDER);
         }
 
+        // request automatic aspect ratio fixes
+        ::rawinput::touch::ASPECT_COMPENSATION_GAME = true;
+
         // create touch window
         touch_create_wnd(wnd);
 
@@ -93,9 +96,6 @@ bool games::rb::ReflecBeatTouchDeviceHandle::open(LPCWSTR lpFileName) {
         if (!GRAPHICS_WINDOWED) {
             ShowWindow(wnd, SW_SHOW);
         }
-
-        // request automatic aspect ratio fixes
-        ::rawinput::touch::ASPECT_COMPENSATION_GAME = true;
 
     } else {
 

--- a/src/spice2x/rawinput/touch.cpp
+++ b/src/spice2x/rawinput/touch.cpp
@@ -35,6 +35,8 @@ namespace rawinput::touch {
     long DISPLAY_NATIVE_Y = 0L;
     bool DISPLAY_INITIALIZED = false;
 
+    static void update_current_display_mode();
+
     bool aspect_compensation_enabled() {
         switch (ASPECT_COMPENSATION_MODE) {
             case AspectMode::On:
@@ -279,7 +281,7 @@ namespace rawinput::touch {
 
         // check if display is initialized
         if (!DISPLAY_INITIALIZED) {
-            display_update();
+            update_current_display_mode();
         }
 
         // update timeouts here as well so events are in the right order
@@ -638,24 +640,13 @@ namespace rawinput::touch {
         return false;
     }
 
-    void display_update() {
-
-        // check if disabled
-        if (DISABLED)
-            return;
-
+    static void update_current_display_mode() {
         // determine monitor size
         static RECT display_rect;
         GetWindowRect(GetDesktopWindow(), &display_rect);
         DISPLAY_SIZE_X = display_rect.right - display_rect.left;
         DISPLAY_SIZE_Y = display_rect.bottom - display_rect.top;
         log_info("rawinput", "primary display size: {}x{}", (int) DISPLAY_SIZE_X, (int) DISPLAY_SIZE_Y);
-
-        // determine the native (maximum) resolution of the primary display; used to
-        // detect and undo letterboxing when a non-native display mode is in use
-        detect_native_resolution();
-        log_info("rawinput", "primary display native size: {}x{}",
-                 (int) DISPLAY_NATIVE_X, (int) DISPLAY_NATIVE_Y);
 
         // determine monitor orientation
         DEVMODE display_mode{};
@@ -702,5 +693,22 @@ namespace rawinput::touch {
 
         // mark as initialized
         DISPLAY_INITIALIZED = true;
+    }
+
+    void display_update() {
+
+        // check if disabled
+        if (DISABLED)
+            return;
+
+        update_current_display_mode();
+
+        if (aspect_compensation_enabled()) {
+            // determine the native (maximum) resolution of the primary display; used to
+            // detect and undo letterboxing when a non-native display mode is in use
+            detect_native_resolution();
+            log_info("rawinput", "primary display native size: {}x{}",
+                     (int) DISPLAY_NATIVE_X, (int) DISPLAY_NATIVE_Y);
+        }
     }
 }


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
Regressed by #790

## Description of change
Avoid enumerating every display mode with `EnumDisplaySettings` during the first raw touchscreen report, as it can take a couple hundred milliseconds.

The latency-sensitive path now refreshes only the current display size using `GetWindowRect(GetDesktopWindow())` and orientation using `EnumDisplaySettingsEx(..., ENUM_CURRENT_SETTINGS, ..., EDS_RAWMODE)`. Full `EnumDisplaySettings` enumeration runs only when native resolution is needed for aspect compensation.

Jubeat and Reflec Beat now enable aspect compensation before initializing touch input.

## Testing
Sanity checked rb/jb on laptops with non-16:9 ratio
