### PR TITLE
touch: make native touch the default for iidx/sdvx/popn

### DIFF
--- a/src/spice2x/games/ccj/ccj.cpp
+++ b/src/spice2x/games/ccj/ccj.cpp
@@ -7,7 +7,6 @@
 #include "util/utils.h"
 #include "util/detour.h"
 #include "acioemu/handle.h"
-#include "misc/wintouchemu.h"
 #include "hooks/graphics/graphics.h"
 #include "bi2x_hook.h"
 #include "trackball.h"

--- a/src/spice2x/games/iidx/iidx.cpp
+++ b/src/spice2x/games/iidx/iidx.cpp
@@ -21,7 +21,6 @@
 #include "launcher/options.h"
 #include "touch/touch.h"
 #include "touch/native/nativetouchhook.h"
-#include "misc/wintouchemu.h"
 #include "misc/eamuse.h"
 #include "util/detour.h"
 #include "util/deferlog.h"
@@ -63,7 +62,6 @@ namespace games::iidx {
     bool TDJ_MODE = false;
     bool FORCE_720P = false;
     bool DISABLE_ESPEC_IO = false;
-    bool NATIVE_TOUCH = false;
     std::optional<std::string> SOUND_OUTPUT_DEVICE = std::nullopt;
     std::optional<std::string> SOUND_OUTPUT_DEVICE_IN_EFFECT = std::nullopt;
     std::optional<std::string> ASIO_DRIVER = std::nullopt;
@@ -350,13 +348,7 @@ namespace games::iidx {
                 // need to hook `avs2-core.dll` so AVS win32fs operations go through rom hook
                 devicehook_init(avs::core::DLL_INSTANCE);
 
-                if (NATIVE_TOUCH) {
-                    nativetouch::hook(avs::game::DLL_INSTANCE);
-                } else {
-                    wintouchemu::FORCE = true;
-                    wintouchemu::INJECT_MOUSE_AS_WM_TOUCH = true;
-                    wintouchemu::hook_title_ends("beatmania IIDX", "main", avs::game::DLL_INSTANCE);
-                }
+                nativetouch::hook(avs::game::DLL_INSTANCE);
             }
 
             // insert BI2X hooks

--- a/src/spice2x/games/iidx/iidx.h
+++ b/src/spice2x/games/iidx/iidx.h
@@ -28,7 +28,6 @@ namespace games::iidx {
     extern bool TDJ_MODE;
     extern bool FORCE_720P;
     extern bool DISABLE_ESPEC_IO;
-    extern bool NATIVE_TOUCH;
     extern std::optional<std::string> SOUND_OUTPUT_DEVICE;
     extern std::optional<std::string> ASIO_DRIVER;
     extern uint8_t DIGITAL_TT_SENS;

--- a/src/spice2x/games/iidx/poke.cpp
+++ b/src/spice2x/games/iidx/poke.cpp
@@ -3,14 +3,10 @@
 #include <thread>
 
 #include "windows.h"
-#include "cfg/screen_resize.h"
 #include "games/io.h"
-#include "games/iidx/iidx.h"
 #include "hooks/graphics/graphics.h"
 #include "launcher/shutdown.h"
 #include "misc/eamuse.h"
-#include "overlay/overlay.h"
-#include "overlay/windows/generic_sub.h"
 #include "touch/native/inject.h"
 #include "touch/touch.h"
 #include "util/logging.h"
@@ -114,15 +110,6 @@ namespace games::iidx::poke {
         nativetouch::inject::inject_synthetic_touch({ touch.x, touch.y }, down);
     }
     
-    void clear_touch_points(std::vector<TouchPoint> *touch_points) {
-        std::vector<DWORD> touch_ids;
-        for (auto &touch : *touch_points) {
-            touch_ids.emplace_back(touch.id);
-        }
-        touch_remove_points(&touch_ids);
-        touch_points->clear();
-    }
-
     void enable() {
 
         // check if already running
@@ -140,19 +127,14 @@ namespace games::iidx::poke {
 
             std::vector<TouchPoint> touch_points;
             std::vector<uint16_t> last_keypad_state = {0, 0};
-            const bool use_native = games::iidx::NATIVE_TOUCH;
 
             // set variable to false to stop
             while (THREAD_RUNNING) {
 
                 // clean up touch from last frame
                 if (touch_points.size() > 0) {
-                    if (use_native) {
-                        inject_native_touch_points(touch_points, false);
-                        touch_points.clear();
-                    } else {
-                        clear_touch_points(&touch_points);
-                    }
+                    inject_native_touch_points(touch_points, false);
+                    touch_points.clear();
                 }
 
                 for (int unit = 0; unit < 2; unit++) {
@@ -177,40 +159,15 @@ namespace games::iidx::poke {
 
                                     float x = x_iter->second / 1920.0;
                                     float y = y_iter->second / 1080.0;
-                                    if (use_native) {
-                                        if (GRAPHICS_WINDOWED) {
-                                            if (SPICETOUCH_TOUCH_WIDTH <= 0 || SPICETOUCH_TOUCH_HEIGHT <= 0) {
-                                                continue;
-                                            }
-                                            x = SPICETOUCH_TOUCH_X + x * SPICETOUCH_TOUCH_WIDTH;
-                                            y = SPICETOUCH_TOUCH_Y + y * SPICETOUCH_TOUCH_HEIGHT;
-                                        } else {
-                                            x = x_iter->second;
-                                            y = y_iter->second;
+                                    if (GRAPHICS_WINDOWED) {
+                                        if (SPICETOUCH_TOUCH_WIDTH <= 0 || SPICETOUCH_TOUCH_HEIGHT <= 0) {
+                                            continue;
                                         }
-                                    } else if (GRAPHICS_IIDX_WSUB) {
-                                        // Scale to windowed subscreen
-                                        x *= GRAPHICS_WSUB_WIDTH;
-                                        y *= GRAPHICS_WSUB_HEIGHT;
-                                    } else if (GENERIC_SUB_WINDOW_FULLSIZE || !overlay::OVERLAY->get_active()) {
-                                        // Overlay is not present, scale to main screen
-                                        if (GRAPHICS_WINDOWED) {
-                                            x *= SPICETOUCH_TOUCH_WIDTH;
-                                            y *= SPICETOUCH_TOUCH_HEIGHT;
-                                        } else {
-                                            x *= ImGui::GetIO().DisplaySize.x;
-                                            y *= ImGui::GetIO().DisplaySize.y;
-                                        }
+                                        x = SPICETOUCH_TOUCH_X + x * SPICETOUCH_TOUCH_WIDTH;
+                                        y = SPICETOUCH_TOUCH_Y + y * SPICETOUCH_TOUCH_HEIGHT;
                                     } else {
-                                        // Overlay subscreen
-                                        x = (GENERIC_SUB_WINDOW_X + x * GENERIC_SUB_WINDOW_WIDTH);
-                                        y = (GENERIC_SUB_WINDOW_Y + y * GENERIC_SUB_WINDOW_HEIGHT);
-
-                                        // Scale to window size ratio
-                                        if (GRAPHICS_WINDOWED) {
-                                            x *= SPICETOUCH_TOUCH_WIDTH / ImGui::GetIO().DisplaySize.x;
-                                            y *= SPICETOUCH_TOUCH_HEIGHT / ImGui::GetIO().DisplaySize.y;
-                                        }
+                                        x = x_iter->second;
+                                        y = y_iter->second;
                                     }
 
                                     TouchPoint tp {
@@ -231,11 +188,7 @@ namespace games::iidx::poke {
                 } // for all units
 
                 if (touch_points.size() > 0) {
-                    if (use_native) {
-                        inject_native_touch_points(touch_points, true);
-                    } else {
-                        touch_write_points(&touch_points);
-                    }
+                    inject_native_touch_points(touch_points, true);
                 }
 
                 // slow down
@@ -243,11 +196,7 @@ namespace games::iidx::poke {
             }
 
             if (!touch_points.empty()) {
-                if (use_native) {
-                    inject_native_touch_points(touch_points, false);
-                } else {
-                    clear_touch_points(&touch_points);
-                }
+                inject_native_touch_points(touch_points, false);
             }
 
             return nullptr;

--- a/src/spice2x/games/mfg/mfg.cpp
+++ b/src/spice2x/games/mfg/mfg.cpp
@@ -6,7 +6,6 @@
 #include "util/utils.h"
 #include "util/execexe.h"
 #include "acioemu/handle.h"
-#include "misc/wintouchemu.h"
 #include "hooks/graphics/graphics.h"
 #include "bi2a_hook.h"
 

--- a/src/spice2x/games/pc/pc.cpp
+++ b/src/spice2x/games/pc/pc.cpp
@@ -12,7 +12,6 @@
 #include "util/unity_player.h"
 #include "util/execexe.h"
 #include "acioemu/handle.h"
-#include "misc/wintouchemu.h"
 #include "hooks/graphics/graphics.h"
 #include "rawinput/rawinput.h"
 #include "util/socd_cleaner.h"

--- a/src/spice2x/games/pcm/pcm.cpp
+++ b/src/spice2x/games/pcm/pcm.cpp
@@ -2,7 +2,6 @@
 
 #include "acio/icca/icca.h"
 #include "io.h"
-#include "misc/wintouchemu.h"
 #include "util/detour.h"
 #include "util/utils.h"
 #include "util/libutils.h"

--- a/src/spice2x/games/popn/popn.cpp
+++ b/src/spice2x/games/popn/popn.cpp
@@ -20,12 +20,10 @@
 #include "io.h"
 #include "util/deferlog.h"
 #include "touch/native/nativetouchhook.h"
-#include "misc/wintouchemu.h"
 
 namespace games::popn {
 
     bool SHOW_PIKA_MONITOR_WARNING = false;
-    bool NATIVE_TOUCH = false;
     
 #if SPICE64 && !SPICE_XP
 
@@ -715,13 +713,7 @@ namespace games::popn {
         //       00000100 0000000B 00000001  (button 9)
         //       set third column to 0 and it will work with BIO2
         
-        if (NATIVE_TOUCH) {
-            nativetouch::hook(avs::game::DLL_INSTANCE);
-        } else if (!GRAPHICS_WINDOWED) {
-            wintouchemu::FORCE = true;
-            wintouchemu::INJECT_MOUSE_AS_WM_TOUCH = true;
-            wintouchemu::hook_title_ends("", "Main Screen", avs::game::DLL_INSTANCE);
-        }
+        nativetouch::hook(avs::game::DLL_INSTANCE);
 
         sysutils::hook_EnumDisplayDevicesA();
 

--- a/src/spice2x/games/popn/popn.h
+++ b/src/spice2x/games/popn/popn.h
@@ -22,7 +22,6 @@ namespace games::popn {
 #endif
 
     extern bool SHOW_PIKA_MONITOR_WARNING;
-    extern bool NATIVE_TOUCH;
 
     class POPNGame : public games::Game {
     public:

--- a/src/spice2x/games/sdvx/sdvx.cpp
+++ b/src/spice2x/games/sdvx/sdvx.cpp
@@ -27,7 +27,6 @@
 #include "util/sysutils.h"
 #include "misc/eamuse.h"
 #include "touch/native/nativetouchhook.h"
-#include "misc/wintouchemu.h"
 #include "bi2x_hook.h"
 #include "camera.h"
 #include "io.h"
@@ -49,7 +48,6 @@ namespace games::sdvx {
     const char *ORIGINAL_ASIO_DEVICE_NAME = "XONAR SOUND CARD(64)";
 
     // settings
-    bool NATIVETOUCH = false;
     uint8_t DIGITAL_KNOB_SENS = 16;
     SdvxOverlayPosition OVERLAY_POS = SDVX_OVERLAY_BOTTOM;
     bool ENABLE_COM_PORT_SCAN_HOOK = false;
@@ -455,18 +453,7 @@ namespace games::sdvx {
             }
 
             if (is_valkyrie_model()) {
-                if (NATIVETOUCH) {
-                    nativetouch::hook(avs::game::DLL_INSTANCE);
-                } else if (!NATIVETOUCH && !GRAPHICS_WINDOWED) {
-                    // hook touch window
-                    // in windowed mode, game can accept mouse input on the second screen
-                    wintouchemu::FORCE = true;
-                    wintouchemu::INJECT_MOUSE_AS_WM_TOUCH = true;
-                    wintouchemu::hook_title_ends(
-                            "SOUND VOLTEX",
-                            "Main Screen",
-                            avs::game::DLL_INSTANCE);
-                }
+                nativetouch::hook(avs::game::DLL_INSTANCE);
 
                 // insert BI2X hooks
                 bi2x_hook_init();

--- a/src/spice2x/games/sdvx/sdvx.h
+++ b/src/spice2x/games/sdvx/sdvx.h
@@ -18,7 +18,6 @@ namespace games::sdvx {
     };
 
     // settings
-    extern bool NATIVETOUCH;
     extern uint8_t DIGITAL_KNOB_SENS;
     extern std::optional<std::string> ASIO_DRIVER;
     extern SdvxOverlayPosition OVERLAY_POS;

--- a/src/spice2x/hooks/graphics/graphics.cpp
+++ b/src/spice2x/hooks/graphics/graphics.cpp
@@ -798,11 +798,7 @@ static BOOL WINAPI MoveWindow_hook(HWND hWnd, int X, int Y, int nWidth, int nHei
             nWidth = rect.right - rect.left;
             nHeight = rect.bottom - rect.top;
 
-            if (games::iidx::NATIVE_TOUCH) {
-                nativetouch::inject::register_and_attach_window(TDJ_SUBSCREEN_WINDOW);
-            } else {
-                touch_attach_wnd(TDJ_SUBSCREEN_WINDOW);
-            }
+            nativetouch::inject::register_and_attach_window(TDJ_SUBSCREEN_WINDOW);
         } else {
             // Existing behaviour: suppress subscreen window and prompt user to use overlay instead
              log_info(
@@ -1169,8 +1165,8 @@ void graphics_hook_window(HWND hWnd, D3DPRESENT_PARAMETERS *pPresentationParamet
         SetWindowLongPtrA(hWnd, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(WindowProc));
 
         const bool native_touch_overlay =
-            (games::iidx::NATIVE_TOUCH && !GRAPHICS_IIDX_WSUB) ||
-            (games::popn::NATIVE_TOUCH && GRAPHICS_PREVENT_SECONDARY_WINDOWS);
+            (games::iidx::TDJ_MODE && !GRAPHICS_IIDX_WSUB) ||
+            (games::popn::is_pikapika_model() && GRAPHICS_PREVENT_SECONDARY_WINDOWS);
         if (native_touch_overlay) {
             nativetouch::inject::register_and_attach_window(hWnd);
         }

--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -428,9 +428,6 @@ int main_implementation(int argc, char *argv[]) {
 
     if (options[launcher::Options::spice2x_NoD3D9DeviceHook].value_bool()) {
         D3D9_DEVICE_HOOK_DISABLE = true;
-        // touch emulation gets disabled, might as well turn these on
-        games::iidx::NATIVE_TOUCH = true;
-        games::sdvx::NATIVETOUCH = true;
         // not strictly necessary as it will fail to init anyway, but cleaner to just disable it now
         overlay::ENABLED = false;
         // leaving these on without dx9hooks result in torn state and therefore failure to draw
@@ -489,9 +486,6 @@ int main_implementation(int argc, char *argv[]) {
     }
     if (options[launcher::Options::LoadSoundVoltexModule].value_bool()) {
         attach_sdvx = true;
-    }
-    if (options[launcher::Options::SDVXNativeTouch].value_bool()) {
-        games::sdvx::NATIVETOUCH = true;
     }
     if (options[launcher::Options::spice2x_SDVXDigitalKnobSensitivity].is_active()) {
         games::sdvx::DIGITAL_KNOB_SENS = (uint8_t)
@@ -593,9 +587,6 @@ int main_implementation(int argc, char *argv[]) {
     if (options[launcher::Options::spice2x_IIDXNoESpec].value_bool()) {
         games::iidx::DISABLE_ESPEC_IO = true;
     }
-    if (options[launcher::Options::spice2x_IIDXNativeTouch].value_bool()) {
-        games::iidx::NATIVE_TOUCH = true;
-    }
     // should come later since this will override a few settings
     if (options[launcher::Options::spice2x_IIDXWindowedTDJ].value_bool() ||
         (options[launcher::Options::IIDXTDJMode].value_bool() && GRAPHICS_WINDOWED)) {
@@ -642,9 +633,6 @@ int main_implementation(int argc, char *argv[]) {
     }
     if (options[launcher::Options::PopnSubMonitorOverride].is_active()) {
         sysutils::SECOND_MONITOR_OVERRIDE = options[launcher::Options::PopnSubMonitorOverride].value_text();
-    }
-    if (options[launcher::Options::PopnNativeTouch].value_bool()) {
-        games::popn::NATIVE_TOUCH = true;
     }
     if (options[launcher::Options::PopnSubRedraw].value_bool()) {
         SUBSCREEN_FORCE_REDRAW = true;

--- a/src/spice2x/launcher/options.cpp
+++ b/src/spice2x/launcher/options.cpp
@@ -962,13 +962,12 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .category = "Cab Peripherals",
     },
     {
-        .title = "SDVX FS Subscreen Native Touch Handling",
+        .title = "SDVX Native Touch (DEPRECATED - no longer needed)",
         .name = "sdvxnativetouch",
-        .desc = "Disables touch hooks and lets the game access a touch screen directly. "
-                "Requires a touch screen to be connected as a secondary monitor. "
-                "Touch input must be routed to the primary screen via Windows Tablet PC settings. "
-                "Enable this when you get duplicate touch inputs from an actual touch screen.",
+        .desc = "This option does nothing.\n\n"
+            "Native touch handling is now enabled by default and this option is no longer needed.",
         .type = OptionType::Bool,
+        .hidden = true,
         .game_name = "Sound Voltex",
         .category = "Advanced Game Options",
     },
@@ -1159,13 +1158,12 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
     },
     {
         // PopnNativeTouch
-        .title = "Pop'n Music PikaPika Native Touch Handling",
+        .title = "Pop'n Music Native Touch (DEPRECATED - no longer needed)",
         .name = "popnnativetouch",
-        .desc = "Disables touch hooks and lets the game access a touch screen directly. "
-                "Requires a touch screen to be connected as a secondary monitor. "
-                "Touch input must be routed to the primary screen via Windows Tablet PC settings. "
-                "Enable this when you get duplicate touch inputs from an actual touch screen.",
+        .desc = "This option does nothing.\n\n"
+            "Native touch handling is now enabled by default and this option is no longer needed.",
         .type = OptionType::Bool,
+        .hidden = true,
         .game_name = "Pop'n Music",
         .category = "Advanced Game Options",
     },
@@ -2870,15 +2868,14 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
     },
     {
         // spice2x_IIDXNativeTouch
-        .title = "IIDX TDJ Subscreen Native Touch Handling",
+        .title = "IIDX Native Touch (DEPRECATED - no longer needed)",
         .name = "sp2x-iidxnativetouch",
         .display_name = "iidxnativetouch",
         .aliases= "iidxnativetouch",
-        .desc = "Disables touch hooks and lets the game access a touch screen directly. "
-                "Requires a touch screen to be connected as a secondary monitor. "
-                "Touch input must be routed to the primary screen via Windows Tablet PC settings. "
-                "Enable this when you get duplicate touch inputs from an actual touch screen.",
+        .desc = "This option does nothing.\n\n"
+            "Native touch handling is now enabled by default and this option is no longer needed.",
         .type = OptionType::Bool,
+        .hidden = true,
         .game_name = "Beatmania IIDX",
         .category = "Advanced Game Options",
     },

--- a/src/spice2x/misc/wintouchemu.cpp
+++ b/src/spice2x/misc/wintouchemu.cpp
@@ -6,24 +6,16 @@
 
 #include <chrono>
 #include <algorithm>
-#include <optional>
 #include <thread>
 
-#include "cfg/screen_resize.h"
 #include "games/gitadora/gitadora.h"
-#include "games/iidx/iidx.h"
-#include "games/popn/popn.h"
 #include "hooks/graphics/graphics.h"
 #include "overlay/overlay.h"
-#include "overlay/windows/generic_sub.h"
 #include "touch/touch.h"
 #include "util/detour.h"
 #include "util/logging.h"
 #include "util/time.h"
 #include "util/utils.h"
-#include "rawinput/touch.h"
-
-#include "avs/game.h"
 
 namespace wintouchemu {
 
@@ -86,7 +78,6 @@ namespace wintouchemu {
     std::vector<TouchPoint> TOUCH_POINTS;
     HMODULE HOOKED_MODULE = nullptr;
     std::string WINDOW_TITLE_START = "";
-    std::optional<std::string> WINDOW_TITLE_END = std::nullopt;
     volatile bool INITIALIZED = false;
     mouse_state_t mouse_state;
 
@@ -123,17 +114,6 @@ namespace wintouchemu {
             log_misc("wintouchemu", "initializing");
             INITIALIZED = true;
         }
-    }
-
-    void hook_title_ends(const char *window_title_start, const char *window_title_end, HMODULE module) {
-        hook(window_title_start, module);
-
-        WINDOW_TITLE_END = window_title_end;
-    }
-
-    static void flip_touch_points(PTOUCHINPUT point) {
-        point->x = rawinput::touch::DISPLAY_SIZE_X * 100 - point->x;
-        point->y = rawinput::touch::DISPLAY_SIZE_Y * 100 - point->y;
     }
 
     static BOOL WINAPI GetTouchInputInfoHook(HANDLE hTouchInput, UINT cInputs, PTOUCHINPUT pInputs, int cbSize) {
@@ -178,13 +158,7 @@ namespace wintouchemu {
 
                 // log_misc("wintouchemu", "touch event ({}, {})", to_string(x), to_string(y));
 
-                if (GRAPHICS_IIDX_WSUB) {
-                    // touch was received on subscreen window.
-                    RECT clientRect {};
-                    GetClientRect(TDJ_SUBSCREEN_WINDOW, &clientRect);
-                    x = (float) x / clientRect.right * SPICETOUCH_TOUCH_WIDTH + SPICETOUCH_TOUCH_X;
-                    y = (float) y / clientRect.bottom * SPICETOUCH_TOUCH_HEIGHT + SPICETOUCH_TOUCH_Y;
-                } else if (overlay::OVERLAY) {
+                if (overlay::OVERLAY) {
                     // touch was received on global coords
                     valid = overlay::OVERLAY->transform_touch_point(&x, &y);
                 } else {
@@ -229,12 +203,6 @@ namespace wintouchemu {
                 touch_input->dwExtraInfo = 0;
                 touch_input->cxContact = 0;
                 touch_input->cyContact = 0;
-
-                if (avs::game::is_model("KFC") &&
-                    rawinput::touch::DISPLAY_INITIALIZED &&
-                    rawinput::touch::DISPLAY_ORIENTATION == DMDO_270) {
-                    flip_touch_points(touch_input);
-                }
 
             } else if (USE_MOUSE && !mouse_used) {
 
@@ -305,7 +273,7 @@ namespace wintouchemu {
                     // reset it since the event was consumed & propagated as touch
                     mouse_state.touch_event = 0;
                 }
-            } else if (!GRAPHICS_IIDX_WSUB) {
+            } else {
 
                 /*
                  * For some reason, Nostalgia won't show an active touch point unless a move event
@@ -380,21 +348,6 @@ namespace wintouchemu {
                 title = get_window_title(hWnd);
             }
 
-            // if a window title end is set, check to see if it matches
-            if (WINDOW_TITLE_END.has_value() && !string_ends_with(title.c_str(), WINDOW_TITLE_END.value().c_str())) {
-                hWnd = nullptr;
-                title = "";
-
-                for (auto &window : find_windows_beginning_with(WINDOW_TITLE_START)) {
-                    auto check_title = get_window_title(window);
-                    if (string_ends_with(check_title.c_str(), WINDOW_TITLE_END.value().c_str())) {
-                        hWnd = std::move(window);
-                        title = std::move(check_title);
-                        break;
-                    }
-                }
-            }
-
             // check window
             if (hWnd == nullptr) {
                 return;
@@ -402,21 +355,7 @@ namespace wintouchemu {
 
             // check if windowed
             if (GRAPHICS_WINDOWED) {
-                if (GRAPHICS_IIDX_WSUB) {
-                    // no handling is needed here
-                    // graphics::MoveWindow_hook will attach hook to windowed subscreen
-                    log_info("wintouchemu", "attach touch hook to windowed subscreen for TDJ");
-                    USE_MOUSE = false;
-                } else if (avs::game::is_model("LDJ") && !GENERIC_SUB_WINDOW_FULLSIZE) {
-                    // overlay subscreen in IIDX
-                    // use mouse position as ImGui overlay will block the touch window  
-                    log_info("wintouchemu", "use mouse cursor API for ldj overlay subscreen");
-                    USE_MOUSE = true;
-                } else if (games::popn::is_pikapika_model()) {
-                    // same as iidx case above
-                    log_info("wintouchemu", "use mouse cursor API for popn overlay subscreen");
-                    USE_MOUSE = true;
-                } else if (games::gitadora::is_arena_model() && GRAPHICS_PREVENT_SECONDARY_WINDOWS) {
+                if (games::gitadora::is_arena_model() && GRAPHICS_PREVENT_SECONDARY_WINDOWS) {
                     log_info("wintouchemu", "use mouse cursor API for gitadora overlay subscreen");
                     USE_MOUSE = true;
                 } else {

--- a/src/spice2x/misc/wintouchemu.h
+++ b/src/spice2x/misc/wintouchemu.h
@@ -11,9 +11,5 @@ namespace wintouchemu {
     extern bool ADD_TOUCH_FLAG_PRIMARY;
 
     void hook(const char *window_title, HMODULE module = nullptr, int delay_in_s=0);
-    void hook_title_ends(
-        const char *window_title_start,
-        const char *window_title_ends,
-        HMODULE module = nullptr);
     void update();
 }


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
Fixes #814

## Description of change
Remove iidx/sdvx/popon `native touch` options.

Remove dead code in wintouchemu that deals with these games.

Native touch is now at feature-parity with wintouchemu. Native touch options work better with touch screens, while rawinput-based wintouchemu has compat issues on some touchscreens. For these subscreen games deprecate the usage of wintouchemu and make them use native touch stack by default.

### For future consideration
Gitadora - not sure what to do with this one. We only use wintouchemu for the single window case. For all other configurations, the game accepts mouse and touch input without any hooks, so perhaps nothing needs to be done here.

Nostalgia - consider moving away from wintouchemu and adopt native touch hook here as well.

## Testing
WIP
