### PR TITLE
patcher: fix plus minus buttons for number patches

### DIFF
--- a/src/spice2x/overlay/windows/patch_manager.cpp
+++ b/src/spice2x/overlay/windows/patch_manager.cpp
@@ -936,14 +936,17 @@ namespace overlay::windows {
                             } else if (patch.type == patcher::PatchType::Integer) {
                                 set_patch_option_width();
                                 auto& numpatch = patch.patch_number;
-                                ImGui::InputInt("##int_input", &numpatch.value, 1, 10);
-                                if (ImGui::IsItemDeactivatedAfterEdit()) {
+                                const bool value_changed = ImGui::InputInt(
+                                    "##int_input", &numpatch.value, 1, 10);
+                                if (value_changed || ImGui::IsItemDeactivatedAfterEdit()) {
                                     numpatch.value = CLAMP(
                                             numpatch.value,
                                             numpatch.min,
                                             numpatch.max);
 
                                     patcher::apply_patch(patch, true);
+                                }
+                                if (ImGui::IsItemDeactivated()) {
                                     patcher::config_dirty = true;
                                 }
                                 if (ImGui::IsItemHovered(ImGui::TOOLTIP_FLAGS)) {


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
Reported by a certain sea reptile

## Description of change
Fix the + / - buttons for number patches not working. Regressed by one of the ImGui version updates.

## Testing
seems fine now