### PR TITLE
iidx: hide tdj sub screen in fullscreen single monitor mode

### DIFF
--- a/src/spice2x/hooks/graphics/graphics.cpp
+++ b/src/spice2x/hooks/graphics/graphics.cpp
@@ -939,6 +939,13 @@ static BOOL WINAPI ShowWindow_hook(HWND hWnd, int nCmdShow) {
         return true;
     }
 
+    if (games::iidx::TDJ_MODE &&
+        GRAPHICS_PREVENT_SECONDARY_WINDOWS &&
+        hWnd == TDJ_SUBSCREEN_WINDOW) {
+        log_info("graphics", "ShowWindow_hook - hiding sub window {}", fmt::ptr(hWnd));
+        return true;
+    }
+
     // call original
     return ShowWindow_orig(hWnd, nCmdShow);
 }

--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -379,6 +379,7 @@ int main_implementation(int argc, char *argv[]) {
     }
     if (options[launcher::Options::spice2x_IIDXNoSub].value_bool()) {
         GRAPHICS_FORCE_SINGLE_ADAPTER = true;
+        GRAPHICS_PREVENT_SECONDARY_WINDOWS = true;
     }
     if (options[launcher::Options::spice2x_SDVXNoSub].value_bool()) {
         GRAPHICS_FORCE_SINGLE_ADAPTER = true;


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
n/a

## Description of change
Prevent the game from launching a blank window when launching fullscreen with sub disabled.

## Testing
