### PR TITLE
sdvx: fix check for enable_console in avs_config.xml

### DIFF
--- a/src/spice2x/avs/core.cpp
+++ b/src/spice2x/avs/core.cpp
@@ -1924,7 +1924,7 @@ namespace avs {
 #if !SPICE64
             // sdvx4 bad log config fix
             if (avs::game::DLL_NAME == "soundvoltex.dll" &&  // it's too early for avs::game::is_model
-                property_search_safe(config, config_node, "/log/enable_console")) {
+                property_search(config, config_node, "/log/enable_console")) {
                 log_info("avs-core", "applying SDVX4 avs-config.xml fix for <log><enable_console>");
                 property_search_remove_safe(config, config_node, "/log/enable_console");
             }


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
Regressed by #657 

## Description of change
Workaround for SDVX4 was applied too broadly and caused sdvx 1/2/3 to not boot, depending on contents of avs-config.xml.

`property_search_safe` throws a fatal error if the node is not present. What we wanted to do was to check for presence. 

## Testing
sanity checked sdvx 1/2/3/4