### PR TITLE
overlay: mouse-as-touch needs to check if subscreen window is active

### DIFF
--- a/src/spice2x/misc/wintouchemu.cpp
+++ b/src/spice2x/misc/wintouchemu.cpp
@@ -495,6 +495,14 @@ namespace wintouchemu {
         if (hWnd != nullptr && USE_MOUSE) {
             bool button_pressed = get_async_primary_mouse();
 
+            // while the subscreen overlay is hidden, treat the mouse button as released;
+            // this ends any active mouse touch and prevents new mouse touch contacts
+            if (overlay::OVERLAY &&
+                overlay::OVERLAY->has_subscreen_touch_transform() &&
+                !overlay::OVERLAY->is_subscreen_overlay_visible()) {
+                button_pressed = false;
+            }
+
             // if there was a touch event in the last 500 ms, don't insert new button presses
             if (button_pressed && (now - last_touch_event) < 500) {
                 button_pressed = false;

--- a/src/spice2x/misc/wintouchemu.cpp
+++ b/src/spice2x/misc/wintouchemu.cpp
@@ -495,11 +495,11 @@ namespace wintouchemu {
         if (hWnd != nullptr && USE_MOUSE) {
             bool button_pressed = get_async_primary_mouse();
 
-            // while the subscreen overlay is hidden, treat the mouse button as released;
-            // this ends any active mouse touch and prevents new mouse touch contacts
+            // while the subscreen overlay cannot accept the mouse, treat the button as
+            // released; this ends any active touch and prevents new mouse touch contacts
             if (overlay::OVERLAY &&
                 overlay::OVERLAY->has_subscreen_touch_transform() &&
-                !overlay::OVERLAY->is_subscreen_overlay_visible()) {
+                !overlay::OVERLAY->accepts_subscreen_mouse_input()) {
                 button_pressed = false;
             }
 

--- a/src/spice2x/overlay/overlay.cpp
+++ b/src/spice2x/overlay/overlay.cpp
@@ -908,6 +908,13 @@ bool overlay::SpiceOverlay::get_active() {
     return this->active;
 }
 
+bool overlay::SpiceOverlay::is_subscreen_overlay_visible() {
+    return this->get_active() &&
+        this->window_sub != nullptr &&
+        this->window_sub->get_active() &&
+        this->window_sub->accepts_mouse_input();
+}
+
 bool overlay::SpiceOverlay::has_focus() {
     return this->get_active() && ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow);
 }

--- a/src/spice2x/overlay/overlay.cpp
+++ b/src/spice2x/overlay/overlay.cpp
@@ -911,8 +911,12 @@ bool overlay::SpiceOverlay::get_active() {
 bool overlay::SpiceOverlay::is_subscreen_overlay_visible() {
     return this->get_active() &&
         this->window_sub != nullptr &&
-        this->window_sub->get_active() &&
-        this->window_sub->accepts_mouse_input();
+        this->window_sub->get_active();
+}
+
+bool overlay::SpiceOverlay::accepts_subscreen_mouse_input() {
+    return this->is_subscreen_overlay_visible() &&
+        this->window_sub->is_mouse_hovered();
 }
 
 bool overlay::SpiceOverlay::has_focus() {

--- a/src/spice2x/overlay/overlay.h
+++ b/src/spice2x/overlay/overlay.h
@@ -109,6 +109,7 @@ namespace overlay {
         void show_main_menu();
         void set_active(bool active);
         bool get_active();
+        bool is_subscreen_overlay_visible();
         bool has_focus();
         bool hotkeys_triggered();
 
@@ -143,20 +144,20 @@ namespace overlay {
             return this->hWnd;
         }
 
-        bool can_transform_touch_input() {
-            return (this->subscreen_mouse_handler != nullptr);
+        bool has_subscreen_touch_transform() {
+            return (this->subscreen_touch_transform != nullptr);
         }
 
         bool transform_touch_point(LONG *x, LONG *y) {
-            if (this->get_active() && this->subscreen_mouse_handler) {
-                return this->subscreen_mouse_handler(x, y);
+            if (this->is_subscreen_overlay_visible() && this->subscreen_touch_transform) {
+                return this->subscreen_touch_transform(x, y);
             } else {
                 return true;
             }
         }
 
-        void set_subscreen_mouse_handler(const std::function<bool(LONG *, LONG *)> &f) {
-            this->subscreen_mouse_handler = f;
+        void set_subscreen_touch_transform(const std::function<bool(LONG *, LONG *)> &f) {
+            this->subscreen_touch_transform = f;
         }
 
         // renderer
@@ -203,7 +204,7 @@ namespace overlay {
 
         std::vector<std::unique_ptr<Window>> windows;
 
-        std::function<bool(LONG *, LONG *)> subscreen_mouse_handler = nullptr;
+        std::function<bool(LONG *, LONG *)> subscreen_touch_transform = nullptr;
 
         bool active = false;
         bool toggle_down = false;

--- a/src/spice2x/overlay/overlay.h
+++ b/src/spice2x/overlay/overlay.h
@@ -109,7 +109,6 @@ namespace overlay {
         void show_main_menu();
         void set_active(bool active);
         bool get_active();
-        bool is_subscreen_overlay_visible();
         bool accepts_subscreen_mouse_input();
         bool has_focus();
         bool hotkeys_triggered();
@@ -218,6 +217,7 @@ namespace overlay {
         // so render() never runs without a matching NewFrame.
         bool has_pending_frame = false;
 
+        bool is_subscreen_overlay_visible();
         void init();
         void add_font(const char* font, ImFontConfig* config, const ImWchar* glyphs);
     };

--- a/src/spice2x/overlay/overlay.h
+++ b/src/spice2x/overlay/overlay.h
@@ -110,6 +110,7 @@ namespace overlay {
         void set_active(bool active);
         bool get_active();
         bool is_subscreen_overlay_visible();
+        bool accepts_subscreen_mouse_input();
         bool has_focus();
         bool hotkeys_triggered();
 
@@ -149,7 +150,7 @@ namespace overlay {
         }
 
         bool transform_touch_point(LONG *x, LONG *y) {
-            if (this->is_subscreen_overlay_visible() && this->subscreen_touch_transform) {
+            if (this->get_active() && this->subscreen_touch_transform) {
                 return this->subscreen_touch_transform(x, y);
             } else {
                 return true;

--- a/src/spice2x/overlay/window.cpp
+++ b/src/spice2x/overlay/window.cpp
@@ -69,6 +69,7 @@ void overlay::Window::build() {
 
     // check if active
     if (!this->active) {
+        this->mouse_hovered = false;
         return;
     }
 
@@ -112,7 +113,7 @@ void overlay::Window::build() {
                 this->flags | ImGuiWindowFlags_NoFocusOnAppearing);
 
         // cache whether this window is the topmost mouse target
-        this->mouse_input_accepted =
+        this->mouse_hovered =
             ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows);
 
         if (build_contents) {
@@ -159,6 +160,9 @@ void overlay::Window::build() {
         }
 
     } else {
+
+        // raw content does not have an ImGui window to hover
+        this->mouse_hovered = false;
 
         // add raw content
         this->build_content();
@@ -208,6 +212,6 @@ bool overlay::Window::get_active() {
     return this->active;
 }
 
-bool overlay::Window::accepts_mouse_input() {
-    return this->active && this->mouse_input_accepted;
+bool overlay::Window::is_mouse_hovered() {
+    return this->mouse_hovered;
 }

--- a/src/spice2x/overlay/window.cpp
+++ b/src/spice2x/overlay/window.cpp
@@ -112,9 +112,11 @@ void overlay::Window::build() {
                 &this->active,
                 this->flags | ImGuiWindowFlags_NoFocusOnAppearing);
 
-        // cache whether this window is the topmost mouse target
+        // keep the window hovered while its invisible input button is held during a drag
         this->mouse_hovered =
-            ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows);
+            ImGui::IsWindowHovered(
+                ImGuiHoveredFlags_RootAndChildWindows |
+                ImGuiHoveredFlags_AllowWhenBlockedByActiveItem);
 
         if (build_contents) {
 

--- a/src/spice2x/overlay/window.cpp
+++ b/src/spice2x/overlay/window.cpp
@@ -106,10 +106,16 @@ void overlay::Window::build() {
         // top spot. suppress that so only an explicit focus request (see below)
         // decides what comes to the front.
         const std::string window_id = this->title + "###" + to_string(this);
-        if (ImGui::Begin(
+        const bool build_contents = ImGui::Begin(
                 window_id.c_str(),
                 &this->active,
-                this->flags | ImGuiWindowFlags_NoFocusOnAppearing)) {
+                this->flags | ImGuiWindowFlags_NoFocusOnAppearing);
+
+        // cache whether this window is the topmost mouse target
+        this->mouse_input_accepted =
+            ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows);
+
+        if (build_contents) {
 
             // window attributes - init_pos / init_size are only honored once
             // (ImGuiCond_Once), so compute them a single time instead of every frame
@@ -200,4 +206,8 @@ bool overlay::Window::get_active() {
 
     // now it depends on us
     return this->active;
+}
+
+bool overlay::Window::accepts_mouse_input() {
+    return this->active && this->mouse_input_accepted;
 }

--- a/src/spice2x/overlay/window.h
+++ b/src/spice2x/overlay/window.h
@@ -24,6 +24,7 @@ namespace overlay {
         void toggle_active();
         void set_active(bool active);
         bool get_active();
+        bool accepts_mouse_input();
 
         // raise this window to the top of the z-order on its next build. only
         // call in response to an explicit user action (keyboard toggle, UI
@@ -37,6 +38,7 @@ namespace overlay {
         // set when the window transitions to visible so build() raises it to the
         // top of the z-order on the next frame
         bool request_focus = false;
+        bool mouse_input_accepted = false;
         std::vector<Window*> children;
 
         // settings

--- a/src/spice2x/overlay/window.h
+++ b/src/spice2x/overlay/window.h
@@ -24,7 +24,7 @@ namespace overlay {
         void toggle_active();
         void set_active(bool active);
         bool get_active();
-        bool accepts_mouse_input();
+        bool is_mouse_hovered();
 
         // raise this window to the top of the z-order on its next build. only
         // call in response to an explicit user action (keyboard toggle, UI
@@ -38,7 +38,7 @@ namespace overlay {
         // set when the window transitions to visible so build() raises it to the
         // top of the z-order on the next frame
         bool request_focus = false;
-        bool mouse_input_accepted = false;
+        bool mouse_hovered = false;
         std::vector<Window*> children;
 
         // settings

--- a/src/spice2x/overlay/windows/generic_sub.cpp
+++ b/src/spice2x/overlay/windows/generic_sub.cpp
@@ -42,7 +42,7 @@ namespace overlay::windows {
         this->texture_width = 0;
         this->texture_height = 0;
 
-        overlay->set_subscreen_mouse_handler([this](LONG *x, LONG *y) -> bool {
+        overlay->set_subscreen_touch_transform([this](LONG *x, LONG *y) -> bool {
             // convert to normalized form (relative window coordinates 0.f-1.f)
             ImVec2 xy;
 

--- a/src/spice2x/touch/native/inject_mouse.cpp
+++ b/src/spice2x/touch/native/inject_mouse.cpp
@@ -41,7 +41,7 @@ namespace nativetouch::inject {
         }
 
         POINT transformed = *position;
-        return transform::screen_to_game(window, &transformed);
+        return transform::mouse_to_game(window, &transformed);
     }
 
     // release the active injected contact and its window capture
@@ -108,7 +108,7 @@ namespace nativetouch::inject {
         }
 
         POINT transformed = position;
-        if (!transform::screen_to_game(window, &transformed)) {
+        if (!transform::mouse_to_game(window, &transformed)) {
             end_mouse_contact(window);
             return;
         }

--- a/src/spice2x/touch/native/transform.cpp
+++ b/src/spice2x/touch/native/transform.cpp
@@ -67,7 +67,7 @@ namespace nativetouch::transform {
 
     static bool has_active_overlay_transform() {
         return overlay::OVERLAY != nullptr &&
-            overlay::OVERLAY->is_subscreen_overlay_visible() &&
+            overlay::OVERLAY->get_active() &&
             overlay::OVERLAY->has_subscreen_touch_transform();
     }
 
@@ -128,11 +128,11 @@ namespace nativetouch::transform {
         }
 
         // if this game has a subscreen overlay that can transform touch input
-        // but the window is not visible, reject mouse-as-touch
+        // but the window is hidden or not under the cursor, reject mouse-as-touch
         // (e.g., iidx/sdvx are rejected here, but nostalgia is allowed)
         if (overlay::OVERLAY != nullptr &&
             overlay::OVERLAY->has_subscreen_touch_transform() &&
-            !overlay::OVERLAY->is_subscreen_overlay_visible()) {
+            !overlay::OVERLAY->accepts_subscreen_mouse_input()) {
             return false;
         }
 

--- a/src/spice2x/touch/native/transform.cpp
+++ b/src/spice2x/touch/native/transform.cpp
@@ -67,8 +67,8 @@ namespace nativetouch::transform {
 
     static bool has_active_overlay_transform() {
         return overlay::OVERLAY != nullptr &&
-            overlay::OVERLAY->get_active() &&
-            overlay::OVERLAY->can_transform_touch_input();
+            overlay::OVERLAY->is_subscreen_overlay_visible() &&
+            overlay::OVERLAY->has_subscreen_touch_transform();
     }
 
     static bool transform_overlay_touch_position(POINT *position) {
@@ -118,6 +118,25 @@ namespace nativetouch::transform {
 
         // ask the overlay to transform the touch point into game coordinates
         return transform_overlay_touch_position(position);
+    }
+
+    bool mouse_to_game(HWND window, POINT *position) {
+
+        // exception: iidx tdj dedicated subscreen window is allowed
+        if (is_tdj_dedicated_subscreen(window)) {
+            return screen_to_game(window, position);
+        }
+
+        // if this game has a subscreen overlay that can transform touch input
+        // but the window is not visible, reject mouse-as-touch
+        // (e.g., iidx/sdvx are rejected here, but nostalgia is allowed)
+        if (overlay::OVERLAY != nullptr &&
+            overlay::OVERLAY->has_subscreen_touch_transform() &&
+            !overlay::OVERLAY->is_subscreen_overlay_visible()) {
+            return false;
+        }
+
+        return screen_to_game(window, position);
     }
 
     // route hardware screen coordinates through dedicated or overlay mapping and report the result

--- a/src/spice2x/touch/native/transform.h
+++ b/src/spice2x/touch/native/transform.h
@@ -12,5 +12,6 @@ namespace nativetouch::transform {
     bool is_tdj_dedicated_subscreen(HWND window);
     bool game_to_screen(HWND window, POINT *position);
     bool screen_to_game(HWND window, POINT *position);
+    bool mouse_to_game(HWND window, POINT *position);
     Result hardware_to_game(POINT *position);
 }

--- a/src/spice2x/touch/touch.cpp
+++ b/src/spice2x/touch/touch.cpp
@@ -944,7 +944,7 @@ void touch_get_points(std::vector<TouchPoint> &touch_points, bool overlay) {
     if (!overlay &&
         overlay::OVERLAY &&
         overlay::OVERLAY->get_active() &&
-        !overlay::OVERLAY->can_transform_touch_input() &&
+        !overlay::OVERLAY->has_subscreen_touch_transform() &&
         ImGui::GetIO().WantCaptureMouse) {
 
         return;
@@ -971,7 +971,7 @@ void touch_get_events(std::vector<TouchEvent> &touch_events, bool overlay) {
     if (!overlay &&
         overlay::OVERLAY &&
         overlay::OVERLAY->get_active() &&
-        !overlay::OVERLAY->can_transform_touch_input() &&
+        !overlay::OVERLAY->has_subscreen_touch_transform() &&
         ImGui::GetIO().WantCaptureMouse) {
 
         TOUCH_EVENTS.reset();


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
Fixes #840 

## Description of change
Currently, for subscreen games, mouse events are still delivered even when the subscreen overlay window is not visible.

Change this so that the subscreen overlay must be active and under the mouse cursor for the mouse-to-touch transformation to occur. Applies to both native and wintouchemu.

## Testing
Needs to test everything again..

iidx:

- [ ]  full screen with overlay
- [ ]  single window with overlay
- [ ]  two window

Test: mouse, poke, api, real touch screen

sdvx:

- [ ] full screen with overlay
- [ ] windowed

popn

- [x] full screen with overlay
- [x] window with overlay
- [x] dedicated window

gitadora

- [x] single window with overlay
- [x] dedicated sub window

nostalgia

- [x] fullscreen
- [x] windowed

test: poke

wintouchemu
- [x] Do all of the above again with wintouchemu