### PR TITLE
sdvx: re-enable landscape mode

### DIFF
--- a/src/spice2x/hooks/graphics/backends/d3d9/d3d9_device.cpp
+++ b/src/spice2x/hooks/graphics/backends/d3d9/d3d9_device.cpp
@@ -1239,7 +1239,36 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DDevice9::GetViewport(
         D3DVIEWPORT9 *pViewport)
 {
     WRAP_DEBUG;
-    CHECK_RESULT(pReal->GetViewport(pViewport));
+    const auto result = pReal->GetViewport(pViewport);
+
+    // SDVX landscape mode
+    // without this, the game calculates the camera angle incorrectly and
+    // ends up with zoomed out view of the lanes
+    const auto landscape_width = GRAPHICS_FS_CUSTOM_RESOLUTION.has_value() ?
+        GRAPHICS_FS_CUSTOM_RESOLUTION.value().first : GRAPHICS_FS_ORIGINAL_HEIGHT;
+    const auto landscape_height = GRAPHICS_FS_CUSTOM_RESOLUTION.has_value() ?
+        GRAPHICS_FS_CUSTOM_RESOLUTION.value().second : GRAPHICS_FS_ORIGINAL_WIDTH;
+    if (SUCCEEDED(result) &&
+        GRAPHICS_FS_ORIENTATION_SWAP &&
+        avs::game::is_model("KFC") &&
+        pViewport != nullptr &&
+        pViewport->Width == landscape_width &&
+        pViewport->Height == landscape_height) {
+
+        static std::once_flag log_once;
+        std::call_once(log_once, [pViewport]() {
+            log_info(
+                "graphics::d3d9",
+                "SDVX landscape viewport fix: {}x{} => {}x{}",
+                pViewport->Width,
+                pViewport->Height,
+                pViewport->Height,
+                pViewport->Width);
+        });
+        std::swap(pViewport->Width, pViewport->Height);
+    }
+
+    return result;
 }
 
 HRESULT STDMETHODCALLTYPE WrappedIDirect3DDevice9::SetMaterial(

--- a/src/spice2x/hooks/graphics/graphics.cpp
+++ b/src/spice2x/hooks/graphics/graphics.cpp
@@ -17,6 +17,7 @@
 #include "games/ddr/ddr.h"
 #include "games/gitadora/gitadora.h"
 #include "games/iidx/iidx.h"
+#include "games/sdvx/sdvx.h"
 #include "games/popn/popn.h"
 #include "hooks/graphics/backends/d3d9/d3d9_backend.h"
 #include "hooks/graphics/backends/d3d11/d3d11_backend.h"
@@ -1098,6 +1099,9 @@ static BOOL WINAPI ShowWindow_hook(HWND hWnd, int nCmdShow) {
         log_info("graphics", "ShowWindow_hook - hiding sub window {}", fmt::ptr(hWnd));
         return true;
     }
+
+    // note: doing the same for SDVX_SUBSCREEN_WINDOW seems to make the main
+    // screen stop drawing occasionally
 
     // call original
     return ShowWindow_orig(hWnd, nCmdShow);

--- a/src/spice2x/hooks/graphics/graphics.cpp
+++ b/src/spice2x/hooks/graphics/graphics.cpp
@@ -1100,9 +1100,6 @@ static BOOL WINAPI ShowWindow_hook(HWND hWnd, int nCmdShow) {
         return true;
     }
 
-    // note: doing the same for SDVX_SUBSCREEN_WINDOW seems to make the main
-    // screen stop drawing occasionally
-
     // call original
     return ShowWindow_orig(hWnd, nCmdShow);
 }

--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -1702,18 +1702,13 @@ int main_implementation(int argc, char *argv[]) {
         }
     }
 
-    // SDVXFullscreenLandscape disabled due to it messing with in-game camera angle
-    // FullscreenOrientationFlip continues to live on, however.
-    if (options[launcher::Options::SDVXFullscreenLandscape].value_bool() && !cfg::CONFIGURATOR_STANDALONE) {
-        log_fatal("launcher", "-sdvxlandscape removed due to a camera bug in SDVX!");
+    if (options[launcher::Options::SDVXFullscreenLandscape].value_bool() && !GRAPHICS_WINDOWED) {
+#if SPICE64
+        GRAPHICS_FS_ORIENTATION_SWAP = true;
+#else
+        log_warning("launcher", "-sdvxlandscape is not supported in 32-bit SDVX, ignoring...");
+#endif
     }
-//  if (options[launcher::Options::SDVXFullscreenLandscape].value_bool() && !GRAPHICS_WINDOWED) {
-// #if SPICE64
-//         GRAPHICS_FS_ORIENTATION_SWAP = true;
-// #else
-//         log_warning("launcher", "-sdvxlandscape is not supported in 32-bit SDVX, ignoring...");
-// #endif
-//   }
 
     if (options[launcher::Options::FullscreenOrientationFlip].value_bool() && !GRAPHICS_WINDOWED) {
         GRAPHICS_FS_ORIENTATION_SWAP = true;

--- a/src/spice2x/launcher/options.cpp
+++ b/src/spice2x/launcher/options.cpp
@@ -330,9 +330,8 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc =
             "Allows you to play portrait games in landscape (and vice versa) by transposing resolution and applying image scaling.\n\n"
             "Works great for some games, but can COMPLETELY BREAK other games - YMMV!\n\n"
-            "Strongly consider combining this with -forceres option to render at monitor native resolution\n\n"
-            "WARNING: for SDVX, this messes with camera angle for note lanes, causing it to be zoomed out, and causes performance issues "
-            "with Live2D!",
+            "Strongly consider combining this with -forceres option to render at monitor native resolution.\n\n"
+            "For SDVX, use the dedicated -sdvxlandscape option.",
         .type = OptionType::Bool,
         .hidden = true,
         .category = "Full Screen Settings"
@@ -3014,17 +3013,17 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
     },
     {
         // SDVXFullscreenLandscape
-        .title = "(DISABLED) SDVX Landscape Mode (SDVX5+)",
+        .title = "SDVX Full Screen Landscape Mode (SDVX5+)",
         .name = "sdvxlandscape",
         .desc =
-            "Option HIDDEN and DISABLED due to it affecting in-game camera angle for displaying lanes.\n\n"
             "Allows you to play in landscape by transposing resolution and applying image scaling.\n\n"
-            "Works only for SDVX5 and above! This is identical to -forceresswap.\n\n"
+            "Corrects the in-game perspective camera for the transposed display aspect ratio.\n\n"
+            "Works only for SDVX5 and above.\n\n"
             "Will launch at 1080p by default; strongly consider combining this with -forceres option to render at monitor native resolution.",
         .type = OptionType::Bool,
-        .hidden = true,
         .game_name = "Sound Voltex",
         .category = "Game Options",
+        .quick_setting_category = "Game",
     },
     {
         // spice2x_EnableSMXStage


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
n/a

## Description of change
Un-deprecate SDVX landscape mode. The game calls `GetViewport` to figure out the camera position, so if we return a sane value the game goes back to rendering correctly.

## Testing
Tested nabla only
