### PR TITLE
gitadora: option to disable frame limiter

### DIFF
--- a/src/spice2x/games/gitadora/gitadora.cpp
+++ b/src/spice2x/games/gitadora/gitadora.cpp
@@ -31,6 +31,7 @@ namespace games::gitadora {
 
     // settings
     bool TWOCHANNEL = false;
+    bool DISABLE_FRAME_LIMITER = false;
     std::optional<unsigned int> CAB_TYPE = std::nullopt;
     bool P1_LEFTY = false;
     bool P2_LEFTY = false;
@@ -64,6 +65,100 @@ namespace games::gitadora {
         }
 
         return CreateDirectoryA(lpPathName, lpSecurityAttributes);
+    }
+
+    // libshare-pj paces mainloop with separate 12 ms and 16 ms waits. these waits
+    // interfere with the game's normal display synchronization on modern Windows
+    // and can hold a nominal 60 FPS game near 58 FPS. locate the instruction
+    // sequences at runtime so the fix does not depend on per-version file offsets.
+    static void disable_mainloop_frame_limiter(HMODULE sharepj_module) {
+
+        // first limiter to wait for 12ms:
+        //
+        // 48 83 F8 0C:     cmp rax, 0Ch;  compare elapsed time with 12 ms
+        // 73 10:           jae +10h;      skip the wait when at least 12 ms elapsed
+        // B9 0C 00 00 00:  mov ecx, 0Ch;  load the 12 ms target
+        // 48 2B C8:        sub rcx, rax;  calculate the remaining wait time
+        // 74 06:           je +6h;        skip the following six-byte Sleep call if no wait remains
+        static constexpr unsigned char limiter_12ms_pattern[] = {
+            0x48, 0x83, 0xF8, 0x0C, 0x73, 0x10, 0xB9, 0x0C,
+            0x00, 0x00, 0x00, 0x48, 0x2B, 0xC8, 0x74, 0x06,
+        };
+
+        // second limiter to wait for 16ms:
+        //
+        // 48 83 F8 10:     cmp rax, 10h;  compare elapsed time with 16 ms
+        // 73 10:           jae +10h;      skip the wait when at least 16 ms elapsed
+        // B9 10 00 00 00:  mov ecx, 10h;  load the 16 ms target
+        // 48 2B C8:        sub rcx, rax;  calculate the remaining wait time
+        // 74 06:           je +6h;        skip the following six-byte Sleep call if no wait remains
+        static constexpr unsigned char limiter_16ms_pattern[] = {
+            0x48, 0x83, 0xF8, 0x10, 0x73, 0x10, 0xB9, 0x10,
+            0x00, 0x00, 0x00, 0x48, 0x2B, 0xC8, 0x74, 0x06,
+        };
+
+        // rax contains the elapsed frame time in milliseconds. changing jae (73h)
+        // to jmp (EBh) makes each block always take its existing skip path. this
+        // bypasses only the associated Sleep call and leaves other waits intact.
+        static constexpr unsigned char short_jump[] = { 0xEB };
+        static constexpr char pattern_mask[] = "XXXXXXXXXXXXXXXX";
+
+        if (!sharepj_module) {
+            return;
+        }
+
+        // find both complete blocks before writing either opcode. an unknown DLL
+        // therefore remains untouched instead of receiving only half of the fix.
+        const auto limiter_12ms = find_pattern(
+                sharepj_module,
+                limiter_12ms_pattern,
+                pattern_mask,
+                0,
+                0);
+        const auto limiter_16ms = find_pattern(
+                sharepj_module,
+                limiter_16ms_pattern,
+                pattern_mask,
+                0,
+                0);
+
+        if (!limiter_12ms || !limiter_16ms) {
+            log_warning(
+                "gitadora",
+                "failed to disable libshare-pj mainloop frame limiter - didn't find matches");
+            return;
+        }
+
+        // byte offset 4 is the jae opcode in each signature. usage 0 selects the
+        // first match, and the one-byte X mask writes only the replacement opcode;
+        // the existing 10h branch displacement remains unchanged.
+        const auto limiter_12ms_disabled = replace_pattern(
+                sharepj_module,
+                limiter_12ms_pattern,
+                pattern_mask,
+                4,
+                0,
+                short_jump,
+                "X");
+        const auto limiter_16ms_disabled = replace_pattern(
+                sharepj_module,
+                limiter_16ms_pattern,
+                pattern_mask,
+                4,
+                0,
+                short_jump,
+                "X");
+
+        if (!limiter_12ms_disabled || !limiter_16ms_disabled) {
+            log_warning(
+                "gitadora",
+                "failed to disable libshare-pj mainloop frame limiter - patch failed");
+            return;
+        }
+
+        log_info(
+            "gitadora",
+            "successfully disabled libshare-pj mainloop frame limiter");
     }
 #endif
 
@@ -687,6 +782,12 @@ namespace games::gitadora {
         HMODULE system_module = libutils::try_module("libsystem.dll");
 
         // patches
+#ifdef SPICE64
+        if (DISABLE_FRAME_LIMITER && !is_arena_model()) {
+            disable_mainloop_frame_limiter(sharepj_module);
+        }
+#endif
+
         detour::inline_hook((void *) eam_network_detected_ip_change, libutils::try_proc(
                 sharepj_module, "eam_network_detected_ip_change"));
         detour::inline_hook((void *) eam_network_settings_conflict, libutils::try_proc(

--- a/src/spice2x/games/gitadora/gitadora.cpp
+++ b/src/spice2x/games/gitadora/gitadora.cpp
@@ -72,93 +72,37 @@ namespace games::gitadora {
     // and can hold a nominal 60 FPS game near 58 FPS. locate the instruction
     // sequences at runtime so the fix does not depend on per-version file offsets.
     static void disable_mainloop_frame_limiter(HMODULE sharepj_module) {
-
-        // first limiter to wait for 12ms:
-        //
-        // 48 83 F8 0C:     cmp rax, 0Ch;  compare elapsed time with 12 ms
-        // 73 10:           jae +10h;      skip the wait when at least 12 ms elapsed
-        // B9 0C 00 00 00:  mov ecx, 0Ch;  load the 12 ms target
-        // 48 2B C8:        sub rcx, rax;  calculate the remaining wait time
-        // 74 06:           je +6h;        skip the following six-byte Sleep call if no wait remains
-        static constexpr unsigned char limiter_12ms_pattern[] = {
-            0x48, 0x83, 0xF8, 0x0C, 0x73, 0x10, 0xB9, 0x0C,
-            0x00, 0x00, 0x00, 0x48, 0x2B, 0xC8, 0x74, 0x06,
-        };
-
-        // second limiter to wait for 16ms:
-        //
-        // 48 83 F8 10:     cmp rax, 10h;  compare elapsed time with 16 ms
-        // 73 10:           jae +10h;      skip the wait when at least 16 ms elapsed
-        // B9 10 00 00 00:  mov ecx, 10h;  load the 16 ms target
-        // 48 2B C8:        sub rcx, rax;  calculate the remaining wait time
-        // 74 06:           je +6h;        skip the following six-byte Sleep call if no wait remains
-        static constexpr unsigned char limiter_16ms_pattern[] = {
-            0x48, 0x83, 0xF8, 0x10, 0x73, 0x10, 0xB9, 0x10,
-            0x00, 0x00, 0x00, 0x48, 0x2B, 0xC8, 0x74, 0x06,
-        };
-
-        // rax contains the elapsed frame time in milliseconds. changing jae (73h)
-        // to jmp (EBh) makes each block always take its existing skip path. this
-        // bypasses only the associated Sleep call and leaves other waits intact.
-        static constexpr unsigned char short_jump[] = { 0xEB };
-        static constexpr char pattern_mask[] = "XXXXXXXXXXXXXXXX";
-
         if (!sharepj_module) {
             return;
         }
 
-        // find both complete blocks before writing either opcode. an unknown DLL
-        // therefore remains untouched instead of receiving only half of the fix.
-        const auto limiter_12ms = find_pattern(
-                sharepj_module,
-                limiter_12ms_pattern,
-                pattern_mask,
-                0,
-                0);
-        const auto limiter_16ms = find_pattern(
-                sharepj_module,
-                limiter_16ms_pattern,
-                pattern_mask,
-                0,
-                0);
-
-        if (!limiter_12ms || !limiter_16ms) {
-            log_warning(
-                "gitadora",
-                "failed to disable libshare-pj mainloop frame limiter - didn't find matches");
-            return;
-        }
-
-        // byte offset 4 is the jae opcode in each signature. usage 0 selects the
-        // first match, and the one-byte X mask writes only the replacement opcode;
-        // the existing 10h branch displacement remains unchanged.
+        // both limiters have the same shape, only the millisecond target xx differs
+        // (0Ch for the 12 ms limiter, 10h for the 16 ms one):
+        //
+        // 48 83 F8 xx:     cmp rax, xx;   compare elapsed frame time with the target
+        // 73 10:           jae +10h;      skip the wait once the target has elapsed
+        // B9 xx 00 00 00:  mov ecx, xx;   load the target
+        // 48 2B C8:        sub rcx, rax;  calculate the remaining wait time
+        // 74 06:           je +6h;        skip the following six-byte Sleep call if no wait remains
+        //
+        // changing jae (73h) to jmp (EBh) makes each block always take its existing
+        // skip path, which bypasses only the associated Sleep call and leaves the 10h
+        // branch displacement and every other wait untouched.
         const auto limiter_12ms_disabled = replace_pattern(
                 sharepj_module,
-                limiter_12ms_pattern,
-                pattern_mask,
-                4,
-                0,
-                short_jump,
-                "X");
+                "4883F80C7310B90C000000482BC87406",
+                "????????EB??????????????????????", 0, 0);
         const auto limiter_16ms_disabled = replace_pattern(
                 sharepj_module,
-                limiter_16ms_pattern,
-                pattern_mask,
-                4,
-                0,
-                short_jump,
-                "X");
+                "4883F8107310B910000000482BC87406",
+                "????????EB??????????????????????", 0, 0);
 
         if (!limiter_12ms_disabled || !limiter_16ms_disabled) {
-            log_warning(
-                "gitadora",
-                "failed to disable libshare-pj mainloop frame limiter - patch failed");
+            log_warning("gitadora", "failed to disable libshare-pj mainloop frame limiter");
             return;
         }
 
-        log_info(
-            "gitadora",
-            "successfully disabled libshare-pj mainloop frame limiter");
+        log_info("gitadora", "successfully disabled libshare-pj mainloop frame limiter");
     }
 #endif
 

--- a/src/spice2x/games/gitadora/gitadora.cpp
+++ b/src/spice2x/games/gitadora/gitadora.cpp
@@ -98,11 +98,13 @@ namespace games::gitadora {
                 "????????EB??????????????????????", 0, 0);
 
         if (!limiter_12ms_disabled || !limiter_16ms_disabled) {
-            log_warning("gitadora", "failed to disable libshare-pj mainloop frame limiter");
+            log_fatal(
+                "gitadora",
+                "failed to disable libshare-pj mainloop frame limiter (-gdnoframelimiter), ensure patch is not already applied");
             return;
         }
 
-        log_info("gitadora", "successfully disabled libshare-pj mainloop frame limiter");
+        log_info("gitadora", "successfully disabled libshare-pj mainloop frame limiter (-gdnoframelimiter)");
     }
 #endif
 

--- a/src/spice2x/games/gitadora/gitadora.h
+++ b/src/spice2x/games/gitadora/gitadora.h
@@ -13,6 +13,7 @@ namespace games::gitadora {
 
     // settings
     extern bool TWOCHANNEL;
+    extern bool DISABLE_FRAME_LIMITER;
     extern std::optional<unsigned int> CAB_TYPE;
     extern bool P1_LEFTY;
     extern bool P2_LEFTY;

--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -644,6 +644,9 @@ int main_implementation(int argc, char *argv[]) {
     if (options[launcher::Options::LoadGitaDoraModule].value_bool()) {
         attach_gitadora = true;
     }
+    if (options[launcher::Options::GitaDoraDisableFrameLimiter].value_bool()) {
+        games::gitadora::DISABLE_FRAME_LIMITER = true;
+    }
     if (options[launcher::Options::GitaDoraCabinetType].is_active()) {
         games::gitadora::CAB_TYPE = options[launcher::Options::GitaDoraCabinetType].value_uint32();
     }

--- a/src/spice2x/launcher/options.cpp
+++ b/src/spice2x/launcher/options.cpp
@@ -1203,6 +1203,18 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .quick_setting_category = "Game",
     },
     {
+        .title = "GitaDora Disable Frame Limiter (EXPERIMENTAL)",
+        .name = "gdnoframelimiter",
+        .desc = "Only for GITADORA to GALAXY WAVE; not for XG series or Arena Model.\n\n"
+            "This disables game engine's built-in frame limiter, which can result in unstable frame pacing "
+            "(around 56-58 FPS) on modern Windows. Turning this on forces the game to rely on V-Sync "
+            "instead, resulting in stable FPS. Ensure your monitors are set to 60Hz.",
+        .type = OptionType::Bool,
+        .game_name = "GitaDora",
+        .category = "Game Options",
+        .quick_setting_category = "Game",
+    },
+    {
         .title = "GitaDora Cabinet Type",
         .name = "gdcabtype",
         .desc = "Select cabinet type. DX has more input and lights. Pick SD2 for single player guitar mode on white cab.",

--- a/src/spice2x/launcher/options.cpp
+++ b/src/spice2x/launcher/options.cpp
@@ -1206,9 +1206,10 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .title = "GitaDora Disable Frame Limiter (EXPERIMENTAL)",
         .name = "gdnoframelimiter",
         .desc = "Only for GITADORA to GALAXY WAVE; not for XG series or Arena Model.\n\n"
-            "This disables game engine's built-in frame limiter, which can result in unstable frame pacing "
-            "(around 56-58 FPS) on modern Windows. Turning this on forces the game to rely on V-Sync "
-            "instead, resulting in stable FPS. Ensure your monitors are set to 60Hz.",
+            "Game engine's built-in frame limiter can result in unstable frame pacing "
+            "(around 56-58 FPS) on modern Windows. Turning this on disables that and "
+            "forces the game to rely on V-Sync instead, resulting in a stable FPS.\n\n"
+            "Ensure your monitors are set to 60Hz.",
         .type = OptionType::Bool,
         .game_name = "GitaDora",
         .category = "Game Options",

--- a/src/spice2x/launcher/options.h
+++ b/src/spice2x/launcher/options.h
@@ -114,6 +114,7 @@ namespace launcher {
             LoadHelloPopnMusicModule,
             LoadGitaDoraModule,
             GitaDoraTwoChannelAudio,
+            GitaDoraDisableFrameLimiter,
             GitaDoraCabinetType,
             GitaDoraLefty,
             GitaDoraWailHold,


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
n/a

## Description of change
There is a patch for GITADORA series that fixes frame pacing on modern Windows. Turn it into a signature patch and embed it into the game.

## Testing
should work for all 64-bit gitadora versions, pre-GWD
