### PR TITLE
iidx: allow main window to receive touches in windows TDJ subscreen mode

### DIFF
--- a/src/spice2x/touch/native/inject.cpp
+++ b/src/spice2x/touch/native/inject.cpp
@@ -394,11 +394,10 @@ namespace nativetouch::inject {
     // preserve native registration and attach mouse injection to the touch window
     static BOOL WINAPI RegisterTouchWindowHook(HWND window, ULONG flags) {
 
-        // for TDJ in windowed subscreen mode, the main game window is
-        // target for delivering touch messages, not the subscreen
+        // TDJ handles touches on the main window, including contacts that the
+        // dedicated subscreen forwards there
         if (GRAPHICS_IIDX_WSUB && window != TDJ_SUBSCREEN_WINDOW) {
             touch_delivery_window.store(window, std::memory_order_release);
-            return TRUE;
         }
 
         // call original


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
n/a

## Description of change
This allows API touches to be recognized even if the main window is in focus.

## Testing
