### PR TITLE
iidx: don't hook legacy camera unless requested

### DIFF
--- a/src/spice2x/games/iidx/iidx.cpp
+++ b/src/spice2x/games/iidx/iidx.cpp
@@ -58,7 +58,7 @@ namespace games::iidx {
 
     // settings
     bool FLIP_CAMS = false;
-    std::optional<bool> DISABLE_CAMS;
+    cab_camera_access_mode CAB_CAMERA_ACCESS = cab_camera_access_mode::automatic;
     bool TDJ_CAMERA = false;
     bool TDJ_CAMERA_PREFER_16_9 = true;
     bool TDJ_MODE = false;
@@ -424,10 +424,7 @@ namespace games::iidx {
                 "RegQueryValueExA", RegQueryValueExA_hook, avs::game::DLL_INSTANCE);
 
         // check if cam hook should be enabled
-        if (!DISABLE_CAMS.has_value()) {
-            log_fatal("iidx", "assertion failure - DISABLE_CAMS not set during attach");
-        }
-        if (!DISABLE_CAMS.value()) {
+        if (CAB_CAMERA_ACCESS == cab_camera_access_mode::legacy) {
             init_legacy_camera_hook(FLIP_CAMS);
         }
 
@@ -454,19 +451,10 @@ namespace games::iidx {
             SetEnvironmentVariable("SCREEN_MODE", SCREEN_MODE.value().c_str());
         }
 
-        // check for cab camera access for the second time (first time was in launcher.cpp)
-        // this time, we are inside -iidx module hook, which means the user is likely NOT on a cab
-        // therefore, start with cams OFF by default, and allow user to forcibly override to ON
-        if (!games::iidx::DISABLE_CAMS.has_value()) {
-            games::iidx::DISABLE_CAMS = true;
-            if (options->at(launcher::Options::IIDXCabCamAccess).is_active() &&
-                options->at(launcher::Options::IIDXCabCamAccess).value_text() == "on") {
-                games::iidx::DISABLE_CAMS = false;
-            }
-            if (games::iidx::DISABLE_CAMS.value()) {
-                log_misc("iidx", "CONNECT_CAMERA env var set to 0");
-                SetEnvironmentVariable("CONNECT_CAMERA", "0");
-            }
+        // auto with iidx module means turn off camera (non-cab use)
+        if (CAB_CAMERA_ACCESS == cab_camera_access_mode::automatic) {
+            log_misc("iidx", "CONNECT_CAMERA env var set to 0");
+            SetEnvironmentVariable("CONNECT_CAMERA", "0");
         }
 
         // windowed subscreen, enabled by default, unless turned off by user

--- a/src/spice2x/games/iidx/iidx.h
+++ b/src/spice2x/games/iidx/iidx.h
@@ -11,6 +11,13 @@
 
 namespace games::iidx {
 
+    enum class cab_camera_access_mode {
+        automatic,
+        off,
+        on,
+        legacy,
+    };
+
     enum class iidx_aio_emulation_state {
         unknown,
         bi2a_com2,
@@ -20,7 +27,7 @@ namespace games::iidx {
     // settings
 
     extern bool FLIP_CAMS;
-    extern std::optional<bool> DISABLE_CAMS;
+    extern cab_camera_access_mode CAB_CAMERA_ACCESS;
     extern bool TDJ_CAMERA;
     extern bool TDJ_CAMERA_PREFER_16_9;
     extern std::optional<std::string> TDJ_CAMERA_OVERRIDE;

--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -524,22 +524,26 @@ int main_implementation(int argc, char *argv[]) {
         games::iidx::FLIP_CAMS = true;
     }
 
-    // IIDX CONNECT_CAMERA logic here for cases where user is running without -iidx module
-    // for now, we assume that user may be running on a cab
-    // (games::iidx::DISABLE_CAMS starts out as false unless user overrides)
-    // we will check again in IIDX module with a different default
-    assert(!games::iidx::DISABLE_CAMS.has_value());
-    if (options[launcher::Options::IIDXDisableCameras].value_bool()) {
-        games::iidx::DISABLE_CAMS = true;
+    // Resolve the IIDX camera policy here so it also applies without the -iidx module.
+    const auto &cab_camera_access = options[launcher::Options::IIDXCabCamAccess];
+    if (cab_camera_access.is_active()) {
+        const auto value = cab_camera_access.value_text();
+        if (value == "off") {
+            games::iidx::CAB_CAMERA_ACCESS = games::iidx::cab_camera_access_mode::off;
+        } else if (value == "on") {
+            games::iidx::CAB_CAMERA_ACCESS = games::iidx::cab_camera_access_mode::on;
+        } else if (value == "legacy") {
+            games::iidx::CAB_CAMERA_ACCESS = games::iidx::cab_camera_access_mode::legacy;
+        }
     }
-    if (options[launcher::Options::IIDXCabCamAccess].is_active() &&
-        options[launcher::Options::IIDXCabCamAccess].value_text() == "off") {
-        games::iidx::DISABLE_CAMS = true;
+
+    if (options[launcher::Options::IIDXDisableCameras].value_bool()) {
+        games::iidx::CAB_CAMERA_ACCESS = games::iidx::cab_camera_access_mode::off;
     }
     if (options[launcher::Options::IIDXCamHook].value_bool()) {
         games::iidx::TDJ_CAMERA = true;
         // Disable legacy behaviour to avoid conflict
-        games::iidx::DISABLE_CAMS = true;
+        games::iidx::CAB_CAMERA_ACCESS = games::iidx::cab_camera_access_mode::off;
     }
     // CONNECT_CAMERA env var will be set once logging is enabled
 
@@ -1717,14 +1721,13 @@ int main_implementation(int argc, char *argv[]) {
         GRAPHICS_FS_ORIENTATION_SWAP = true;
     }
 
-
-    // for cab usage - set environment variables (outside of -iidx module)
-    if (games::iidx::DISABLE_CAMS.has_value() &&
-        games::iidx::DISABLE_CAMS.value() &&
+    // apply an explicit off outside of the -iidx module so it also works on cabinets.
+    if (games::iidx::CAB_CAMERA_ACCESS == games::iidx::cab_camera_access_mode::off &&
         !cfg::CONFIGURATOR_STANDALONE) {
         log_misc("launcher::iidx", "CONNECT_CAMERA env var set to 0");
         SetEnvironmentVariable("CONNECT_CAMERA", "0");
     }
+
     if (games::iidx::SOUND_OUTPUT_DEVICE.has_value() &&
         games::iidx::SOUND_OUTPUT_DEVICE.value() != "auto" &&
         !cfg::CONFIGURATOR_STANDALONE) {

--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -5,7 +5,6 @@
 
 #include <cmath>
 #include <cstdlib>
-#include <assert.h>
 #include <shlwapi.h>
 #include <windows.h>
 #include <cfg/configurator.h>
@@ -542,7 +541,6 @@ int main_implementation(int argc, char *argv[]) {
     }
     if (options[launcher::Options::IIDXCamHook].value_bool()) {
         games::iidx::TDJ_CAMERA = true;
-        // Disable legacy behaviour to avoid conflict
         games::iidx::CAB_CAMERA_ACCESS = games::iidx::cab_camera_access_mode::off;
     }
     // CONNECT_CAMERA env var will be set once logging is enabled

--- a/src/spice2x/launcher/options.cpp
+++ b/src/spice2x/launcher/options.cpp
@@ -640,17 +640,21 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
     },
     {
         // IIDXCabCamAccess
-        .title = "IIDX Use Official AC Cams",
+        .title = "IIDX Official AC Camera Access",
         .name = "iidxcabcams",
-        .desc = "For IIDX25+, allow direct access to cameras from real arcade cabinets. "
-            "Only turn this on if you have OFFICIAL arcade cameras connected to the correct USB ports. Default: auto.",
+        .desc = "Controls how the game accesses USB cameras for IIDX 25+.\n\n"
+            "auto (default): use [off] when the IIDX module is enabled; otherwise, use [on].\n\n"
+            "on: game discovers and directly accesses cameras; requires official cameras on correct USB ports.\n\n"
+            "legacy: for IIDX 25/26 only; allow camera access with emulated discovery.\n\n"
+            "off: prevent game from accessing USB cameras.",
         .type = OptionType::Enum,
         .game_name = "Beatmania IIDX",
         .category = "Cab Peripherals",
         .elements = {
             {"auto", ""},
+            {"on", ""},
+            {"legacy", ""},
             {"off", ""},
-            {"on", ""}
         },
     },
     {


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
Fixes #855 

## Description of change
Legacy camera hooks are specifically for IIDX 25/26 and they only perform redirection of device discovery (emulates USB vendor/device ID and USB port). It has very limited use since most cameras are practically unusable in IIDX 25/26. Don't enable it, unless explicitly requested by the user.

New truth table for `-iidxcabcams` :

| Mode | `-iidx` off (cab setup) | `-iidx` on |
|---|---|---|
| `auto` | Native cameras enabled (same as `on`) | Cameras disabled (same as `off`) |
| `off` | Cameras disabled | Cameras disabled |
| `on` | Native cameras enabled | Native cameras enabled |
| `legacy` | Native cameras enabled | IIDX 25/26 discovery emulation enabled |

## Testing

