### PR TITLE
sdvx: fix api touch in windowed mode

### DIFF
--- a/src/spice2x/api/modules/touch.cpp
+++ b/src/spice2x/api/modules/touch.cpp
@@ -55,10 +55,12 @@ namespace api::modules {
         native_canvas_w = 0;
         native_canvas_h = 0;
         if (is_sdvx) {
-            // landscape API coordinates already match the primary screen orientation;
-            // portrait coordinates are rotated by apply_touch_errata
-            native_canvas_w = GRAPHICS_FS_ORIENTATION_SWAP ? 1920 : 1080;
-            native_canvas_h = GRAPHICS_FS_ORIENTATION_SWAP ? 1080 : 1920;
+            // windowed and landscape API coordinates already match the primary screen orientation;
+            // fullscreen portrait coordinates are rotated by apply_touch_errata
+            const bool landscape_coordinates =
+                GRAPHICS_WINDOWED || GRAPHICS_FS_ORIENTATION_SWAP;
+            native_canvas_w = landscape_coordinates ? 1920 : 1080;
+            native_canvas_h = landscape_coordinates ? 1080 : 1920;
         } else if (avs::game::is_model("LDJ")) {
             // TDJ subscreen; FHD models are upscaled to 1080p by apply_touch_errata
             native_canvas_w = is_tdj_fhd ? 1920 : 1280;
@@ -219,7 +221,7 @@ namespace api::modules {
             // the target of the touch events so just assume it's the sub screen
             x = x_raw * 1920 / 1280;
             y = y_raw * 1080 / 720;
-        } else if (is_sdvx && !GRAPHICS_FS_ORIENTATION_SWAP) {
+        } else if (is_sdvx && !GRAPHICS_WINDOWED && !GRAPHICS_FS_ORIENTATION_SWAP) {
             // rotate API coordinates into SDVX's portrait touch space
             x = 1080 - y_raw;
             y = x_raw;

--- a/src/spice2x/touch/native/transform.cpp
+++ b/src/spice2x/touch/native/transform.cpp
@@ -147,6 +147,12 @@ namespace nativetouch::transform {
             return screen_to_game(window, position);
         }
 
+        // exception: sdvx windowed subscreen does not use the subscreen overlay transform
+        if (GRAPHICS_WINDOWED && window == SDVX_SUBSCREEN_WINDOW) {
+            POINT client_position = *position;
+            return screen_to_game_client(window, &client_position);
+        }
+
         // if this game has a subscreen overlay that can transform touch input
         // but the window is hidden or not under the cursor, reject mouse-as-touch
         // (e.g., iidx/sdvx are rejected here, but nostalgia is allowed)


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
Fixes #858 

## Description of change
Fix orientation being wrong in windowed mode when API touch is used

Fix mouse no longer working when API client is in use.

This PR only affects windowed mode SDVX.

## Testing

