### PR TITLE
overlay: fix subscreen overlay rendering for popn

### DIFF
--- a/src/spice2x/overlay/windows/generic_sub.cpp
+++ b/src/spice2x/overlay/windows/generic_sub.cpp
@@ -25,6 +25,15 @@ namespace overlay::windows {
     const ImVec4 YELLOW(1.f, 1.f, 0.f, 1.f);
     const ImVec4 WHITE(1.f, 1.f, 1.f, 1.f);
 
+    // a subscreen is an already-composited backbuffer, so its alpha bits are not
+    // meaningful for display. Use AddImage's diffuse alpha (opaque by default)
+    // instead of the texture alpha while preserving ImGui's normal blend state.
+    static void ignore_texture_alpha(const ImDrawList *, const ImDrawCmd *command) {
+        auto device = static_cast<IDirect3DDevice9 *>(command->UserCallbackData);
+        device->SetTextureStageState(0, D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+        device->SetTextureStageState(0, D3DTSS_ALPHAOP, D3DTOP_SELECTARG2);
+    }
+
     GenericSubScreen::GenericSubScreen(SpiceOverlay *overlay) : Window(overlay), device(overlay->get_device()) {
         this->remove_window_padding = true;
         // ImGuiWindowFlags_NoBackground is needed as the background is drawn on top of the subscreen image
@@ -239,10 +248,13 @@ namespace overlay::windows {
         auto draw_list = this->draws_window
             ? ImGui::GetWindowDrawList()
             : ImGui::GetBackgroundDrawList();
+        draw_list->AddCallback(ignore_texture_alpha, this->device);
         draw_list->AddImage(
             reinterpret_cast<ImTextureID>(this->texture),
             overlay_content_top_left,
             bottom_right);
+        // following ImGui draws should resume normal texture-alpha modulation
+        draw_list->AddCallback(ImGui::GetPlatformIO().DrawCallback_ResetRenderState);
 
         if (this->draws_window) {
             // draw an invisible button so that it swallows mouse input


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
n/a

## Description of change
For popn HC, some transparency effects, like the one for touch feedback, rendered incorrectly; this is due to how alpha channel is handled for subscreen overlay drawing on top of ImGui.

## Testing
Tested popn and iidx.