### PR TITLE
build: speed up the deps image build for docker

### DIFF
--- a/src/spice2x/external/docker/Dockerfile
+++ b/src/spice2x/external/docker/Dockerfile
@@ -25,10 +25,13 @@ ENV PATH="$PATH:/opt/llvm-mingw-xp/bin"
 RUN curl -fsSL "https://github.com/mon/windows-dll-compat-checker/releases/download/v1.3/windows_dll_compat_checker-linux-x86_64.tar.xz" \
     | tar -xJ -C /usr/local/bin
 
-# libjpeg-turbo for JPEG encoding. Only the mingw-w64 toolchains get it;
-# the WinXP targets build without JPEG support entirely.
-RUN su user -c "yay --noconfirm -S mingw-w64-libjpeg-turbo"
+# The AUR mingw-w64 packages below are compiled from source, once per target arch,
+# and stock makepkg.conf builds serially. Sourced after /etc/makepkg.conf, so
+# OPTIONS+= layers onto the system defaults instead of replacing them.
+RUN printf '%s\n' 'MAKEFLAGS="-j$(nproc)"' "PKGEXT='.pkg.tar'" 'OPTIONS+=(!lto)' > /home/user/.makepkg.conf \
+    && chown user: /home/user/.makepkg.conf
 
-# x264 for the API H.264 video stream. Only the mingw-w64 toolchains need it;
-# the WinXP targets build without the stream encoder.
-RUN su user -c "yay --noconfirm -S mingw-w64-x264"
+# libjpeg-turbo for JPEG encoding, x264 for the API H.264 video stream. Only the
+# mingw-w64 toolchains get these; the WinXP targets build without JPEG support
+# and without the stream encoder.
+RUN su user -c "yay --noconfirm -S mingw-w64-libjpeg-turbo mingw-w64-x264"


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
#0

## Description of change

`mingw-w64-libjpeg-turbo` and `mingw-w64-x264` are AUR packages, so the deps image compiles them from source, once per mingw target arch. Stock `makepkg.conf` leaves `MAKEFLAGS` commented out and both PKGBUILDs call bare `make`, so all of that was building single-threaded.

Adds a `~/.makepkg.conf` for the build user:

- `MAKEFLAGS="-j$(nproc)"`: parallel compile. This is nearly all of the speedup.
- `PKGEXT='.pkg.tar'`: skips compressing a package that yay installs and discards immediately.
- `OPTIONS+=(!lto)`: no LTO link step. Both libraries get their speed from SIMD assembly, not cross-module optimization.

Using `~/.makepkg.conf` rather than `/etc` keeps the pacman-owned system file untouched and lets `OPTIONS+=` layer onto its defaults.

Also merges the two `yay` invocations into a single layer.

## Testing
