### PR TITLE
overlay: fix hotkey init race

### DIFF
--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -2483,7 +2483,6 @@ int main_implementation(int argc, char *argv[]) {
 
     // initialize raw input
     RI_MGR = std::make_unique<rawinput::RawInputManager>();
-    hotkeys::enable_raw_input();
     for (const auto &device : sextet_devices) {
         RI_MGR->sextet_register(device);
     }
@@ -2507,6 +2506,7 @@ int main_implementation(int argc, char *argv[]) {
     dump_analog_bindings();
 
     // mappings are ready; begin screenshot and coin polling during late startup
+    hotkeys::enable_raw_input();
     hotkeys::enable_input();
 
     // for certain games, show cursor if no touch is available (must be called after RI_MGR is available)


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
Regressed by #864

## Description of change
The hotkey sampler thread starts touching `games::io` the moment `enable_raw_input()` is called, and that call sat right after `RI_MGR` was constructed, a few lines before the main thread's own first `games::io` calls. Both threads then hit the unsynchronized lazy `initialize()` at once, crashing at startup with an access violation in `memcmp`.

Moved the call down next to `enable_input()`, after the bindings are built.

## Testing
