### PR TITLE
gitadora: fix 32bit gfdm coin button not working

### DIFF
--- a/src/spice2x/misc/device.cpp
+++ b/src/spice2x/misc/device.cpp
@@ -285,8 +285,10 @@ static int __cdecl device_read_secplug(int a1, int a2, int a3) {
     return 1;
 }
 
-static int __cdecl device_set_coinblocker_open(char number, char open) {
-    return 0;
+static void __cdecl device_set_coinblocker_open(char slot1_open, char slot2_open) {
+    // libdevice exposes one open flag per coin slot. Since spice has a shared
+    // software coin stock, consider it blocked only when both slots are closed.
+    eamuse_coin_set_block(!slot1_open && !slot2_open);
 }
 
 static void __cdecl device_set_coincounter_merge() {
@@ -617,7 +619,9 @@ void spicedevice_attach() {
     detour::inline_hook((void *) device_finalize, libutils::try_proc_list(
             DEVICE_INSTANCE, {"device_finalize", "?device_finalize@@YAXXZ"}));
     detour::inline_hook((void *) device_get_coinstock, libutils::try_proc_list(
-            DEVICE_INSTANCE, {"device_get_coinstock", "?device_get_coinstock@@YAXPEAG0@Z"}));
+            DEVICE_INSTANCE, {"device_get_coinstock",
+                              "?device_get_coinstock@@YAXPEAG0@Z",
+                              "?device_get_coinstock@@YAXPAG0@Z"}));
     detour::inline_hook((void *) device_get_coinstock_all, libutils::try_proc_list(
             DEVICE_INSTANCE, {"device_get_coinstock_all",
                               "?device_get_coinstock_all@@YAXPEAG0@Z",


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
#0

## Description of change
Fix Add Coin/COIN button not actuated after pressing

## Testing
*XG2*
<img width="1594" height="458" alt="XG2" src="https://github.com/user-attachments/assets/0d90ffaf-b0a0-421f-8986-5d87040ace93" />

*XG3*
<img width="1594" height="458" alt="XG3" src="https://github.com/user-attachments/assets/e326fd91-3477-44ed-854b-4160cf0f103a" />
