### PR TITLE
drs: hook down movement, adjust touch hooks

### DIFF
--- a/src/spice2x/CMakeLists.txt
+++ b/src/spice2x/CMakeLists.txt
@@ -520,6 +520,7 @@ set(SOURCE_FILES ${SOURCE_FILES}
         games/scotto/io.cpp
         games/drs/drs.cpp
         games/drs/io.cpp
+        games/drs/motion_cam.cpp
         games/drs/rgb_cam.cpp
         games/we/we.cpp
         games/we/io.cpp

--- a/src/spice2x/games/drs/drs.cpp
+++ b/src/spice2x/games/drs/drs.cpp
@@ -9,6 +9,8 @@
 #include "util/logging.h"
 #include "util/precise_timer.h"
 #include "util/memutils.h"
+#include "util/sigscan.h"
+#include "io.h"
 #include "rgb_cam.h"
 
 #pragma pack(push)
@@ -270,6 +272,60 @@ namespace games::drs {
         t.detach();
     }
 
+    /*
+     * DOWN motion
+     *
+     * The cabinet detects a squat with an Intel RealSense SR300 depth camera. Its driver is
+     * compiled into the game DLL rather than being a separate library, so there is no import to
+     * replace; the whole pipeline is reached instead at its single exit point,
+     * CInputManager::IsDown, which CNote::Update calls for every DOWN note in its judge window.
+     *
+     * IsDown reports whether the smoothed player height was falling on this frame or the previous
+     * one. Without a camera the height reading never changes, so the state is permanently "stable"
+     * and no DOWN note can ever be hit. Reading the two state ints and OR-ing a button in keeps
+     * real hardware working for anyone who has it.
+     */
+    static const int32_t *MOTION_STATE = nullptr;
+    static const int32_t *MOTION_STATE_PREV = nullptr;
+    static const int32_t MOTION_STATE_DOWN = 2;
+
+    static bool InputManager_IsDown(void *) {
+        if (*MOTION_STATE == MOTION_STATE_DOWN || *MOTION_STATE_PREV == MOTION_STATE_DOWN) {
+            return true;
+        }
+
+        auto &buttons = get_buttons();
+
+        return GameAPI::Buttons::getState(RI_MGR, buttons.at(Buttons::DownMotion));
+    }
+
+    static void init_down_motion_hook() {
+
+        // cmp [rip+prev], 2 / je / cmp [rip+cur], 2 / jne / mov al, 1 / ret / xor al, al / ret
+        auto address = reinterpret_cast<uint8_t *>(find_pattern(
+                avs::game::DLL_INSTANCE,
+                "833D0000000002740C833D00000000027503B001C332C0C3",
+                "XX????XXXXX????XXXXXXXXX",
+                0, 0));
+
+        if (address == nullptr) {
+            log_warning("drs", "motion sensor state not found, DOWN motion button unavailable");
+            return;
+        }
+
+        // resolve both rip-relative operands before the detour overwrites them
+        MOTION_STATE_PREV = (const int32_t *) (address + 7 + *(int32_t *) (address + 2));
+        MOTION_STATE = (const int32_t *) (address + 16 + *(int32_t *) (address + 11));
+
+        // build the button list here so the hook never races on it from the game thread
+        get_buttons();
+
+        detour::inline_hook((void *) InputManager_IsDown, address);
+
+        log_info("drs", "hooked DOWN motion detection at +{:#x}",
+                (size_t) (address - (uint8_t *) avs::game::DLL_INSTANCE));
+    }
+
     DRSGame::DRSGame() : Game("DANCERUSH") {
     }
 
@@ -317,6 +373,8 @@ namespace games::drs {
         } else {
             log_info("drs", "no native input method detected");
         }
+
+        init_down_motion_hook();
 
         if (RGB_CAMERA_HOOK) {
             init_rgb_camera_hook();

--- a/src/spice2x/games/drs/drs.cpp
+++ b/src/spice2x/games/drs/drs.cpp
@@ -317,7 +317,7 @@ namespace games::drs {
 
             start_touch();
         } else {
-            log_info("drs", "touch input for dnace floor disabled");
+            log_info("drs", "touch input for dance floor disabled");
         }
 
         init_down_motion_hook();

--- a/src/spice2x/games/drs/drs.cpp
+++ b/src/spice2x/games/drs/drs.cpp
@@ -9,8 +9,8 @@
 #include "util/logging.h"
 #include "util/precise_timer.h"
 #include "util/memutils.h"
-#include "util/sigscan.h"
 #include "io.h"
+#include "motion_cam.h"
 #include "rgb_cam.h"
 
 #pragma pack(push)
@@ -272,106 +272,52 @@ namespace games::drs {
         t.detach();
     }
 
-    /*
-     * DOWN motion
-     *
-     * The cabinet detects a squat with an Intel RealSense SR300 depth camera. Its driver is
-     * compiled into the game DLL rather than being a separate library, so there is no import to
-     * replace; the whole pipeline is reached instead at its single exit point,
-     * CInputManager::IsDown, which CNote::Update calls for every DOWN note in its judge window.
-     *
-     * IsDown reports whether the smoothed player height was falling on this frame or the previous
-     * one. Without a camera the height reading never changes, so the state is permanently "stable"
-     * and no DOWN note can ever be hit. Reading the two state ints and OR-ing a button in keeps
-     * real hardware working for anyone who has it.
-     */
-    static const int32_t *MOTION_STATE = nullptr;
-    static const int32_t *MOTION_STATE_PREV = nullptr;
-    static const int32_t MOTION_STATE_DOWN = 2;
-
-    static bool InputManager_IsDown(void *) {
-        if (*MOTION_STATE == MOTION_STATE_DOWN || *MOTION_STATE_PREV == MOTION_STATE_DOWN) {
-            return true;
-        }
-
-        auto &buttons = get_buttons();
-
-        return GameAPI::Buttons::getState(RI_MGR, buttons.at(Buttons::DownMotion));
-    }
-
-    static void init_down_motion_hook() {
-
-        // cmp [rip+prev], 2 / je / cmp [rip+cur], 2 / jne / mov al, 1 / ret / xor al, al / ret
-        auto address = reinterpret_cast<uint8_t *>(find_pattern(
-                avs::game::DLL_INSTANCE,
-                "833D0000000002740C833D00000000027503B001C332C0C3",
-                "XX????XXXXX????XXXXXXXXX",
-                0, 0));
-
-        if (address == nullptr) {
-            log_warning("drs", "motion sensor state not found, DOWN motion button unavailable");
-            return;
-        }
-
-        // resolve both rip-relative operands before the detour overwrites them
-        MOTION_STATE_PREV = (const int32_t *) (address + 7 + *(int32_t *) (address + 2));
-        MOTION_STATE = (const int32_t *) (address + 16 + *(int32_t *) (address + 11));
-
-        // build the button list here so the hook never races on it from the game thread
-        get_buttons();
-
-        detour::inline_hook((void *) InputManager_IsDown, address);
-
-        log_info("drs", "hooked DOWN motion detection at +{:#x}",
-                (size_t) (address - (uint8_t *) avs::game::DLL_INSTANCE));
-    }
-
     DRSGame::DRSGame() : Game("DANCERUSH") {
     }
 
     void DRSGame::attach() {
         Game::attach();
 
-        // TouchSDK hooks
-        detour::iat("??0TouchSDK@@QEAA@XZ",
-                (void *) &TouchSDK_Constructor, avs::game::DLL_INSTANCE);
-        detour::iat("?SendData@TouchSDK@@QEAA_NU_DeviceInfo@@QEAEH1HH@Z",
-                (void *) &TouchSDK_SendData, avs::game::DLL_INSTANCE);
-        detour::iat("?SetSignalInit@TouchSDK@@QEAA_NU_DeviceInfo@@H@Z",
-                (void *) &TouchSDK_SetSignalInit, avs::game::DLL_INSTANCE);
-        detour::iat("??1TouchSDK@@QEAA@XZ",
-                (void *) &TouchSDK_Destructor, avs::game::DLL_INSTANCE);
-        detour::iat("?GetYLedTotal@TouchSDK@@QEAAHU_DeviceInfo@@H@Z",
-                (void *) &TouchSDK_GetYLedTotal, avs::game::DLL_INSTANCE);
-        detour::iat("?GetXLedTotal@TouchSDK@@QEAAHU_DeviceInfo@@H@Z",
-                (void *) &TouchSDK_GetXLedTotal, avs::game::DLL_INSTANCE);
-        detour::iat("?DisableTouch@TouchSDK@@QEAA_NU_DeviceInfo@@H@Z",
-                (void *) &TouchSDK_DisableTouch, avs::game::DLL_INSTANCE);
-        detour::iat("?DisableDrag@TouchSDK@@QEAA_NU_DeviceInfo@@H@Z",
-                (void *) &TouchSDK_DisableDrag, avs::game::DLL_INSTANCE);
-        detour::iat("?DisableWheel@TouchSDK@@QEAA_NU_DeviceInfo@@H@Z",
-                (void *) &TouchSDK_DisableWheel, avs::game::DLL_INSTANCE);
-        detour::iat("?DisableRightClick@TouchSDK@@QEAA_NU_DeviceInfo@@H@Z",
-                (void *) &TouchSDK_DisableRightClick, avs::game::DLL_INSTANCE);
-        detour::iat("?SetMultiTouchMode@TouchSDK@@QEAA_NU_DeviceInfo@@H@Z",
-                (void *) &TouchSDK_SetMultiTouchMode, avs::game::DLL_INSTANCE);
-        detour::iat("?EnableTouchWidthData@TouchSDK@@QEAA_NU_DeviceInfo@@H@Z",
-                (void *) &TouchSDK_EnableTouchWidthData, avs::game::DLL_INSTANCE);
-        detour::iat("?EnableRawData@TouchSDK@@QEAA_NU_DeviceInfo@@H@Z",
-                (void *) &TouchSDK_EnableRawData, avs::game::DLL_INSTANCE);
-        detour::iat("?SetAllEnable@TouchSDK@@QEAA_NU_DeviceInfo@@_NH@Z",
-                (void *) &TouchSDK_SetAllEnable, avs::game::DLL_INSTANCE);
-        detour::iat("?GetTouchDeviceCount@TouchSDK@@QEAAHXZ",
-                (void *) &TouchSDK_GetTouchDeviceCount, avs::game::DLL_INSTANCE);
-        detour::iat("?GetTouchSDKVersion@TouchSDK@@QEAAIXZ",
-                (void *) &TouchSDK_GetTouchSDKVersion, avs::game::DLL_INSTANCE);
-        detour::iat("?InitTouch@TouchSDK@@QEAAHPEAU_DeviceInfo@@HP6AXU2@PEBU_TouchPointData@@HHPEBX@ZP6AX1_N3@ZPEAX@Z",
-                (void *) &TouchSDK_InitTouch, avs::game::DLL_INSTANCE);
-
         if (!DISABLE_TOUCH) {
+            // TouchSDK hooks
+            detour::iat("??0TouchSDK@@QEAA@XZ",
+                    (void *) &TouchSDK_Constructor, avs::game::DLL_INSTANCE);
+            detour::iat("?SendData@TouchSDK@@QEAA_NU_DeviceInfo@@QEAEH1HH@Z",
+                    (void *) &TouchSDK_SendData, avs::game::DLL_INSTANCE);
+            detour::iat("?SetSignalInit@TouchSDK@@QEAA_NU_DeviceInfo@@H@Z",
+                    (void *) &TouchSDK_SetSignalInit, avs::game::DLL_INSTANCE);
+            detour::iat("??1TouchSDK@@QEAA@XZ",
+                    (void *) &TouchSDK_Destructor, avs::game::DLL_INSTANCE);
+            detour::iat("?GetYLedTotal@TouchSDK@@QEAAHU_DeviceInfo@@H@Z",
+                    (void *) &TouchSDK_GetYLedTotal, avs::game::DLL_INSTANCE);
+            detour::iat("?GetXLedTotal@TouchSDK@@QEAAHU_DeviceInfo@@H@Z",
+                    (void *) &TouchSDK_GetXLedTotal, avs::game::DLL_INSTANCE);
+            detour::iat("?DisableTouch@TouchSDK@@QEAA_NU_DeviceInfo@@H@Z",
+                    (void *) &TouchSDK_DisableTouch, avs::game::DLL_INSTANCE);
+            detour::iat("?DisableDrag@TouchSDK@@QEAA_NU_DeviceInfo@@H@Z",
+                    (void *) &TouchSDK_DisableDrag, avs::game::DLL_INSTANCE);
+            detour::iat("?DisableWheel@TouchSDK@@QEAA_NU_DeviceInfo@@H@Z",
+                    (void *) &TouchSDK_DisableWheel, avs::game::DLL_INSTANCE);
+            detour::iat("?DisableRightClick@TouchSDK@@QEAA_NU_DeviceInfo@@H@Z",
+                    (void *) &TouchSDK_DisableRightClick, avs::game::DLL_INSTANCE);
+            detour::iat("?SetMultiTouchMode@TouchSDK@@QEAA_NU_DeviceInfo@@H@Z",
+                    (void *) &TouchSDK_SetMultiTouchMode, avs::game::DLL_INSTANCE);
+            detour::iat("?EnableTouchWidthData@TouchSDK@@QEAA_NU_DeviceInfo@@H@Z",
+                    (void *) &TouchSDK_EnableTouchWidthData, avs::game::DLL_INSTANCE);
+            detour::iat("?EnableRawData@TouchSDK@@QEAA_NU_DeviceInfo@@H@Z",
+                    (void *) &TouchSDK_EnableRawData, avs::game::DLL_INSTANCE);
+            detour::iat("?SetAllEnable@TouchSDK@@QEAA_NU_DeviceInfo@@_NH@Z",
+                    (void *) &TouchSDK_SetAllEnable, avs::game::DLL_INSTANCE);
+            detour::iat("?GetTouchDeviceCount@TouchSDK@@QEAAHXZ",
+                    (void *) &TouchSDK_GetTouchDeviceCount, avs::game::DLL_INSTANCE);
+            detour::iat("?GetTouchSDKVersion@TouchSDK@@QEAAIXZ",
+                    (void *) &TouchSDK_GetTouchSDKVersion, avs::game::DLL_INSTANCE);
+            detour::iat("?InitTouch@TouchSDK@@QEAAHPEAU_DeviceInfo@@HP6AXU2@PEBU_TouchPointData@@HHPEBX@ZP6AX1_N3@ZPEAX@Z",
+                    (void *) &TouchSDK_InitTouch, avs::game::DLL_INSTANCE);
+
             start_touch();
         } else {
-            log_info("drs", "no native input method detected");
+            log_info("drs", "touch input for dnace floor disabled");
         }
 
         init_down_motion_hook();

--- a/src/spice2x/games/drs/io.cpp
+++ b/src/spice2x/games/drs/io.cpp
@@ -31,9 +31,8 @@ std::vector<Button> &games::drs::get_buttons() {
 std::string games::drs::get_buttons_help() {
     // keep to max 100 characters wide
     return
-        "Down Motion stands in for the cabinet's depth camera. The game tracks only one player\n"
-        "height, so this button triggers DOWN notes for both sides at once.\n"
-        "Touchscreen supported for dance floor."
+        "Touchscreen supported for dance floor.\n"
+        "Down Motion applies to both players."
         ;
 }
 

--- a/src/spice2x/games/drs/io.cpp
+++ b/src/spice2x/games/drs/io.cpp
@@ -20,7 +20,8 @@ std::vector<Button> &games::drs::get_buttons() {
                 "P2 Up",
                 "P2 Down",
                 "P2 Left",
-                "P2 Right"
+                "P2 Right",
+                "Down Motion"
         );
     }
 
@@ -30,7 +31,8 @@ std::vector<Button> &games::drs::get_buttons() {
 std::string games::drs::get_buttons_help() {
     // keep to max 100 characters wide
     return
-        "Motion camera required for DOWN movement.\n"
+        "Down Motion stands in for the cabinet's depth camera. The game tracks only one player\n"
+        "height, so this button triggers DOWN notes for both sides at once.\n"
         "Touchscreen supported for dance floor."
         ;
 }

--- a/src/spice2x/games/drs/io.h
+++ b/src/spice2x/games/drs/io.h
@@ -20,7 +20,8 @@ namespace games::drs {
             P2_Up,
             P2_Down,
             P2_Left,
-            P2_Right
+            P2_Right,
+            DownMotion
         };
     }
 

--- a/src/spice2x/games/drs/motion_cam.cpp
+++ b/src/spice2x/games/drs/motion_cam.cpp
@@ -1,0 +1,109 @@
+#include "games/drs/motion_cam.h"
+
+#include <cstdint>
+
+#include "avs/game.h"
+#include "util/detour.h"
+#include "util/logging.h"
+#include "util/sigscan.h"
+#include "io.h"
+
+namespace games::drs {
+
+    // the game reads down movement from a depth camera whose driver is compiled into the game DLL,
+    // so there is no import to replace.
+    //
+    // with no camera the tracked height never changes, so the motion state never leaves "still"
+    // and DOWN notes can never be hit.
+    //
+    // rather than answer CInputManager::IsDown, the button drives the same state pair the camera
+    // would; that leaves the game's own edge test untouched and keeps every note in a frame seeing
+    // one answer.
+    static int32_t *MOTION_STATE = nullptr;
+    static int32_t *MOTION_STATE_PREV = nullptr;
+    static constexpr int32_t MOTION_STATE_STILL = 1;
+    static constexpr int32_t MOTION_STATE_DOWN = 2;
+
+    static void (*UpdateMotion_orig)() = nullptr;
+    static bool DOWN_MOTION_HELD = false;
+
+    static void InputManager_UpdateMotion() {
+        UpdateMotion_orig();
+
+        auto &buttons = get_buttons();
+        const bool held = GameAPI::Buttons::getState(RI_MGR, buttons.at(Buttons::DownMotion));
+
+        // a state of DOWN only counts as movement when the frame before it was something else
+        if (held) {
+            *MOTION_STATE_PREV = DOWN_MOTION_HELD ? MOTION_STATE_DOWN : MOTION_STATE_STILL;
+            *MOTION_STATE = MOTION_STATE_DOWN;
+        }
+
+        DOWN_MOTION_HELD = held;
+    }
+
+    void init_down_motion_hook() {
+        // only hook motion camera if the user has down motion button bound to something
+        auto &buttons = get_buttons();
+        if (!buttons.at(Buttons::DownMotion).isSet()) {
+            return;
+        }
+
+        // CInputManager::IsDown - read the state pair out of its two operands.
+        // Identical in game versions 2020121400 and 2022121400 / 2024120300:
+        //
+        //   83 3D xx xx xx xx 02   cmp dword [rip+prev], 2  ; state one frame ago
+        //   74 0C                  je  FALSE                ; already down, so no new edge
+        //   83 3D xx xx xx xx 02   cmp dword [rip+cur], 2   ; state this frame
+        //   75 03                  jne FALSE                ; not down
+        //   B0 01                  mov al, 1                ; went down on this frame
+        //   C3                     ret
+        //   32 C0           FALSE: xor al, al
+        //   C3                     ret
+        auto is_down = reinterpret_cast<uint8_t *>(find_pattern(
+                avs::game::DLL_INSTANCE,
+                "833D0000000002740C833D00000000027503B001C332C0C3",
+                "XX????XXXXX????XXXXXXXXX",
+                0, 0));
+
+        if (is_down == nullptr) {
+            log_warning("drs", "motion sensor state not found, DOWN motion button unavailable");
+            return;
+        }
+
+        // rip-relative displacements resolve against the end of their own instruction, and each
+        // cmp above is 7 bytes with its displacement 4 bytes in: the first ends at +7 with its
+        // displacement at +2, the second starts at +9 so it ends at +16 with its own at +11.
+        // read signed, since a target sitting below the instruction encodes as negative.
+        MOTION_STATE_PREV = (int32_t *) (is_down + 7 + *(int32_t *) (is_down + 2));
+        MOTION_STATE = (int32_t *) (is_down + 16 + *(int32_t *) (is_down + 11));
+
+        // CInputManager::UpdateMotion is hooked for the sole purpose of reading the Down Motion
+        // button mapping frequently enough so that the rising edge can be detected.
+        //
+        // Matched over the prologue up to the camera read; the wildcards are a float and a callee:
+        //
+        //   48 83 EC 38               sub    rsp, 0x38
+        //   0F 29 74 24 20            movaps [rsp+0x20], xmm6
+        //   F3 0F 10 35 xx xx xx xx   movss  xmm6, [rip+height]  ; reading as of last frame
+        //   E8 xx xx xx xx            call   GetPlayVideoProcess
+        //   48 8B C8                  mov    rcx, rax
+        //   48 8B 10                  mov    rdx, [rax]
+        //   FF 52 60                  call   [rdx+0x60]          ; reading off the newest frame
+        auto update = reinterpret_cast<void *>(find_pattern(
+                avs::game::DLL_INSTANCE,
+                "4883EC380F29742420F30F103500000000E800000000488BC8488B10FF5260",
+                "XXXXXXXXXXXXX????X????XXXXXXXXX",
+                0, 0));
+
+        if (update == nullptr ||
+            !detour::trampoline_try(
+                update, (void *) InputManager_UpdateMotion, (void **) &UpdateMotion_orig)) {
+            log_warning("drs", "motion update not hooked, DOWN motion button unavailable");
+            return;
+        }
+
+        log_info("drs", "hooked DOWN motion at +{:#x}",
+                (uintptr_t) ((uint8_t *) update - (uint8_t *) avs::game::DLL_INSTANCE));
+    }
+}

--- a/src/spice2x/games/drs/motion_cam.h
+++ b/src/spice2x/games/drs/motion_cam.h
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace games::drs {
+    void init_down_motion_hook();
+}

--- a/src/spice2x/sdk/include/spicesdk_io.h
+++ b/src/spice2x/sdk/include/spicesdk_io.h
@@ -1607,6 +1607,7 @@ typedef enum SPICE_SDK_DANCERUSH_BUTTONS {
     DRS_Button_P2_Down,
     DRS_Button_P2_Left,
     DRS_Button_P2_Right,
+    DRS_Button_DownMotion
 } SPICE_SDK_DANCERUSH_BUTTONS;
 
 typedef enum SPICE_SDK_DANCERUSH_LIGHTS {

--- a/src/spice2x/sdk/include/spicesdk_io.h
+++ b/src/spice2x/sdk/include/spicesdk_io.h
@@ -1607,7 +1607,7 @@ typedef enum SPICE_SDK_DANCERUSH_BUTTONS {
     DRS_Button_P2_Down,
     DRS_Button_P2_Left,
     DRS_Button_P2_Right,
-    DRS_Button_DownMotion
+    DRS_Button_DownMotion,
 } SPICE_SDK_DANCERUSH_BUTTONS;
 
 typedef enum SPICE_SDK_DANCERUSH_LIGHTS {


### PR DESCRIPTION
When Down Motion button is bound, install hooks into the game that detects down movement via patches.

When Disable Touch option is enabled, don't install touch hooks.

