### PR TITLE
gitadora: allow a landscape monitor to display subscreen

### DIFF
--- a/src/spice2x/games/gitadora/gitadora.cpp
+++ b/src/spice2x/games/gitadora/gitadora.cpp
@@ -45,13 +45,13 @@ namespace games::gitadora {
     bool NATIVE_TOUCH = false;
 
     std::pair<UINT, UINT> arena_subscreen_host_size() {
-        if (!ARENA_SUBSCREEN_LANDSCAPE) {
-            return { ARENA_SUBSCREEN_WIDTH, ARENA_SUBSCREEN_HEIGHT };
-        }
         if (GRAPHICS_FS_CUSTOM_RESOLUTION_SUB.has_value()) {
             return GRAPHICS_FS_CUSTOM_RESOLUTION_SUB.value();
         }
-        return { ARENA_SUBSCREEN_LANDSCAPE_WIDTH, ARENA_SUBSCREEN_LANDSCAPE_HEIGHT };
+        if (ARENA_SUBSCREEN_LANDSCAPE) {
+            return { ARENA_SUBSCREEN_LANDSCAPE_WIDTH, ARENA_SUBSCREEN_LANDSCAPE_HEIGHT };
+        }
+        return { ARENA_SUBSCREEN_WIDTH, ARENA_SUBSCREEN_HEIGHT };
     }
 
     RECT arena_subscreen_content_rect(LONG host_width, LONG host_height) {
@@ -378,12 +378,15 @@ namespace games::gitadora {
                         "arena model: landscape subscreen needs full screen two-window mode, ignoring");
                     ARENA_SUBSCREEN_LANDSCAPE = false;
                 }
-                if (ARENA_SUBSCREEN_LANDSCAPE) {
+                if (ARENA_TWO_HEAD_EXCLUSIVE) {
                     const auto [host_width, host_height] = arena_subscreen_host_size();
-                    log_info(
-                        "gitadora",
-                        "arena model: landscape subscreen, SMALL head runs at {}x{}",
-                        host_width, host_height);
+                    if (host_width != ARENA_SUBSCREEN_WIDTH
+                            || host_height != ARENA_SUBSCREEN_HEIGHT) {
+                        log_info(
+                            "gitadora",
+                            "arena model: SMALL head runs at {}x{}, subscreen is scaled to fit",
+                            host_width, host_height);
+                    }
                 }
             }
 

--- a/src/spice2x/games/gitadora/gitadora.cpp
+++ b/src/spice2x/games/gitadora/gitadora.cpp
@@ -39,9 +39,37 @@ namespace games::gitadora {
     std::optional<socd::SocdAlgorithm> PICK_ALGO = socd::SocdAlgorithm::PreferRecent;
     std::optional<uint8_t> ARENA_WINDOW_COUNT = std::nullopt;
     bool ARENA_TWO_HEAD_EXCLUSIVE = false;
+    bool ARENA_SUBSCREEN_LANDSCAPE = false;
     std::optional<std::string> ASIO_DRIVER = std::nullopt;
     bool ALLOW_REALTEK_AUDIO = false;
     bool NATIVE_TOUCH = false;
+
+    std::pair<UINT, UINT> arena_subscreen_host_size() {
+        if (!ARENA_SUBSCREEN_LANDSCAPE) {
+            return { ARENA_SUBSCREEN_WIDTH, ARENA_SUBSCREEN_HEIGHT };
+        }
+        if (GRAPHICS_FS_CUSTOM_RESOLUTION_SUB.has_value()) {
+            return GRAPHICS_FS_CUSTOM_RESOLUTION_SUB.value();
+        }
+        return { ARENA_SUBSCREEN_LANDSCAPE_WIDTH, ARENA_SUBSCREEN_LANDSCAPE_HEIGHT };
+    }
+
+    RECT arena_subscreen_content_rect(LONG host_width, LONG host_height) {
+        if (host_width <= 0 || host_height <= 0) {
+            return RECT {};
+        }
+
+        LONG width = MulDiv(host_height, ARENA_SUBSCREEN_WIDTH, ARENA_SUBSCREEN_HEIGHT);
+        LONG height = host_height;
+        if (width > host_width) {
+            width = host_width;
+            height = MulDiv(host_width, ARENA_SUBSCREEN_HEIGHT, ARENA_SUBSCREEN_WIDTH);
+        }
+
+        const LONG left = (host_width - width) / 2;
+        const LONG top = (host_height - height) / 2;
+        return RECT { left, top, left + width, top + height };
+    }
 
     /*
      * Prevent GitaDora from creating folders on F drive
@@ -342,6 +370,20 @@ namespace games::gitadora {
                         log_fatal(
                             "gitadora",
                             "arena model: unsupported window count: {}", count);
+                }
+
+                if (ARENA_SUBSCREEN_LANDSCAPE && !ARENA_TWO_HEAD_EXCLUSIVE) {
+                    log_warning(
+                        "gitadora",
+                        "arena model: landscape subscreen needs full screen two-window mode, ignoring");
+                    ARENA_SUBSCREEN_LANDSCAPE = false;
+                }
+                if (ARENA_SUBSCREEN_LANDSCAPE) {
+                    const auto [host_width, host_height] = arena_subscreen_host_size();
+                    log_info(
+                        "gitadora",
+                        "arena model: landscape subscreen, SMALL head runs at {}x{}",
+                        host_width, host_height);
                 }
             }
 

--- a/src/spice2x/games/gitadora/gitadora.h
+++ b/src/spice2x/games/gitadora/gitadora.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <optional>
+#include <utility>
 
 #include <windows.h>
 #include <mmreg.h>
@@ -21,6 +22,7 @@ namespace games::gitadora {
     extern std::optional<socd::SocdAlgorithm> PICK_ALGO;
     extern std::optional<uint8_t> ARENA_WINDOW_COUNT;
     extern bool ARENA_TWO_HEAD_EXCLUSIVE;
+    extern bool ARENA_SUBSCREEN_LANDSCAPE;
     extern std::optional<std::string> ASIO_DRIVER;
     extern bool ALLOW_REALTEK_AUDIO;
     extern bool NATIVE_TOUCH;
@@ -28,6 +30,18 @@ namespace games::gitadora {
     // arena SMALL subscreen (touch panel) resolution
     static constexpr int ARENA_SUBSCREEN_WIDTH = 800;
     static constexpr int ARENA_SUBSCREEN_HEIGHT = 1280;
+
+    // used when a landscape monitor drives the SMALL head and -forceressub is unset
+    static constexpr int ARENA_SUBSCREEN_LANDSCAPE_WIDTH = 1920;
+    static constexpr int ARENA_SUBSCREEN_LANDSCAPE_HEIGHT = 1080;
+
+    // resolution the SMALL head actually runs at; the portrait panel size unless a
+    // landscape monitor is driving it
+    std::pair<UINT, UINT> arena_subscreen_host_size();
+
+    // area of the host the portrait subscreen occupies, centered and aspect-preserved;
+    // whatever is left over on either side stays black
+    RECT arena_subscreen_content_rect(LONG host_width, LONG host_height);
 
     class GitaDoraGame : public games::Game {
     public:

--- a/src/spice2x/games/gitadora/gitadora.h
+++ b/src/spice2x/games/gitadora/gitadora.h
@@ -35,8 +35,8 @@ namespace games::gitadora {
     static constexpr int ARENA_SUBSCREEN_LANDSCAPE_WIDTH = 1920;
     static constexpr int ARENA_SUBSCREEN_LANDSCAPE_HEIGHT = 1080;
 
-    // resolution the SMALL head actually runs at; the portrait panel size unless a
-    // landscape monitor is driving it
+    // resolution the SMALL head actually runs at; the portrait panel size unless
+    // -forceressub or the landscape option overrides it
     std::pair<UINT, UINT> arena_subscreen_host_size();
 
     // area of the host the portrait subscreen occupies, centered and aspect-preserved;

--- a/src/spice2x/hooks/graphics/backends/d3d9/d3d9_backend.cpp
+++ b/src/spice2x/hooks/graphics/backends/d3d9/d3d9_backend.cpp
@@ -1033,16 +1033,6 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3D9::CreateDeviceEx(
 
         return D3DERR_INVALIDCALL;
     }
-    if (gfdm_two_head_exclusive() && !gfdm_small_landscape()
-            && GRAPHICS_FS_CUSTOM_RESOLUTION_SUB.has_value()) {
-        log_warning(
-                "graphics::d3d9",
-                "-forceressub is unavailable; SMALL must remain {}x{} unless the "
-                "landscape subscreen option is enabled",
-                GFDM_SMALL_WIDTH,
-                GFDM_SMALL_HEIGHT);
-        return D3DERR_INVALIDCALL;
-    }
 
     DWORD orig_behavior_flags = BehaviorFlags;
     size_t num_adapters = 1;

--- a/src/spice2x/hooks/graphics/backends/d3d9/d3d9_backend.cpp
+++ b/src/spice2x/hooks/graphics/backends/d3d9/d3d9_backend.cpp
@@ -1284,19 +1284,10 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3D9::CreateDeviceEx(
             ppReturnedDeviceInterface);
 
     if (SUCCEEDED(result) && gfdm_two_head_exclusive()) {
-        pPresentationParameters[0] = gfdm_parameters.presentation_parameters[0];
-        pPresentationParameters[gfdm_parameters.logical_small_swapchain] =
-                gfdm_parameters.presentation_parameters[1];
-        if (pFullscreenDisplayMode != nullptr) {
-            pFullscreenDisplayMode[0] = gfdm_parameters.fullscreen_display_modes[0];
-            pFullscreenDisplayMode[gfdm_parameters.logical_small_swapchain] =
-                    gfdm_parameters.fullscreen_display_modes[1];
-        }
-        gfdm_restore_small_logical_size(
-                &pPresentationParameters[gfdm_parameters.logical_small_swapchain],
-                pFullscreenDisplayMode != nullptr
-                        ? &pFullscreenDisplayMode[gfdm_parameters.logical_small_swapchain]
-                        : nullptr);
+        gfdm_publish_two_head_parameters(
+                pPresentationParameters,
+                pFullscreenDisplayMode,
+                gfdm_parameters);
     }
 
     // check for error

--- a/src/spice2x/hooks/graphics/backends/d3d9/d3d9_backend.cpp
+++ b/src/spice2x/hooks/graphics/backends/d3d9/d3d9_backend.cpp
@@ -1033,10 +1033,12 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3D9::CreateDeviceEx(
 
         return D3DERR_INVALIDCALL;
     }
-    if (gfdm_two_head_exclusive() && GRAPHICS_FS_CUSTOM_RESOLUTION_SUB.has_value()) {
+    if (gfdm_two_head_exclusive() && !gfdm_small_landscape()
+            && GRAPHICS_FS_CUSTOM_RESOLUTION_SUB.has_value()) {
         log_warning(
                 "graphics::d3d9",
-                "-forceressub is unavailable; SMALL must remain {}x{}",
+                "-forceressub is unavailable; SMALL must remain {}x{} unless the "
+                "landscape subscreen option is enabled",
                 GFDM_SMALL_WIDTH,
                 GFDM_SMALL_HEIGHT);
         return D3DERR_INVALIDCALL;
@@ -1096,7 +1098,8 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3D9::CreateDeviceEx(
                         params->BackBufferHeight, params->BackBufferWidth);
                     std::swap(params->BackBufferWidth, params->BackBufferHeight);
                 }
-            } else if (i == 1 && GRAPHICS_FS_CUSTOM_RESOLUTION_SUB.has_value()) {
+            } else if (i == 1 && !gfdm_two_head_exclusive()
+                    && GRAPHICS_FS_CUSTOM_RESOLUTION_SUB.has_value()) {
                 log_misc(
                     "graphics::d3d9",
                     "use custom sub resolution {}x{} => {}x{}",
@@ -1140,7 +1143,8 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3D9::CreateDeviceEx(
                     } else if (GRAPHICS_FS_ORIENTATION_SWAP) {
                         std::swap(fullscreen_display_mode->Width, fullscreen_display_mode->Height);
                     }
-                } else if (i == 1 && GRAPHICS_FS_CUSTOM_RESOLUTION_SUB.has_value()) {
+                } else if (i == 1 && !gfdm_two_head_exclusive()
+                        && GRAPHICS_FS_CUSTOM_RESOLUTION_SUB.has_value()) {
                     fullscreen_display_mode->Width = GRAPHICS_FS_CUSTOM_RESOLUTION_SUB.value().first;
                     fullscreen_display_mode->Height = GRAPHICS_FS_CUSTOM_RESOLUTION_SUB.value().second;
                 }
@@ -1298,6 +1302,11 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3D9::CreateDeviceEx(
             pFullscreenDisplayMode[gfdm_parameters.logical_small_swapchain] =
                     gfdm_parameters.fullscreen_display_modes[1];
         }
+        gfdm_restore_small_logical_size(
+                &pPresentationParameters[gfdm_parameters.logical_small_swapchain],
+                pFullscreenDisplayMode != nullptr
+                        ? &pFullscreenDisplayMode[gfdm_parameters.logical_small_swapchain]
+                        : nullptr);
     }
 
     // check for error

--- a/src/spice2x/hooks/graphics/backends/d3d9/d3d9_device.cpp
+++ b/src/spice2x/hooks/graphics/backends/d3d9/d3d9_device.cpp
@@ -670,8 +670,8 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DDevice9::Present(
 
     // an adapter group device presents every head at once, so the SMALL head has to be
     // composed here as well as in its own swap chain
-    if (is_gfdm_small_landscape()) {
-        gfdm_compose_small_landscape();
+    if (is_gfdm_small_head_scaled()) {
+        gfdm_compose_small_head();
     }
 
     CHECK_RESULT(pReal->Present(pSourceRect, pDestRect, hDestWindowOverride, pDirtyRegion));
@@ -695,7 +695,7 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DDevice9::GetBackBuffer(
     if (is_gfdm_two_head_exclusive()
             && is_gfdm_logical_small_swapchain(iSwapChain))
     {
-        if (is_gfdm_small_landscape()
+        if (is_gfdm_small_head_scaled()
                 && iBackBuffer == 0
                 && Type == D3DBACKBUFFER_TYPE_MONO)
         {

--- a/src/spice2x/hooks/graphics/backends/d3d9/d3d9_device.cpp
+++ b/src/spice2x/hooks/graphics/backends/d3d9/d3d9_device.cpp
@@ -157,6 +157,9 @@ ULONG STDMETHODCALLTYPE WrappedIDirect3DDevice9::Release() {
             }
         }
 
+        // holds a reference on the device, so it has to go before the counts are compared
+        this->gfdm_small_head.release();
+
         d3d9_readback::release_device_resources(this->pReal);
 
         if (overlay::ENABLED) {

--- a/src/spice2x/hooks/graphics/backends/d3d9/d3d9_device.cpp
+++ b/src/spice2x/hooks/graphics/backends/d3d9/d3d9_device.cpp
@@ -252,7 +252,11 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DDevice9::GetDisplayMode(
     if (is_gfdm_two_head_exclusive()
             && is_gfdm_logical_small_swapchain(iSwapChain))
     {
-        CHECK_RESULT(pReal->GetDisplayMode(GFDM_NATIVE_SMALL_SWAPCHAIN, pMode));
+        HRESULT result = pReal->GetDisplayMode(GFDM_NATIVE_SMALL_SWAPCHAIN, pMode);
+        if (SUCCEEDED(result) && pMode != nullptr) {
+            gfdm_apply_small_logical_size(&pMode->Width, &pMode->Height);
+        }
+        CHECK_RESULT(result);
     }
 
     CHECK_RESULT(pReal->GetDisplayMode(iSwapChain, pMode));
@@ -634,6 +638,8 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DDevice9::Reset(
         overlay::OVERLAY->reset_invalidate();
     }
 
+    gfdm_release_small_proxy();
+
     // Reset refuses to run while any default pool resource is outstanding
     d3d9_readback::discard_snapshot_targets(pReal);
 
@@ -662,6 +668,12 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DDevice9::Present(
 
     graphics_d3d9_on_present(hFocusWindow, pReal, this);
 
+    // an adapter group device presents every head at once, so the SMALL head has to be
+    // composed here as well as in its own swap chain
+    if (is_gfdm_small_landscape()) {
+        gfdm_compose_small_landscape();
+    }
+
     CHECK_RESULT(pReal->Present(pSourceRect, pDestRect, hDestWindowOverride, pDirtyRegion));
 }
 
@@ -683,6 +695,12 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DDevice9::GetBackBuffer(
     if (is_gfdm_two_head_exclusive()
             && is_gfdm_logical_small_swapchain(iSwapChain))
     {
+        if (is_gfdm_small_landscape()
+                && iBackBuffer == 0
+                && Type == D3DBACKBUFFER_TYPE_MONO)
+        {
+            CHECK_RESULT(gfdm_small_proxy_backbuffer(ppBackBuffer));
+        }
         CHECK_RESULT(pReal->GetBackBuffer(
                 GFDM_NATIVE_SMALL_SWAPCHAIN,
                 iBackBuffer,
@@ -2324,6 +2342,8 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DDevice9::ResetEx(
         overlay::OVERLAY->reset_invalidate();
     }
 
+    gfdm_release_small_proxy();
+
     // ResetEx refuses to run while any default pool resource is outstanding
     d3d9_readback::discard_snapshot_targets(pReal);
 
@@ -2349,6 +2369,11 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DDevice9::ResetEx(
             pFullscreenDisplayMode[gfdm_parameters.logical_small_swapchain] =
                     gfdm_parameters.fullscreen_display_modes[1];
         }
+        gfdm_restore_small_logical_size(
+                &pPresentationParameters[gfdm_parameters.logical_small_swapchain],
+                pFullscreenDisplayMode != nullptr
+                        ? &pFullscreenDisplayMode[gfdm_parameters.logical_small_swapchain]
+                        : nullptr);
     }
 
     // recreate overlay
@@ -2377,10 +2402,14 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DDevice9::GetDisplayModeEx(
     if (is_gfdm_two_head_exclusive()
             && is_gfdm_logical_small_swapchain(iSwapChain))
     {
-        CHECK_RESULT(static_cast<IDirect3DDevice9Ex *>(pReal)->GetDisplayModeEx(
+        HRESULT result = static_cast<IDirect3DDevice9Ex *>(pReal)->GetDisplayModeEx(
                 GFDM_NATIVE_SMALL_SWAPCHAIN,
                 pMode,
-                pRotation));
+                pRotation);
+        if (SUCCEEDED(result) && pMode != nullptr) {
+            gfdm_apply_small_logical_size(&pMode->Width, &pMode->Height);
+        }
+        CHECK_RESULT(result);
     }
 
     CHECK_RESULT(static_cast<IDirect3DDevice9Ex *>(pReal)->GetDisplayModeEx(

--- a/src/spice2x/hooks/graphics/backends/d3d9/d3d9_device.cpp
+++ b/src/spice2x/hooks/graphics/backends/d3d9/d3d9_device.cpp
@@ -252,11 +252,7 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DDevice9::GetDisplayMode(
     if (is_gfdm_two_head_exclusive()
             && is_gfdm_logical_small_swapchain(iSwapChain))
     {
-        HRESULT result = pReal->GetDisplayMode(GFDM_NATIVE_SMALL_SWAPCHAIN, pMode);
-        if (SUCCEEDED(result) && pMode != nullptr) {
-            gfdm_apply_small_logical_size(&pMode->Width, &pMode->Height);
-        }
-        CHECK_RESULT(result);
+        CHECK_RESULT(pReal->GetDisplayMode(GFDM_NATIVE_SMALL_SWAPCHAIN, pMode));
     }
 
     CHECK_RESULT(pReal->GetDisplayMode(iSwapChain, pMode));
@@ -638,7 +634,7 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DDevice9::Reset(
         overlay::OVERLAY->reset_invalidate();
     }
 
-    gfdm_release_small_proxy();
+    gfdm_small_head.release();
 
     // Reset refuses to run while any default pool resource is outstanding
     d3d9_readback::discard_snapshot_targets(pReal);
@@ -670,8 +666,8 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DDevice9::Present(
 
     // an adapter group device presents every head at once, so the SMALL head has to be
     // composed here as well as in its own swap chain
-    if (is_gfdm_small_head_scaled()) {
-        gfdm_compose_small_head();
+    if (gfdm_small_head.scaled()) {
+        gfdm_small_head.compose(pReal);
     }
 
     CHECK_RESULT(pReal->Present(pSourceRect, pDestRect, hDestWindowOverride, pDirtyRegion));
@@ -695,11 +691,11 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DDevice9::GetBackBuffer(
     if (is_gfdm_two_head_exclusive()
             && is_gfdm_logical_small_swapchain(iSwapChain))
     {
-        if (is_gfdm_small_head_scaled()
+        if (gfdm_small_head.scaled()
                 && iBackBuffer == 0
                 && Type == D3DBACKBUFFER_TYPE_MONO)
         {
-            CHECK_RESULT(gfdm_small_proxy_backbuffer(ppBackBuffer));
+            CHECK_RESULT(gfdm_small_head.backbuffer(pReal, ppBackBuffer));
         }
         CHECK_RESULT(pReal->GetBackBuffer(
                 GFDM_NATIVE_SMALL_SWAPCHAIN,
@@ -2342,7 +2338,7 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DDevice9::ResetEx(
         overlay::OVERLAY->reset_invalidate();
     }
 
-    gfdm_release_small_proxy();
+    gfdm_small_head.release();
 
     // ResetEx refuses to run while any default pool resource is outstanding
     d3d9_readback::discard_snapshot_targets(pReal);
@@ -2361,19 +2357,10 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DDevice9::ResetEx(
     }
     if (is_gfdm_two_head_exclusive() && SUCCEEDED(res)) {
         gfdm_logical_small_swapchain = gfdm_parameters.logical_small_swapchain;
-        pPresentationParameters[0] = gfdm_parameters.presentation_parameters[0];
-        pPresentationParameters[gfdm_parameters.logical_small_swapchain] =
-                gfdm_parameters.presentation_parameters[1];
-        if (pFullscreenDisplayMode != nullptr) {
-            pFullscreenDisplayMode[0] = gfdm_parameters.fullscreen_display_modes[0];
-            pFullscreenDisplayMode[gfdm_parameters.logical_small_swapchain] =
-                    gfdm_parameters.fullscreen_display_modes[1];
-        }
-        gfdm_restore_small_logical_size(
-                &pPresentationParameters[gfdm_parameters.logical_small_swapchain],
-                pFullscreenDisplayMode != nullptr
-                        ? &pFullscreenDisplayMode[gfdm_parameters.logical_small_swapchain]
-                        : nullptr);
+        gfdm_publish_two_head_parameters(
+                pPresentationParameters,
+                pFullscreenDisplayMode,
+                gfdm_parameters);
     }
 
     // recreate overlay
@@ -2402,14 +2389,10 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DDevice9::GetDisplayModeEx(
     if (is_gfdm_two_head_exclusive()
             && is_gfdm_logical_small_swapchain(iSwapChain))
     {
-        HRESULT result = static_cast<IDirect3DDevice9Ex *>(pReal)->GetDisplayModeEx(
+        CHECK_RESULT(static_cast<IDirect3DDevice9Ex *>(pReal)->GetDisplayModeEx(
                 GFDM_NATIVE_SMALL_SWAPCHAIN,
                 pMode,
-                pRotation);
-        if (SUCCEEDED(result) && pMode != nullptr) {
-            gfdm_apply_small_logical_size(&pMode->Width, &pMode->Height);
-        }
-        CHECK_RESULT(result);
+                pRotation));
     }
 
     CHECK_RESULT(static_cast<IDirect3DDevice9Ex *>(pReal)->GetDisplayModeEx(

--- a/src/spice2x/hooks/graphics/backends/d3d9/d3d9_device.h
+++ b/src/spice2x/hooks/graphics/backends/d3d9/d3d9_device.h
@@ -249,12 +249,13 @@ struct WrappedIDirect3DDevice9 : IDirect3DDevice9Ex {
     FakeIDirect3DSwapChain9 *ensure_gfdm_hidden_side_swapchain(UINT iSwapChain);
     void release_gfdm_hidden_side_swapchains();
 
-    // when a landscape monitor drives the SMALL head, the game keeps drawing into a
-    // portrait surface of its own and that surface is pillarboxed onto the real head
-    bool is_gfdm_small_landscape() const;
+    // when the SMALL head does not match the panel resolution the game renders, the
+    // game keeps drawing into a portrait surface of its own and that surface is scaled
+    // to fit the real head
+    bool is_gfdm_small_head_scaled() const;
     HRESULT gfdm_small_proxy_backbuffer(IDirect3DSurface9 **ppBackBuffer);
     void gfdm_release_small_proxy();
-    HRESULT gfdm_compose_small_landscape();
+    HRESULT gfdm_compose_small_head();
     void gfdm_apply_small_logical_size(UINT *width, UINT *height) const;
 
     enum class GfdmPresentModeRecoveryResult {
@@ -288,6 +289,7 @@ struct WrappedIDirect3DDevice9 : IDirect3DDevice9Ex {
     std::array<D3DPRESENT_PARAMETERS, 4> gfdm_logical_group_parameters {};
     bool gfdm_logical_group_parameters_valid = false;
     IDirect3D9 *gfdm_parent_d3d = nullptr;
+    bool gfdm_scale_small_head = false;
     IDirect3DSurface9 *gfdm_small_proxy_surface = nullptr;
 
     std::mutex gfdm_recovery_mutex;

--- a/src/spice2x/hooks/graphics/backends/d3d9/d3d9_device.h
+++ b/src/spice2x/hooks/graphics/backends/d3d9/d3d9_device.h
@@ -11,6 +11,7 @@
 #include "util/logging.h"
 
 #include "d3d9_fake_swapchain.h"
+#include "d3d9_gfdm.h"
 #include "d3d9_swapchain.h"
 
 /*
@@ -87,7 +88,6 @@ struct WrappedIDirect3DDevice9 : IDirect3DDevice9Ex {
     WrappedIDirect3DDevice9 &operator=(const WrappedIDirect3DDevice9 &) = delete;
 
     virtual ~WrappedIDirect3DDevice9() {
-        gfdm_release_small_proxy();
         if (gfdm_parent_d3d != nullptr) {
             gfdm_parent_d3d->Release();
         }
@@ -249,15 +249,6 @@ struct WrappedIDirect3DDevice9 : IDirect3DDevice9Ex {
     FakeIDirect3DSwapChain9 *ensure_gfdm_hidden_side_swapchain(UINT iSwapChain);
     void release_gfdm_hidden_side_swapchains();
 
-    // when the SMALL head does not match the panel resolution the game renders, the
-    // game keeps drawing into a portrait surface of its own and that surface is scaled
-    // to fit the real head
-    bool is_gfdm_small_head_scaled() const;
-    HRESULT gfdm_small_proxy_backbuffer(IDirect3DSurface9 **ppBackBuffer);
-    void gfdm_release_small_proxy();
-    HRESULT gfdm_compose_small_head();
-    void gfdm_apply_small_logical_size(UINT *width, UINT *height) const;
-
     enum class GfdmPresentModeRecoveryResult {
         NotAttempted,
         ReadyToRetry,
@@ -289,8 +280,7 @@ struct WrappedIDirect3DDevice9 : IDirect3DDevice9Ex {
     std::array<D3DPRESENT_PARAMETERS, 4> gfdm_logical_group_parameters {};
     bool gfdm_logical_group_parameters_valid = false;
     IDirect3D9 *gfdm_parent_d3d = nullptr;
-    bool gfdm_scale_small_head = false;
-    IDirect3DSurface9 *gfdm_small_proxy_surface = nullptr;
+    GfdmSmallHead gfdm_small_head;
 
     std::mutex gfdm_recovery_mutex;
     std::array<D3DPRESENT_PARAMETERS, 2> gfdm_recovery_parameters {};

--- a/src/spice2x/hooks/graphics/backends/d3d9/d3d9_device.h
+++ b/src/spice2x/hooks/graphics/backends/d3d9/d3d9_device.h
@@ -87,6 +87,7 @@ struct WrappedIDirect3DDevice9 : IDirect3DDevice9Ex {
     WrappedIDirect3DDevice9 &operator=(const WrappedIDirect3DDevice9 &) = delete;
 
     virtual ~WrappedIDirect3DDevice9() {
+        gfdm_release_small_proxy();
         if (gfdm_parent_d3d != nullptr) {
             gfdm_parent_d3d->Release();
         }
@@ -248,6 +249,14 @@ struct WrappedIDirect3DDevice9 : IDirect3DDevice9Ex {
     FakeIDirect3DSwapChain9 *ensure_gfdm_hidden_side_swapchain(UINT iSwapChain);
     void release_gfdm_hidden_side_swapchains();
 
+    // when a landscape monitor drives the SMALL head, the game keeps drawing into a
+    // portrait surface of its own and that surface is pillarboxed onto the real head
+    bool is_gfdm_small_landscape() const;
+    HRESULT gfdm_small_proxy_backbuffer(IDirect3DSurface9 **ppBackBuffer);
+    void gfdm_release_small_proxy();
+    HRESULT gfdm_compose_small_landscape();
+    void gfdm_apply_small_logical_size(UINT *width, UINT *height) const;
+
     enum class GfdmPresentModeRecoveryResult {
         NotAttempted,
         ReadyToRetry,
@@ -279,6 +288,7 @@ struct WrappedIDirect3DDevice9 : IDirect3DDevice9Ex {
     std::array<D3DPRESENT_PARAMETERS, 4> gfdm_logical_group_parameters {};
     bool gfdm_logical_group_parameters_valid = false;
     IDirect3D9 *gfdm_parent_d3d = nullptr;
+    IDirect3DSurface9 *gfdm_small_proxy_surface = nullptr;
 
     std::mutex gfdm_recovery_mutex;
     std::array<D3DPRESENT_PARAMETERS, 2> gfdm_recovery_parameters {};

--- a/src/spice2x/hooks/graphics/backends/d3d9/d3d9_gfdm.cpp
+++ b/src/spice2x/hooks/graphics/backends/d3d9/d3d9_gfdm.cpp
@@ -16,47 +16,51 @@ bool gfdm_two_head_exclusive() {
             && !GRAPHICS_WINDOWED;
 }
 
-void gfdm_small_head_size(UINT *width, UINT *height) {
-    if (width == nullptr || height == nullptr) {
-        return;
-    }
+static std::pair<UINT, UINT> gfdm_small_head_size() {
     if (!gfdm_two_head_exclusive()) {
-        *width = GFDM_SMALL_WIDTH;
-        *height = GFDM_SMALL_HEIGHT;
-        return;
+        return { GFDM_SMALL_WIDTH, GFDM_SMALL_HEIGHT };
     }
-
-    const auto host_size = games::gitadora::arena_subscreen_host_size();
-    *width = host_size.first;
-    *height = host_size.second;
+    return games::gitadora::arena_subscreen_host_size();
 }
 
 // scaling is only needed when the head is not the panel size the game draws into
-bool gfdm_small_head_scaled() {
-    UINT width = 0;
-    UINT height = 0;
-    gfdm_small_head_size(&width, &height);
-    return gfdm_two_head_exclusive()
-            && (width != GFDM_SMALL_WIDTH || height != GFDM_SMALL_HEIGHT);
+static bool gfdm_small_head_scaled() {
+    const auto [width, height] = gfdm_small_head_size();
+    return width != GFDM_SMALL_WIDTH || height != GFDM_SMALL_HEIGHT;
 }
 
-// device creation and reset hand the resolved head parameters back to the game; the
-// SMALL entry has to stay portrait there, both because that is what the game renders
-// and because the next reset locates the SMALL head by that size
-void gfdm_restore_small_logical_size(
-        D3DPRESENT_PARAMETERS *presentation_parameters,
-        D3DDISPLAYMODEEX *fullscreen_display_mode)
+// Hand the resolved MAIN/SMALL heads back to the game's own array. The SMALL entry keeps
+// the portrait size the game asked for: that is what it renders, and the next reset finds
+// the SMALL head by matching it.
+void gfdm_publish_two_head_parameters(
+        D3DPRESENT_PARAMETERS *logical_presentation_parameters,
+        D3DDISPLAYMODEEX *logical_fullscreen_display_modes,
+        const GfdmTwoHeadDeviceState &state)
 {
+    if (logical_presentation_parameters == nullptr) {
+        return;
+    }
+
+    const UINT small = state.logical_small_swapchain;
+    const bool publish_modes = logical_fullscreen_display_modes != nullptr
+            && state.fullscreen_display_modes != nullptr;
+
+    logical_presentation_parameters[0] = state.presentation_parameters[0];
+    logical_presentation_parameters[small] = state.presentation_parameters[1];
+    if (publish_modes) {
+        logical_fullscreen_display_modes[0] = state.fullscreen_display_modes[0];
+        logical_fullscreen_display_modes[small] = state.fullscreen_display_modes[1];
+    }
+
     if (!gfdm_small_head_scaled()) {
         return;
     }
-    if (presentation_parameters != nullptr) {
-        presentation_parameters->BackBufferWidth = GFDM_SMALL_WIDTH;
-        presentation_parameters->BackBufferHeight = GFDM_SMALL_HEIGHT;
-    }
-    if (fullscreen_display_mode != nullptr) {
-        fullscreen_display_mode->Width = GFDM_SMALL_WIDTH;
-        fullscreen_display_mode->Height = GFDM_SMALL_HEIGHT;
+
+    logical_presentation_parameters[small].BackBufferWidth = GFDM_SMALL_WIDTH;
+    logical_presentation_parameters[small].BackBufferHeight = GFDM_SMALL_HEIGHT;
+    if (publish_modes) {
+        logical_fullscreen_display_modes[small].Width = GFDM_SMALL_WIDTH;
+        logical_fullscreen_display_modes[small].Height = GFDM_SMALL_HEIGHT;
     }
 }
 
@@ -233,9 +237,7 @@ HRESULT graphics_d3d9_gfdm_remap_two_head_group_parameters(
     // the game keeps rendering the portrait subscreen; only the head it is scanned out
     // on changes size, and the scaling happens when the head is presented
     if (gfdm_small_head_scaled()) {
-        UINT host_width = 0;
-        UINT host_height = 0;
-        gfdm_small_head_size(&host_width, &host_height);
+        const auto [host_width, host_height] = gfdm_small_head_size();
         log_info(
                 "graphics::d3d9",
                 "two-head exclusive: {} SMALL head {}x{} -> {}x{}",
@@ -384,9 +386,7 @@ HRESULT validate_gfdm_two_head_exclusive(
 
     const auto &main = presentation_parameters[0];
     const auto &small_params = presentation_parameters[1];
-    UINT expected_small_width = 0;
-    UINT expected_small_height = 0;
-    gfdm_small_head_size(&expected_small_width, &expected_small_height);
+    const auto [expected_small_width, expected_small_height] = gfdm_small_head_size();
     if (main.Windowed || small_params.Windowed) {
         log_warning(
                 "graphics::d3d9",
@@ -614,13 +614,9 @@ size_t WrappedIDirect3DDevice9::gfdm_hidden_side_swapchain_slot(
 void WrappedIDirect3DDevice9::set_gfdm_logical_group_parameters(
         const D3DPRESENT_PARAMETERS *presentation_parameters)
 {
-    // resolved with the device: an Arena run that leaves the SMALL head at the panel
-    // resolution must never enter the proxy/scaling path, and the answer cannot change
-    // for the lifetime of the device
-    gfdm_scale_small_head = ::gfdm_small_head_scaled();
-
     if (presentation_parameters == nullptr) {
         gfdm_logical_group_parameters_valid = false;
+        gfdm_small_head.resolve(nullptr);
         return;
     }
     std::copy_n(
@@ -628,6 +624,8 @@ void WrappedIDirect3DDevice9::set_gfdm_logical_group_parameters(
             gfdm_logical_group_parameters.size(),
             gfdm_logical_group_parameters.begin());
     gfdm_logical_group_parameters_valid = true;
+    gfdm_small_head.resolve(
+            &gfdm_logical_group_parameters[gfdm_logical_small_swapchain]);
 }
 
 FakeIDirect3DSwapChain9 *
@@ -673,17 +671,26 @@ void WrappedIDirect3DDevice9::release_gfdm_hidden_side_swapchains() {
     }
 }
 
-bool WrappedIDirect3DDevice9::is_gfdm_small_head_scaled() const {
-    return gfdm_scale_small_head;
+void GfdmSmallHead::resolve(const D3DPRESENT_PARAMETERS *logical_small_parameters) {
+    release();
+
+    active = gfdm_small_head_scaled();
+    format = D3DFMT_X8R8G8B8;
+    multisample = D3DMULTISAMPLE_NONE;
+    multisample_quality = 0;
+    if (!active || logical_small_parameters == nullptr) {
+        return;
+    }
+
+    if (logical_small_parameters->BackBufferFormat != D3DFMT_UNKNOWN) {
+        format = logical_small_parameters->BackBufferFormat;
+    }
+    multisample = logical_small_parameters->MultiSampleType;
+    multisample_quality = logical_small_parameters->MultiSampleQuality;
 }
 
-// the game is never told about the real head size; every size it can observe for the
-// SMALL swap chain stays the portrait one it asked for
-void WrappedIDirect3DDevice9::gfdm_apply_small_logical_size(
-        UINT *width,
-        UINT *height) const
-{
-    if (!is_gfdm_small_head_scaled()) {
+void GfdmSmallHead::apply_logical_size(UINT *width, UINT *height) const {
+    if (!active) {
         return;
     }
     if (width != nullptr) {
@@ -694,79 +701,64 @@ void WrappedIDirect3DDevice9::gfdm_apply_small_logical_size(
     }
 }
 
-HRESULT WrappedIDirect3DDevice9::gfdm_small_proxy_backbuffer(
-        IDirect3DSurface9 **ppBackBuffer)
-{
-    if (ppBackBuffer == nullptr) {
+HRESULT GfdmSmallHead::backbuffer(IDirect3DDevice9 *device, IDirect3DSurface9 **out) {
+    if (device == nullptr || out == nullptr || !active) {
         return D3DERR_INVALIDCALL;
     }
 
-    if (gfdm_small_proxy_surface == nullptr) {
-        D3DFORMAT format = D3DFMT_X8R8G8B8;
-        D3DMULTISAMPLE_TYPE multisample = D3DMULTISAMPLE_NONE;
-        DWORD multisample_quality = 0;
-        if (gfdm_logical_group_parameters_valid) {
-            const auto &params =
-                    gfdm_logical_group_parameters[gfdm_logical_small_swapchain];
-            if (params.BackBufferFormat != D3DFMT_UNKNOWN) {
-                format = params.BackBufferFormat;
-            }
-            multisample = params.MultiSampleType;
-            multisample_quality = params.MultiSampleQuality;
-        }
-
-        const HRESULT result = pReal->CreateRenderTarget(
+    if (surface == nullptr) {
+        const HRESULT result = device->CreateRenderTarget(
                 GFDM_SMALL_WIDTH,
                 GFDM_SMALL_HEIGHT,
                 format,
                 multisample,
                 multisample_quality,
                 FALSE,
-                &gfdm_small_proxy_surface,
+                &surface,
                 nullptr);
         if (FAILED(result)) {
             log_warning(
                     "graphics::d3d9",
                     "two-head exclusive: could not create the portrait SMALL surface, hr={}",
                     FMT_HRESULT(result));
-            gfdm_small_proxy_surface = nullptr;
+            surface = nullptr;
             return result;
         }
-        pReal->ColorFill(gfdm_small_proxy_surface, nullptr, D3DCOLOR_XRGB(0, 0, 0));
+        device->ColorFill(surface, nullptr, D3DCOLOR_XRGB(0, 0, 0));
     }
 
-    gfdm_small_proxy_surface->AddRef();
-    *ppBackBuffer = gfdm_small_proxy_surface;
+    surface->AddRef();
+    *out = surface;
     return D3D_OK;
 }
 
-void WrappedIDirect3DDevice9::gfdm_release_small_proxy() {
-    if (gfdm_small_proxy_surface != nullptr) {
-        gfdm_small_proxy_surface->Release();
-        gfdm_small_proxy_surface = nullptr;
+void GfdmSmallHead::release() {
+    if (surface != nullptr) {
+        surface->Release();
+        surface = nullptr;
     }
 }
 
-HRESULT WrappedIDirect3DDevice9::gfdm_compose_small_head() {
+HRESULT GfdmSmallHead::compose(IDirect3DDevice9 *device) {
     IDirect3DSurface9 *proxy = nullptr;
-    HRESULT result = gfdm_small_proxy_backbuffer(&proxy);
+    HRESULT result = backbuffer(device, &proxy);
     if (FAILED(result)) {
         return result;
     }
 
-    IDirect3DSurface9 *backbuffer = nullptr;
-    result = pReal->GetBackBuffer(
+    IDirect3DSurface9 *head = nullptr;
+    result = device->GetBackBuffer(
             GFDM_NATIVE_SMALL_SWAPCHAIN,
             0,
             D3DBACKBUFFER_TYPE_MONO,
-            &backbuffer);
+            &head);
     if (FAILED(result)) {
         proxy->Release();
         return result;
     }
 
     D3DSURFACE_DESC desc {};
-    result = backbuffer->GetDesc(&desc);
+    result = head->GetDesc(&desc);
     if (SUCCEEDED(result)) {
         const RECT content = games::gitadora::arena_subscreen_content_rect(
                 static_cast<LONG>(desc.Width),
@@ -774,16 +766,11 @@ HRESULT WrappedIDirect3DDevice9::gfdm_compose_small_head() {
 
         // discard swap effect leaves the whole head undefined every frame, so the bars
         // have to be repainted along with the image
-        pReal->ColorFill(backbuffer, nullptr, D3DCOLOR_XRGB(0, 0, 0));
-        result = pReal->StretchRect(
-                proxy,
-                nullptr,
-                backbuffer,
-                &content,
-                D3DTEXF_LINEAR);
+        device->ColorFill(head, nullptr, D3DCOLOR_XRGB(0, 0, 0));
+        result = device->StretchRect(proxy, nullptr, head, &content, D3DTEXF_LINEAR);
     }
 
-    backbuffer->Release();
+    head->Release();
     proxy->Release();
     return result;
 }

--- a/src/spice2x/hooks/graphics/backends/d3d9/d3d9_gfdm.cpp
+++ b/src/spice2x/hooks/graphics/backends/d3d9/d3d9_gfdm.cpp
@@ -16,15 +16,11 @@ bool gfdm_two_head_exclusive() {
             && !GRAPHICS_WINDOWED;
 }
 
-bool gfdm_small_landscape() {
-    return gfdm_two_head_exclusive() && games::gitadora::ARENA_SUBSCREEN_LANDSCAPE;
-}
-
 void gfdm_small_head_size(UINT *width, UINT *height) {
     if (width == nullptr || height == nullptr) {
         return;
     }
-    if (!gfdm_small_landscape()) {
+    if (!gfdm_two_head_exclusive()) {
         *width = GFDM_SMALL_WIDTH;
         *height = GFDM_SMALL_HEIGHT;
         return;
@@ -35,6 +31,15 @@ void gfdm_small_head_size(UINT *width, UINT *height) {
     *height = host_size.second;
 }
 
+// scaling is only needed when the head is not the panel size the game draws into
+bool gfdm_small_head_scaled() {
+    UINT width = 0;
+    UINT height = 0;
+    gfdm_small_head_size(&width, &height);
+    return gfdm_two_head_exclusive()
+            && (width != GFDM_SMALL_WIDTH || height != GFDM_SMALL_HEIGHT);
+}
+
 // device creation and reset hand the resolved head parameters back to the game; the
 // SMALL entry has to stay portrait there, both because that is what the game renders
 // and because the next reset locates the SMALL head by that size
@@ -42,7 +47,7 @@ void gfdm_restore_small_logical_size(
         D3DPRESENT_PARAMETERS *presentation_parameters,
         D3DDISPLAYMODEEX *fullscreen_display_mode)
 {
-    if (!gfdm_small_landscape()) {
+    if (!gfdm_small_head_scaled()) {
         return;
     }
     if (presentation_parameters != nullptr) {
@@ -226,14 +231,14 @@ HRESULT graphics_d3d9_gfdm_remap_two_head_group_parameters(
     }
 
     // the game keeps rendering the portrait subscreen; only the head it is scanned out
-    // on becomes landscape, and the pillarboxing happens when the head is presented
-    if (gfdm_small_landscape()) {
+    // on changes size, and the scaling happens when the head is presented
+    if (gfdm_small_head_scaled()) {
         UINT host_width = 0;
         UINT host_height = 0;
         gfdm_small_head_size(&host_width, &host_height);
         log_info(
                 "graphics::d3d9",
-                "two-head exclusive: {} SMALL head {}x{} -> {}x{} (landscape subscreen)",
+                "two-head exclusive: {} SMALL head {}x{} -> {}x{}",
                 operation,
                 secondary.BackBufferWidth,
                 secondary.BackBufferHeight,
@@ -609,6 +614,11 @@ size_t WrappedIDirect3DDevice9::gfdm_hidden_side_swapchain_slot(
 void WrappedIDirect3DDevice9::set_gfdm_logical_group_parameters(
         const D3DPRESENT_PARAMETERS *presentation_parameters)
 {
+    // resolved with the device: an Arena run that leaves the SMALL head at the panel
+    // resolution must never enter the proxy/scaling path, and the answer cannot change
+    // for the lifetime of the device
+    gfdm_scale_small_head = ::gfdm_small_head_scaled();
+
     if (presentation_parameters == nullptr) {
         gfdm_logical_group_parameters_valid = false;
         return;
@@ -663,17 +673,17 @@ void WrappedIDirect3DDevice9::release_gfdm_hidden_side_swapchains() {
     }
 }
 
-bool WrappedIDirect3DDevice9::is_gfdm_small_landscape() const {
-    return ::gfdm_small_landscape();
+bool WrappedIDirect3DDevice9::is_gfdm_small_head_scaled() const {
+    return gfdm_scale_small_head;
 }
 
-// the game is never told about the landscape head; every size it can observe for the
+// the game is never told about the real head size; every size it can observe for the
 // SMALL swap chain stays the portrait one it asked for
 void WrappedIDirect3DDevice9::gfdm_apply_small_logical_size(
         UINT *width,
         UINT *height) const
 {
-    if (!is_gfdm_small_landscape()) {
+    if (!is_gfdm_small_head_scaled()) {
         return;
     }
     if (width != nullptr) {
@@ -737,7 +747,7 @@ void WrappedIDirect3DDevice9::gfdm_release_small_proxy() {
     }
 }
 
-HRESULT WrappedIDirect3DDevice9::gfdm_compose_small_landscape() {
+HRESULT WrappedIDirect3DDevice9::gfdm_compose_small_head() {
     IDirect3DSurface9 *proxy = nullptr;
     HRESULT result = gfdm_small_proxy_backbuffer(&proxy);
     if (FAILED(result)) {

--- a/src/spice2x/hooks/graphics/backends/d3d9/d3d9_gfdm.cpp
+++ b/src/spice2x/hooks/graphics/backends/d3d9/d3d9_gfdm.cpp
@@ -16,6 +16,45 @@ bool gfdm_two_head_exclusive() {
             && !GRAPHICS_WINDOWED;
 }
 
+bool gfdm_small_landscape() {
+    return gfdm_two_head_exclusive() && games::gitadora::ARENA_SUBSCREEN_LANDSCAPE;
+}
+
+void gfdm_small_head_size(UINT *width, UINT *height) {
+    if (width == nullptr || height == nullptr) {
+        return;
+    }
+    if (!gfdm_small_landscape()) {
+        *width = GFDM_SMALL_WIDTH;
+        *height = GFDM_SMALL_HEIGHT;
+        return;
+    }
+
+    const auto host_size = games::gitadora::arena_subscreen_host_size();
+    *width = host_size.first;
+    *height = host_size.second;
+}
+
+// device creation and reset hand the resolved head parameters back to the game; the
+// SMALL entry has to stay portrait there, both because that is what the game renders
+// and because the next reset locates the SMALL head by that size
+void gfdm_restore_small_logical_size(
+        D3DPRESENT_PARAMETERS *presentation_parameters,
+        D3DDISPLAYMODEEX *fullscreen_display_mode)
+{
+    if (!gfdm_small_landscape()) {
+        return;
+    }
+    if (presentation_parameters != nullptr) {
+        presentation_parameters->BackBufferWidth = GFDM_SMALL_WIDTH;
+        presentation_parameters->BackBufferHeight = GFDM_SMALL_HEIGHT;
+    }
+    if (fullscreen_display_mode != nullptr) {
+        fullscreen_display_mode->Width = GFDM_SMALL_WIDTH;
+        fullscreen_display_mode->Height = GFDM_SMALL_HEIGHT;
+    }
+}
+
 HRESULT graphics_d3d9_gfdm_select_two_head_group_parameters(
         const D3DPRESENT_PARAMETERS *logical_presentation_parameters,
         const D3DDISPLAYMODEEX *logical_fullscreen_display_modes,
@@ -186,6 +225,28 @@ HRESULT graphics_d3d9_gfdm_remap_two_head_group_parameters(
         return D3DERR_INVALIDCALL;
     }
 
+    // the game keeps rendering the portrait subscreen; only the head it is scanned out
+    // on becomes landscape, and the pillarboxing happens when the head is presented
+    if (gfdm_small_landscape()) {
+        UINT host_width = 0;
+        UINT host_height = 0;
+        gfdm_small_head_size(&host_width, &host_height);
+        log_info(
+                "graphics::d3d9",
+                "two-head exclusive: {} SMALL head {}x{} -> {}x{} (landscape subscreen)",
+                operation,
+                secondary.BackBufferWidth,
+                secondary.BackBufferHeight,
+                host_width,
+                host_height);
+        secondary.BackBufferWidth = host_width;
+        secondary.BackBufferHeight = host_height;
+        if (fullscreen_display_modes != nullptr) {
+            fullscreen_display_modes[1].Width = host_width;
+            fullscreen_display_modes[1].Height = host_height;
+        }
+    }
+
     return D3D_OK;
 }
 
@@ -318,20 +379,23 @@ HRESULT validate_gfdm_two_head_exclusive(
 
     const auto &main = presentation_parameters[0];
     const auto &small_params = presentation_parameters[1];
+    UINT expected_small_width = 0;
+    UINT expected_small_height = 0;
+    gfdm_small_head_size(&expected_small_width, &expected_small_height);
     if (main.Windowed || small_params.Windowed) {
         log_warning(
                 "graphics::d3d9",
                 "two-head exclusive mode requires both group heads to be fullscreen");
         return D3DERR_INVALIDCALL;
     }
-    if (small_params.BackBufferWidth != GFDM_SMALL_WIDTH
-            || small_params.BackBufferHeight != GFDM_SMALL_HEIGHT)
+    if (small_params.BackBufferWidth != expected_small_width
+            || small_params.BackBufferHeight != expected_small_height)
     {
         log_warning(
                 "graphics::d3d9",
                 "SMALL head must be {}x{}; got {}x{}",
-                GFDM_SMALL_WIDTH,
-                GFDM_SMALL_HEIGHT,
+                expected_small_width,
+                expected_small_height,
                 small_params.BackBufferWidth,
                 small_params.BackBufferHeight);
         return D3DERR_INVALIDCALL;
@@ -597,6 +661,121 @@ void WrappedIDirect3DDevice9::release_gfdm_hidden_side_swapchains() {
             fake_sub_swapchain[index] = nullptr;
         }
     }
+}
+
+bool WrappedIDirect3DDevice9::is_gfdm_small_landscape() const {
+    return ::gfdm_small_landscape();
+}
+
+// the game is never told about the landscape head; every size it can observe for the
+// SMALL swap chain stays the portrait one it asked for
+void WrappedIDirect3DDevice9::gfdm_apply_small_logical_size(
+        UINT *width,
+        UINT *height) const
+{
+    if (!is_gfdm_small_landscape()) {
+        return;
+    }
+    if (width != nullptr) {
+        *width = GFDM_SMALL_WIDTH;
+    }
+    if (height != nullptr) {
+        *height = GFDM_SMALL_HEIGHT;
+    }
+}
+
+HRESULT WrappedIDirect3DDevice9::gfdm_small_proxy_backbuffer(
+        IDirect3DSurface9 **ppBackBuffer)
+{
+    if (ppBackBuffer == nullptr) {
+        return D3DERR_INVALIDCALL;
+    }
+
+    if (gfdm_small_proxy_surface == nullptr) {
+        D3DFORMAT format = D3DFMT_X8R8G8B8;
+        D3DMULTISAMPLE_TYPE multisample = D3DMULTISAMPLE_NONE;
+        DWORD multisample_quality = 0;
+        if (gfdm_logical_group_parameters_valid) {
+            const auto &params =
+                    gfdm_logical_group_parameters[gfdm_logical_small_swapchain];
+            if (params.BackBufferFormat != D3DFMT_UNKNOWN) {
+                format = params.BackBufferFormat;
+            }
+            multisample = params.MultiSampleType;
+            multisample_quality = params.MultiSampleQuality;
+        }
+
+        const HRESULT result = pReal->CreateRenderTarget(
+                GFDM_SMALL_WIDTH,
+                GFDM_SMALL_HEIGHT,
+                format,
+                multisample,
+                multisample_quality,
+                FALSE,
+                &gfdm_small_proxy_surface,
+                nullptr);
+        if (FAILED(result)) {
+            log_warning(
+                    "graphics::d3d9",
+                    "two-head exclusive: could not create the portrait SMALL surface, hr={}",
+                    FMT_HRESULT(result));
+            gfdm_small_proxy_surface = nullptr;
+            return result;
+        }
+        pReal->ColorFill(gfdm_small_proxy_surface, nullptr, D3DCOLOR_XRGB(0, 0, 0));
+    }
+
+    gfdm_small_proxy_surface->AddRef();
+    *ppBackBuffer = gfdm_small_proxy_surface;
+    return D3D_OK;
+}
+
+void WrappedIDirect3DDevice9::gfdm_release_small_proxy() {
+    if (gfdm_small_proxy_surface != nullptr) {
+        gfdm_small_proxy_surface->Release();
+        gfdm_small_proxy_surface = nullptr;
+    }
+}
+
+HRESULT WrappedIDirect3DDevice9::gfdm_compose_small_landscape() {
+    IDirect3DSurface9 *proxy = nullptr;
+    HRESULT result = gfdm_small_proxy_backbuffer(&proxy);
+    if (FAILED(result)) {
+        return result;
+    }
+
+    IDirect3DSurface9 *backbuffer = nullptr;
+    result = pReal->GetBackBuffer(
+            GFDM_NATIVE_SMALL_SWAPCHAIN,
+            0,
+            D3DBACKBUFFER_TYPE_MONO,
+            &backbuffer);
+    if (FAILED(result)) {
+        proxy->Release();
+        return result;
+    }
+
+    D3DSURFACE_DESC desc {};
+    result = backbuffer->GetDesc(&desc);
+    if (SUCCEEDED(result)) {
+        const RECT content = games::gitadora::arena_subscreen_content_rect(
+                static_cast<LONG>(desc.Width),
+                static_cast<LONG>(desc.Height));
+
+        // discard swap effect leaves the whole head undefined every frame, so the bars
+        // have to be repainted along with the image
+        pReal->ColorFill(backbuffer, nullptr, D3DCOLOR_XRGB(0, 0, 0));
+        result = pReal->StretchRect(
+                proxy,
+                nullptr,
+                backbuffer,
+                &content,
+                D3DTEXF_LINEAR);
+    }
+
+    backbuffer->Release();
+    proxy->Release();
+    return result;
 }
 
 void WrappedIDirect3DDevice9::gfdm_disarm_present_mode_recovery() {

--- a/src/spice2x/hooks/graphics/backends/d3d9/d3d9_gfdm.h
+++ b/src/spice2x/hooks/graphics/backends/d3d9/d3d9_gfdm.h
@@ -13,6 +13,34 @@ inline constexpr UINT GFDM_SMALL_HEIGHT = games::gitadora::ARENA_SUBSCREEN_HEIGH
 inline constexpr UINT GFDM_LOGICAL_HEAD_COUNT = 4;
 inline constexpr UINT GFDM_NATIVE_SMALL_SWAPCHAIN = 1;
 
+// Owns the portrait surface the game draws into while the SMALL head is scanned out at a
+// different resolution, and composes it onto the real head. Allocates nothing and reports
+// nothing until resolve() finds a head that is not the panel size.
+struct GfdmSmallHead {
+    GfdmSmallHead() = default;
+    ~GfdmSmallHead() { release(); }
+    GfdmSmallHead(const GfdmSmallHead &) = delete;
+    GfdmSmallHead &operator=(const GfdmSmallHead &) = delete;
+
+    // settled with the device, so it cannot change under the game mid-session
+    void resolve(const D3DPRESENT_PARAMETERS *logical_small_parameters);
+    bool scaled() const { return active; }
+
+    HRESULT backbuffer(IDirect3DDevice9 *device, IDirect3DSurface9 **out);
+    HRESULT compose(IDirect3DDevice9 *device);
+    void release();
+
+    // the game only ever sees the portrait size it asked for
+    void apply_logical_size(UINT *width, UINT *height) const;
+
+private:
+    bool active = false;
+    D3DFORMAT format = D3DFMT_X8R8G8B8;
+    D3DMULTISAMPLE_TYPE multisample = D3DMULTISAMPLE_NONE;
+    DWORD multisample_quality = 0;
+    IDirect3DSurface9 *surface = nullptr;
+};
+
 struct GfdmTwoHeadDeviceState {
     explicit GfdmTwoHeadDeviceState(
             D3DPRESENT_PARAMETERS *presentation_parameters,
@@ -41,11 +69,10 @@ struct GfdmTwoHeadDeviceState {
 };
 
 bool gfdm_two_head_exclusive();
-bool gfdm_small_head_scaled();
-void gfdm_small_head_size(UINT *width, UINT *height);
-void gfdm_restore_small_logical_size(
-        D3DPRESENT_PARAMETERS *presentation_parameters,
-        D3DDISPLAYMODEEX *fullscreen_display_mode);
+void gfdm_publish_two_head_parameters(
+        D3DPRESENT_PARAMETERS *logical_presentation_parameters,
+        D3DDISPLAYMODEEX *logical_fullscreen_display_modes,
+        const GfdmTwoHeadDeviceState &state);
 bool is_fake_subscreen_adapter(UINT adapter);
 void get_fake_subscreen_display_mode(UINT adapter, D3DDISPLAYMODE *mode);
 void get_fake_subscreen_display_mode_ex(UINT adapter, D3DDISPLAYMODEEX *mode);

--- a/src/spice2x/hooks/graphics/backends/d3d9/d3d9_gfdm.h
+++ b/src/spice2x/hooks/graphics/backends/d3d9/d3d9_gfdm.h
@@ -41,7 +41,7 @@ struct GfdmTwoHeadDeviceState {
 };
 
 bool gfdm_two_head_exclusive();
-bool gfdm_small_landscape();
+bool gfdm_small_head_scaled();
 void gfdm_small_head_size(UINT *width, UINT *height);
 void gfdm_restore_small_logical_size(
         D3DPRESENT_PARAMETERS *presentation_parameters,

--- a/src/spice2x/hooks/graphics/backends/d3d9/d3d9_gfdm.h
+++ b/src/spice2x/hooks/graphics/backends/d3d9/d3d9_gfdm.h
@@ -41,6 +41,11 @@ struct GfdmTwoHeadDeviceState {
 };
 
 bool gfdm_two_head_exclusive();
+bool gfdm_small_landscape();
+void gfdm_small_head_size(UINT *width, UINT *height);
+void gfdm_restore_small_logical_size(
+        D3DPRESENT_PARAMETERS *presentation_parameters,
+        D3DDISPLAYMODEEX *fullscreen_display_mode);
 bool is_fake_subscreen_adapter(UINT adapter);
 void get_fake_subscreen_display_mode(UINT adapter, D3DDISPLAYMODE *mode);
 void get_fake_subscreen_display_mode_ex(UINT adapter, D3DDISPLAYMODEEX *mode);

--- a/src/spice2x/hooks/graphics/backends/d3d9/d3d9_swapchain.cpp
+++ b/src/spice2x/hooks/graphics/backends/d3d9/d3d9_swapchain.cpp
@@ -89,6 +89,10 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DSwapChain9::Present(const RECT *pSourc
         graphics_d3d9_on_present(pDev->hFocusWindow, pDev->pReal, pDev);
     }
 
+    if (native_group_head == NativeGroupHead::Small && pDev->is_gfdm_small_landscape()) {
+        pDev->gfdm_compose_small_landscape();
+    }
+
     HRESULT result = pReal->Present(
             pSourceRect,
             pDestRect,
@@ -138,13 +142,26 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DSwapChain9::GetFrontBufferData(IDirect
 HRESULT STDMETHODCALLTYPE WrappedIDirect3DSwapChain9::GetBackBuffer(UINT iBackBuffer, D3DBACKBUFFER_TYPE Type,
         IDirect3DSurface9 **ppBackBuffer)
 {
+    if (native_group_head == NativeGroupHead::Small && pDev->is_gfdm_small_landscape() &&
+        iBackBuffer == 0 && Type == D3DBACKBUFFER_TYPE_MONO)
+    {
+        CHECK_RESULT(pDev->gfdm_small_proxy_backbuffer(ppBackBuffer));
+    }
+
     CHECK_RESULT(pReal->GetBackBuffer(iBackBuffer, Type, ppBackBuffer));
 }
 HRESULT STDMETHODCALLTYPE WrappedIDirect3DSwapChain9::GetRasterStatus(D3DRASTER_STATUS *pRasterStatus) {
     CHECK_RESULT(pReal->GetRasterStatus(pRasterStatus));
 }
 HRESULT STDMETHODCALLTYPE WrappedIDirect3DSwapChain9::GetDisplayMode(D3DDISPLAYMODE *pMode) {
-    CHECK_RESULT(pReal->GetDisplayMode(pMode));
+    HRESULT result = pReal->GetDisplayMode(pMode);
+    if (SUCCEEDED(result) && pMode != nullptr &&
+        native_group_head == NativeGroupHead::Small)
+    {
+        pDev->gfdm_apply_small_logical_size(&pMode->Width, &pMode->Height);
+    }
+
+    CHECK_RESULT(result);
 }
 HRESULT STDMETHODCALLTYPE WrappedIDirect3DSwapChain9::GetDevice(IDirect3DDevice9 **ppDevice) {
     if (ppDevice == nullptr) {
@@ -159,7 +176,16 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DSwapChain9::GetDevice(IDirect3DDevice9
 HRESULT STDMETHODCALLTYPE WrappedIDirect3DSwapChain9::GetPresentParameters(
         D3DPRESENT_PARAMETERS *pPresentationParameters)
 {
-    CHECK_RESULT(pReal->GetPresentParameters(pPresentationParameters));
+    HRESULT result = pReal->GetPresentParameters(pPresentationParameters);
+    if (SUCCEEDED(result) && pPresentationParameters != nullptr &&
+        native_group_head == NativeGroupHead::Small)
+    {
+        pDev->gfdm_apply_small_logical_size(
+                &pPresentationParameters->BackBufferWidth,
+                &pPresentationParameters->BackBufferHeight);
+    }
+
+    CHECK_RESULT(result);
 }
 
 /*
@@ -178,5 +204,12 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DSwapChain9::GetDisplayModeEx(D3DDISPLA
         D3DDISPLAYROTATION *pRotation)
 {
     assert(is_d3d9ex);
-    CHECK_RESULT(static_cast<IDirect3DSwapChain9Ex *>(pReal)->GetDisplayModeEx(pMode, pRotation));
+    HRESULT result = static_cast<IDirect3DSwapChain9Ex *>(pReal)->GetDisplayModeEx(pMode, pRotation);
+    if (SUCCEEDED(result) && pMode != nullptr &&
+        native_group_head == NativeGroupHead::Small)
+    {
+        pDev->gfdm_apply_small_logical_size(&pMode->Width, &pMode->Height);
+    }
+
+    CHECK_RESULT(result);
 }

--- a/src/spice2x/hooks/graphics/backends/d3d9/d3d9_swapchain.cpp
+++ b/src/spice2x/hooks/graphics/backends/d3d9/d3d9_swapchain.cpp
@@ -21,6 +21,10 @@
     } \
     return ret
 
+bool WrappedIDirect3DSwapChain9::scales_small_head() const {
+    return native_group_head == NativeGroupHead::Small && pDev->is_gfdm_small_head_scaled();
+}
+
 HRESULT STDMETHODCALLTYPE WrappedIDirect3DSwapChain9::QueryInterface(REFIID riid, void **ppvObj) {
     if (ppvObj == nullptr) {
         return E_POINTER;
@@ -89,8 +93,8 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DSwapChain9::Present(const RECT *pSourc
         graphics_d3d9_on_present(pDev->hFocusWindow, pDev->pReal, pDev);
     }
 
-    if (native_group_head == NativeGroupHead::Small && pDev->is_gfdm_small_landscape()) {
-        pDev->gfdm_compose_small_landscape();
+    if (scales_small_head()) {
+        pDev->gfdm_compose_small_head();
     }
 
     HRESULT result = pReal->Present(
@@ -142,9 +146,7 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DSwapChain9::GetFrontBufferData(IDirect
 HRESULT STDMETHODCALLTYPE WrappedIDirect3DSwapChain9::GetBackBuffer(UINT iBackBuffer, D3DBACKBUFFER_TYPE Type,
         IDirect3DSurface9 **ppBackBuffer)
 {
-    if (native_group_head == NativeGroupHead::Small && pDev->is_gfdm_small_landscape() &&
-        iBackBuffer == 0 && Type == D3DBACKBUFFER_TYPE_MONO)
-    {
+    if (scales_small_head() && iBackBuffer == 0 && Type == D3DBACKBUFFER_TYPE_MONO) {
         CHECK_RESULT(pDev->gfdm_small_proxy_backbuffer(ppBackBuffer));
     }
 
@@ -155,9 +157,7 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DSwapChain9::GetRasterStatus(D3DRASTER_
 }
 HRESULT STDMETHODCALLTYPE WrappedIDirect3DSwapChain9::GetDisplayMode(D3DDISPLAYMODE *pMode) {
     HRESULT result = pReal->GetDisplayMode(pMode);
-    if (SUCCEEDED(result) && pMode != nullptr &&
-        native_group_head == NativeGroupHead::Small)
-    {
+    if (SUCCEEDED(result) && pMode != nullptr && scales_small_head()) {
         pDev->gfdm_apply_small_logical_size(&pMode->Width, &pMode->Height);
     }
 
@@ -177,9 +177,7 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DSwapChain9::GetPresentParameters(
         D3DPRESENT_PARAMETERS *pPresentationParameters)
 {
     HRESULT result = pReal->GetPresentParameters(pPresentationParameters);
-    if (SUCCEEDED(result) && pPresentationParameters != nullptr &&
-        native_group_head == NativeGroupHead::Small)
-    {
+    if (SUCCEEDED(result) && pPresentationParameters != nullptr && scales_small_head()) {
         pDev->gfdm_apply_small_logical_size(
                 &pPresentationParameters->BackBufferWidth,
                 &pPresentationParameters->BackBufferHeight);
@@ -205,9 +203,7 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DSwapChain9::GetDisplayModeEx(D3DDISPLA
 {
     assert(is_d3d9ex);
     HRESULT result = static_cast<IDirect3DSwapChain9Ex *>(pReal)->GetDisplayModeEx(pMode, pRotation);
-    if (SUCCEEDED(result) && pMode != nullptr &&
-        native_group_head == NativeGroupHead::Small)
-    {
+    if (SUCCEEDED(result) && pMode != nullptr && scales_small_head()) {
         pDev->gfdm_apply_small_logical_size(&pMode->Width, &pMode->Height);
     }
 

--- a/src/spice2x/hooks/graphics/backends/d3d9/d3d9_swapchain.cpp
+++ b/src/spice2x/hooks/graphics/backends/d3d9/d3d9_swapchain.cpp
@@ -21,8 +21,10 @@
     } \
     return ret
 
-bool WrappedIDirect3DSwapChain9::scales_small_head() const {
-    return native_group_head == NativeGroupHead::Small && pDev->is_gfdm_small_head_scaled();
+// inert unless this is the SMALL head and it is being scaled onto a differently sized monitor
+static bool scales_small_head(const WrappedIDirect3DSwapChain9 *chain) {
+    return chain->native_group_head == WrappedIDirect3DSwapChain9::NativeGroupHead::Small
+            && chain->pDev->gfdm_small_head.scaled();
 }
 
 HRESULT STDMETHODCALLTYPE WrappedIDirect3DSwapChain9::QueryInterface(REFIID riid, void **ppvObj) {
@@ -93,8 +95,8 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DSwapChain9::Present(const RECT *pSourc
         graphics_d3d9_on_present(pDev->hFocusWindow, pDev->pReal, pDev);
     }
 
-    if (scales_small_head()) {
-        pDev->gfdm_compose_small_head();
+    if (scales_small_head(this)) {
+        pDev->gfdm_small_head.compose(pDev->pReal);
     }
 
     HRESULT result = pReal->Present(
@@ -146,8 +148,8 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DSwapChain9::GetFrontBufferData(IDirect
 HRESULT STDMETHODCALLTYPE WrappedIDirect3DSwapChain9::GetBackBuffer(UINT iBackBuffer, D3DBACKBUFFER_TYPE Type,
         IDirect3DSurface9 **ppBackBuffer)
 {
-    if (scales_small_head() && iBackBuffer == 0 && Type == D3DBACKBUFFER_TYPE_MONO) {
-        CHECK_RESULT(pDev->gfdm_small_proxy_backbuffer(ppBackBuffer));
+    if (scales_small_head(this) && iBackBuffer == 0 && Type == D3DBACKBUFFER_TYPE_MONO) {
+        CHECK_RESULT(pDev->gfdm_small_head.backbuffer(pDev->pReal, ppBackBuffer));
     }
 
     CHECK_RESULT(pReal->GetBackBuffer(iBackBuffer, Type, ppBackBuffer));
@@ -156,12 +158,7 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DSwapChain9::GetRasterStatus(D3DRASTER_
     CHECK_RESULT(pReal->GetRasterStatus(pRasterStatus));
 }
 HRESULT STDMETHODCALLTYPE WrappedIDirect3DSwapChain9::GetDisplayMode(D3DDISPLAYMODE *pMode) {
-    HRESULT result = pReal->GetDisplayMode(pMode);
-    if (SUCCEEDED(result) && pMode != nullptr && scales_small_head()) {
-        pDev->gfdm_apply_small_logical_size(&pMode->Width, &pMode->Height);
-    }
-
-    CHECK_RESULT(result);
+    CHECK_RESULT(pReal->GetDisplayMode(pMode));
 }
 HRESULT STDMETHODCALLTYPE WrappedIDirect3DSwapChain9::GetDevice(IDirect3DDevice9 **ppDevice) {
     if (ppDevice == nullptr) {
@@ -177,8 +174,8 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DSwapChain9::GetPresentParameters(
         D3DPRESENT_PARAMETERS *pPresentationParameters)
 {
     HRESULT result = pReal->GetPresentParameters(pPresentationParameters);
-    if (SUCCEEDED(result) && pPresentationParameters != nullptr && scales_small_head()) {
-        pDev->gfdm_apply_small_logical_size(
+    if (SUCCEEDED(result) && pPresentationParameters != nullptr && scales_small_head(this)) {
+        pDev->gfdm_small_head.apply_logical_size(
                 &pPresentationParameters->BackBufferWidth,
                 &pPresentationParameters->BackBufferHeight);
     }
@@ -202,10 +199,5 @@ HRESULT STDMETHODCALLTYPE WrappedIDirect3DSwapChain9::GetDisplayModeEx(D3DDISPLA
         D3DDISPLAYROTATION *pRotation)
 {
     assert(is_d3d9ex);
-    HRESULT result = static_cast<IDirect3DSwapChain9Ex *>(pReal)->GetDisplayModeEx(pMode, pRotation);
-    if (SUCCEEDED(result) && pMode != nullptr && scales_small_head()) {
-        pDev->gfdm_apply_small_logical_size(&pMode->Width, &pMode->Height);
-    }
-
-    CHECK_RESULT(result);
+    CHECK_RESULT(static_cast<IDirect3DSwapChain9Ex *>(pReal)->GetDisplayModeEx(pMode, pRotation));
 }

--- a/src/spice2x/hooks/graphics/backends/d3d9/d3d9_swapchain.h
+++ b/src/spice2x/hooks/graphics/backends/d3d9/d3d9_swapchain.h
@@ -64,4 +64,9 @@ struct WrappedIDirect3DSwapChain9 : IDirect3DSwapChain9Ex {
     NativeGroupHead native_group_head = NativeGroupHead::Unknown;
 
     bool should_run_hooks = true;
+
+private:
+    // true only while this is the SMALL head and it is being scaled onto a monitor of a
+    // different size; everything guarded by it must be inert otherwise
+    bool scales_small_head() const;
 };

--- a/src/spice2x/hooks/graphics/backends/d3d9/d3d9_swapchain.h
+++ b/src/spice2x/hooks/graphics/backends/d3d9/d3d9_swapchain.h
@@ -64,9 +64,4 @@ struct WrappedIDirect3DSwapChain9 : IDirect3DSwapChain9Ex {
     NativeGroupHead native_group_head = NativeGroupHead::Unknown;
 
     bool should_run_hooks = true;
-
-private:
-    // true only while this is the SMALL head and it is being scaled onto a monitor of a
-    // different size; everything guarded by it must be inert otherwise
-    bool scales_small_head() const;
 };

--- a/src/spice2x/launcher/launcher.cpp
+++ b/src/spice2x/launcher/launcher.cpp
@@ -693,6 +693,9 @@ int main_implementation(int argc, char *argv[]) {
     if (options[launcher::Options::GitaDoraArenaRealtekAccess].value_bool()) {
         games::gitadora::ALLOW_REALTEK_AUDIO = true;
     }
+    if (options[launcher::Options::GitaDoraSubscreenLandscape].value_bool()) {
+        games::gitadora::ARENA_SUBSCREEN_LANDSCAPE = true;
+    }
     if (options[launcher::Options::LoadNostalgiaModule].value_bool()) {
         attach_nostalgia = true;
     }

--- a/src/spice2x/launcher/options.cpp
+++ b/src/spice2x/launcher/options.cpp
@@ -343,7 +343,6 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc =
             "Override fullscreen resolution requested by the game for second monitor, "
             "useful if you have a sub monitor that is not quite exactly what the game expects.\n\n"
-            "Also sets the resolution used by the GitaDora Arena landscape subscreen option.\n\n"
             "WARNING: experimental as we have not done extensive testing to see if this causes desyncs.",
         .type = OptionType::Text,
         .setting_name = "1280,720",
@@ -3433,7 +3432,8 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "For Arena Model full screen two-window mode: drive the SMALL touch subscreen "
             "with a landscape monitor instead of a portrait one.\n\n"
             "The portrait image is centered and black bars fill the space on either side.\n\n"
-            "Runs the monitor at 1920x1080 unless -forceressub sets another resolution.",
+            "Shorthand for running the monitor at 1920x1080; use -forceressub instead if you "
+            "need a different resolution.",
         .type = OptionType::Bool,
         .game_name = "GitaDora",
         .category = "Full Screen Settings",

--- a/src/spice2x/launcher/options.cpp
+++ b/src/spice2x/launcher/options.cpp
@@ -343,6 +343,7 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc =
             "Override fullscreen resolution requested by the game for second monitor, "
             "useful if you have a sub monitor that is not quite exactly what the game expects.\n\n"
+            "Also sets the resolution used by the GitaDora Arena landscape subscreen option.\n\n"
             "WARNING: experimental as we have not done extensive testing to see if this causes desyncs.",
         .type = OptionType::Text,
         .setting_name = "1280,720",
@@ -3424,6 +3425,19 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "Saves each subscreen as a separate PNG alongside the primary screenshot.",
         .type = OptionType::Bool,
         .category = "General Overlay",
+    },
+    {
+        // GitaDoraSubscreenLandscape
+        .title = "GitaDora Arena Landscape Subscreen (EXPERIMENTAL)",
+        .name = "gdsublandscape",
+        .desc = "For Arena Model full screen two-window mode: drive the SMALL touch subscreen "
+            "with a landscape monitor instead of a portrait one.\n\n"
+            "The portrait image is centered and black bars fill the space on either side.\n\n"
+            "Runs the monitor at 1920x1080 unless -forceressub sets another resolution.",
+        .type = OptionType::Bool,
+        .game_name = "GitaDora",
+        .category = "Full Screen Settings",
+        .quick_setting_category = "Game",
     },
 };
 

--- a/src/spice2x/launcher/options.cpp
+++ b/src/spice2x/launcher/options.cpp
@@ -3432,11 +3432,10 @@ static const std::vector<OptionDefinition> OPTION_DEFINITIONS = {
         .desc = "For Arena Model full screen two-window mode: drive the SMALL touch subscreen "
             "with a landscape monitor instead of a portrait one.\n\n"
             "The portrait image is centered and black bars fill the space on either side.\n\n"
-            "Shorthand for running the monitor at 1920x1080; use -forceressub instead if you "
-            "need a different resolution.",
+            "Launches at 1920x1080; use -forceressub if you need a different resolution.",
         .type = OptionType::Bool,
         .game_name = "GitaDora",
-        .category = "Full Screen Settings",
+        .category = "Game Options",
         .quick_setting_category = "Game",
     },
 };

--- a/src/spice2x/launcher/options.h
+++ b/src/spice2x/launcher/options.h
@@ -323,7 +323,8 @@ namespace launcher {
             OBSWebSocketPassword,
             OBSWebSocketDebug,
             ScreenshotIncludeOverlay,
-            ScreenshotSubscreens
+            ScreenshotSubscreens,
+            GitaDoraSubscreenLandscape
         };
 
         enum class OptionsCategory {


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
#0

## Description of change
Arena Model's SMALL touch subscreen is a portrait (800x1280) panel - however, it's common for people to set up a touch screen in landscape orientation since IIDX/SDVX/popn all use landscape.

Add a new option, `-gdsublandscape`, which forces the subscreen to launch at 1080p landscape. The image is rendered with black bars on the sides. Touches will be unaligned initially; user needs to go into test mode and recalibrate. In reality this option is just a short hand for `-forceressub 1920,1080`.

Wire up `-forceressub` which previously didn't work for gitadora, so that a resolution other than 1080p can be used in either orientation. In other games `-forceressub` just forces the rendering resolution and IIDX/SDVX/popn's game engine automatically stretches to fill... however for gitadora it works differently since we want to keep the aspect ratio of the original screen; it instead hijacks the back buffer and makes the game draw to an intermediate buffer.

## Testing

