### PR TITLE
danevo: add 2p card reader

### DIFF
--- a/src/spice2x/misc/eamuse.cpp
+++ b/src/spice2x/misc/eamuse.cpp
@@ -621,6 +621,7 @@ int eamuse_get_game_keypads() {
         avs::game::is_model("JDX") ||
         avs::game::is_model("KDX") ||
         avs::game::is_model("MDX") ||
+        avs::game::is_model("KDM") ||
         avs::game::is_model("J33") ||
         avs::game::is_model("K33") ||
         avs::game::is_model("L33") ||
@@ -637,6 +638,7 @@ int eamuse_get_game_keypads_name() {
 
     if (game_name == "Beatmania IIDX" ||
         game_name == "Dance Dance Revolution" ||
+        game_name == "Dance Evolution" ||
         game_name == "GitaDora")
     {
         return 2;


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
Fixes #901

## Description of change
This adds 2p card reader support to DanEvo. The cab only has one keypad but this is not a configuration spice supports today so spicecfg will show two keypads.

## Testing
2p card was recognized in test mode. No other testing performed.
