### PR TITLE
scard: Add SCARD_ATR_PROTOCOL_ISO15693_PART4 support

### DIFF
--- a/src/spice2x/external/scard/scard.cpp
+++ b/src/spice2x/external/scard/scard.cpp
@@ -50,6 +50,7 @@ static const BYTE UID_CMD[5] = { 0xFFu, 0xCAu, 0x00u, 0x00u, 0x00u };
 enum scard_atr_protocol {
     SCARD_ATR_PROTOCOL_ISO14443_PART3 = 0x03,
     SCARD_ATR_PROTOCOL_ISO15693_PART3 = 0x0B,
+    SCARD_ATR_PROTOCOL_ISO15693_PART4 = 0x0C,
     SCARD_ATR_PROTOCOL_FELICA_212K = 0x11,
     SCARD_ATR_PROTOCOL_FELICA_424K = 0x12,
 };
@@ -121,11 +122,14 @@ void scard_update(SCARDCONTEXT hContext, LPCTSTR readerName, uint8_t unit_no) {
     BYTE cardProtocol = atr[12];
     BOOL shouldReverseUid = false;
     bool is_felica = false;
-    if (cardProtocol == SCARD_ATR_PROTOCOL_ISO15693_PART3) {
+    if (cardProtocol == SCARD_ATR_PROTOCOL_ISO14443_PART3) {
+        log_info("scard", "card protocol: ISO14443_PART3");
+    } else if (cardProtocol == SCARD_ATR_PROTOCOL_ISO15693_PART3) {
         log_info("scard", "card protocol: ISO15693_PART3");
         shouldReverseUid = true;
-    } else if (cardProtocol == SCARD_ATR_PROTOCOL_ISO14443_PART3) {
-        log_info("scard", "card protocol: ISO14443_PART3");
+    } else if (cardProtocol == SCARD_ATR_PROTOCOL_ISO15693_PART4) {
+        log_info("scard", "card protocol: ISO15693_PART4");
+        shouldReverseUid = true; 
     } else if (cardProtocol == SCARD_ATR_PROTOCOL_FELICA_212K) {
         log_info("scard", "card protocol: FELICA_212K");
         is_felica = true;


### PR DESCRIPTION
## Link to GitHub Issue or related Pull Request, if one exists
None

## Description of change
Add ISO15693_PART4 support for old e-Amusement Pass.

Changes Proposed:
Added SCARD_ATR_PROTOCOL_ISO15693_PART4 = 0x0C to the scard_atr_protocol enum to natively support SONY's vendor implementation. 
Added an else if branch in the protocol check to handle 0x0C. 
When 0x0C is detected, the code now properly flags shouldReverseUid = true. 
Sinces old e-Amusement Pass is E00401 format, not enable the is_felica flag.

## Testing
Tested with real HW on Sony RC-S300 with Windows WUDF drivers.

Verified that compiling with this change correctly identifies SONY PaSoRi readers. 
Verified that the UID is successfully swapped back to the correct E00401XXXXXXXXXX format and logs into the game normally.
